### PR TITLE
feat: add analyst agent with e2b code interpreter tool and langfuse integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 FRED_API_KEY=your_fred_api_key
 GEMINI_API_KEY=your_gemini_api_key
 ANTHROPIC_API_KEY=your_anthropic_api_key
+E2B_API_KEY=your_e2b_api_key
 
 # Langfuse — required for trace logging in playground/news_search and misalignment_qa
 LANGFUSE_PUBLIC_KEY=pk-lf-...

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ wheels/
 # Guard against notebooks inadvertently creating a cache here if run with a
 # stale relative path (the canonical cache location is /data/ at repo root)
 /implementations/data/
+
+# google adk
+**/.adk/

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ The bootcamp teaches participants to build, evaluate, and compare forecasting sy
 ## What This Repo Provides
 
 - Core forecasting infrastructure in `aieng-forecasting` (`aieng.forecasting`): data services, cutoff enforcement, forecasting tasks, prediction payloads, backtesting, evaluation, and artifacts.
-- Reference methods in `aieng-forecasting/aieng/forecasting/methods`: reusable `Predictor` implementations such as naive and Darts baselines.
+- Reference methods in `aieng-forecasting/aieng/forecasting/methods`: reusable `Predictor` implementations including naive baselines, Darts numerical predictors, and an ADK-based analyst agent (`build_analyst_agent` / `AdkTextRunner`).
+- Langfuse / OpenTelemetry tracing bootstrap (`aieng.forecasting.langfuse_tracing`) for LiteLLM and Google ADK.
 - Reference experiments in `implementations`: notebooks, helpers, and task-specific configuration.
 - Canonical YAML specs in `reference_specs`.
-- Data population scripts in `scripts`.
+- Data population scripts in `scripts`, including `build_e2b_template.py` for building the E2B sandbox image.
 - Planning source of truth in `planning-docs/bootcamp-workplan.md`.
 
 ## Bootcamp Scope
@@ -83,6 +84,22 @@ Data is fetched once and cached locally (gitignored). Run the relevant script be
 ```bash
 uv run python scripts/fetch_cpi.py
 ```
+
+### 3. (Agentic track only) Build the E2B sandbox image
+
+The analyst agent runs code in an E2B cloud sandbox. Do this once before using `AdkTextRunner` / `build_analyst_agent`:
+
+1. Create a free account at [e2b.dev](https://e2b.dev) and copy your API key.
+2. Add it to your `.env` file alongside the other keys (see `.env.example`):
+   ```
+   E2B_API_KEY=your_e2b_api_key
+   ```
+3. Build the template (takes a few minutes on first run):
+   ```bash
+   uv run --env-file .env scripts/build_e2b_template.py
+   ```
+
+The template is named `agentic-forecasting-bootcamp` and is the default in `AnalystAgentConfig.e2b_template_name`.
 
 Then start with:
 

--- a/aieng-forecasting/README.md
+++ b/aieng-forecasting/README.md
@@ -8,6 +8,7 @@ This package provides stable infrastructure used across reference implementation
 - Forecasting task and prediction payload models.
 - Backtesting, evaluation, scoring, and artifact helpers.
 - Reusable reference predictors under `aieng.forecasting.methods`.
+- Langfuse / OpenTelemetry tracing bootstrap in `aieng.forecasting.langfuse_tracing`.
 
 ## Install
 
@@ -27,9 +28,12 @@ pip install "aieng-forecasting[agentic]"
 
 Current extras:
 
-- `numerical` - Darts-based numerical predictors and related model dependencies
-- `llm` - LLM-process predictors and tracing support
-- `agentic` - ADK-based agentic predictors and tracing support
+- `numerical` — Darts-based numerical predictors and related model dependencies
+- `llm` — LiteLLM-based LLM-process predictors; Langfuse tracing via `langfuse_otel`
+- `agentic` — Google ADK runner (`AdkTextRunner`), analyst agent (`build_analyst_agent`), E2B code interpreter, and Langfuse / OpenInference tracing
+
+> **E2B setup:** the `agentic` extra requires a one-time sandbox image build.
+> See [Getting Started — step 3](../README.md#3-agentic-track-only-build-the-e2b-sandbox-image) in the root README.
 
 Use-case notebooks and task-specific configuration live in `../implementations`.
 

--- a/aieng-forecasting/aieng/forecasting/langfuse_tracing.py
+++ b/aieng-forecasting/aieng/forecasting/langfuse_tracing.py
@@ -1,0 +1,127 @@
+"""Langfuse-oriented tracing bootstrap for LiteLLM and Google ADK.
+
+Call :func:`init_langfuse_tracing` once at process startup when using the
+``llm`` or ``agentic`` extras and Langfuse credentials are set in the
+environment.
+"""
+
+import logging
+import os
+
+
+logger = logging.getLogger(__name__)
+
+
+def _langfuse_credentials_present() -> bool:
+    pub = os.environ.get("LANGFUSE_PUBLIC_KEY", "").strip()
+    sec = os.environ.get("LANGFUSE_SECRET_KEY", "").strip()
+    return bool(pub and sec)
+
+
+class _LangfuseTracingBootstrap:
+    """Registers LiteLLM + ADK exporters at most once per process."""
+
+    __slots__ = ("_google_adk_instrumented", "_langfuse_client_initialized", "_litellm_instrumented")
+
+    def __init__(self) -> None:
+        self._litellm_instrumented = False
+        self._google_adk_instrumented = False
+        self._langfuse_client_initialized = False
+
+    def init(self) -> None:
+        """Initialize Langfuse tracing when credentials and dependencies exist."""
+        if not _langfuse_credentials_present():
+            logger.debug(
+                "Skipping Langfuse tracing: set LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY.",
+            )
+            return
+
+        # OpenInference's ADK instrumentor uses the *global* OTel tracer provider.
+        # Langfuse attaches its span processor when the SDK client is created; without
+        # this, ADK spans are emitted into a no-op provider and never reach Langfuse.
+        self._ensure_langfuse_client()
+
+        self._register_litellm_langfuse_otel()
+        self._instrument_google_adk()
+
+    def _ensure_langfuse_client(self) -> None:
+        if self._langfuse_client_initialized:
+            return
+        try:
+            from langfuse import get_client  # noqa: PLC0415
+        except ImportError:
+            logger.debug("langfuse not installed; skipping Langfuse client initialization.")
+            return
+        try:
+            get_client()
+        except Exception:
+            logger.exception("Langfuse get_client() failed; ADK spans may not export.")
+            return
+        self._langfuse_client_initialized = True
+
+    def _register_litellm_langfuse_otel(self) -> None:
+        """Register LiteLLM Langfuse callback."""
+        if self._litellm_instrumented:
+            return
+        try:
+            import litellm  # noqa: PLC0415
+        except ImportError:
+            logger.debug("litellm not installed; skipping LiteLLM Langfuse callback.")
+            return
+
+        existing = list(getattr(litellm, "callbacks", None) or [])
+        if "langfuse_otel" not in existing:
+            litellm.callbacks = [*existing, "langfuse_otel"]
+        self._litellm_instrumented = True
+
+    def _instrument_google_adk(self) -> None:
+        """Instrument Google ADK."""
+        if self._google_adk_instrumented:
+            return
+        try:
+            from openinference.instrumentation.google_adk import (  # noqa: PLC0415
+                GoogleADKInstrumentor,
+            )
+        except ImportError:
+            logger.debug(
+                "openinference-instrumentation-google-adk not installed; skipping ADK instrumentation.",
+            )
+            return
+
+        try:
+            GoogleADKInstrumentor().instrument()
+        except Exception:
+            logger.exception("GoogleADKInstrumentor().instrument() failed.")
+            return
+
+        self._google_adk_instrumented = True
+
+
+_bootstrap = _LangfuseTracingBootstrap()
+
+
+def init_langfuse_tracing() -> None:
+    """Wire LiteLLM and Google ADK to Langfuse.
+
+    No-ops when ``LANGFUSE_PUBLIC_KEY`` or ``LANGFUSE_SECRET_KEY`` is absent
+    from the environment.  Safe to call multiple times.
+
+    Notes
+    -----
+    When both environment keys are present, performs up to three one-time
+    registrations:
+
+    1. Calls ``langfuse.get_client()`` so the global OpenTelemetry
+       ``TracerProvider`` receives Langfuse's span processor.  This is required
+       for ADK spans emitted via ``openinference-instrumentation-google-adk``
+       to reach Langfuse.
+    2. Appends ``"langfuse_otel"`` to ``litellm.callbacks`` once (if
+       ``litellm`` is importable).
+    3. Runs ``GoogleADKInstrumentor().instrument()`` once (if
+       ``openinference-instrumentation-google-adk`` is importable).
+
+    Set ``LANGFUSE_HOST`` or ``LANGFUSE_BASE_URL`` for non-default regions.
+    For short-lived processes, call ``langfuse.get_client().flush()`` before
+    exit so pending spans are exported.
+    """
+    _bootstrap.init()

--- a/aieng-forecasting/aieng/forecasting/methods/README.md
+++ b/aieng-forecasting/aieng/forecasting/methods/README.md
@@ -11,7 +11,7 @@ methods/
 ├── baselines/       # simple floor baselines and teaching references
 ├── numerical/       # classical / ML numerical forecasters
 ├── llm_processes/   # planned LLM-process predictors
-└── agentic/         # planned tool-using / hybrid predictors
+└── agentic/         # ADK-based agentic runners and the analyst agent
 ```
 
 ---
@@ -53,6 +53,16 @@ from aieng.forecasting.methods.baselines import LastValuePredictor
 from aieng.forecasting.methods.numerical import DartsAutoARIMAPredictor
 ```
 
+Agentic runner and analyst agent:
+
+```python
+from aieng.forecasting.methods.agentic import AdkTextRunner, AdkTextRunnerConfig
+from aieng.forecasting.methods.agentic.analyst_agent import (
+    AnalystAgentConfig,
+    build_analyst_agent,
+)
+```
+
 ---
 
 ## Current contents
@@ -70,3 +80,12 @@ from aieng.forecasting.methods.numerical import DartsAutoARIMAPredictor
 | `numerical/darts_arima.py` | `DartsAutoARIMAPredictor` | Univariate Darts AutoARIMA with probabilistic multi-horizon output via Monte Carlo sampling. |
 | `numerical/darts_regression.py` | `DartsLinearRegressionPredictor` | Darts linear regression predictor with optional past covariates and probabilistic output. |
 | `numerical/darts_regression.py` | `DartsLightGBMPredictor` | Darts LightGBM quantile-regression predictor with optional past covariates. |
+
+### Agentic
+
+| Module | Class / Function | Description |
+|---|---|---|
+| `agentic/adk_runner.py` | `AdkTextRunner` | Async text-in / text-out wrapper around ADK `InMemoryRunner`. Manages ADK sessions (fresh-per-message or sticky) and optionally traces each turn to Langfuse via `propagate_attributes`. |
+| `agentic/adk_runner.py` | `AdkTextRunnerConfig` | Pydantic configuration for `AdkTextRunner` (session mode, Langfuse fields). |
+| `agentic/analyst_agent/` | `build_analyst_agent` | Factory that creates the analyst `LlmAgent` equipped with the E2B code interpreter and the `use-aieng-forecasting` skill. |
+| `agentic/analyst_agent/` | `AnalystAgentConfig` | Pydantic configuration for the analyst agent (model, sandbox timeouts, generation overrides, and instruction knobs). |

--- a/aieng-forecasting/aieng/forecasting/methods/agentic/__init__.py
+++ b/aieng-forecasting/aieng/forecasting/methods/agentic/__init__.py
@@ -1,7 +1,18 @@
-"""Agentic predictor implementations.
+"""ADK-based agentic predictors.
 
-This package is reserved for concrete forecasting predictors that use tools,
-code execution, or hybrid numerical reasoning to produce forecasts.
+Concrete forecasting components that use tool execution, code interpreters,
+or hybrid numerical reasoning to produce forecasts.
+
+Public API
+----------
+AdkTextRunner : class
+    Async text-in / text-out wrapper around ADK ``InMemoryRunner`` with
+    session management and optional Langfuse tracing.
+AdkTextRunnerConfig : BaseModel
+    Pydantic configuration for :class:`AdkTextRunner`.
 """
 
-__all__: list[str] = []
+from aieng.forecasting.methods.agentic.adk_runner import AdkTextRunner, AdkTextRunnerConfig
+
+
+__all__: list[str] = ["AdkTextRunner", "AdkTextRunnerConfig"]

--- a/aieng-forecasting/aieng/forecasting/methods/agentic/adk_runner.py
+++ b/aieng-forecasting/aieng/forecasting/methods/agentic/adk_runner.py
@@ -1,0 +1,303 @@
+"""General-purpose ADK runner: text-in / text-out over ``InMemoryRunner``."""
+
+from __future__ import annotations
+
+import types as py_types
+from typing import Any
+
+from google.adk.agents.base_agent import BaseAgent
+from google.adk.agents.run_config import RunConfig
+from google.adk.runners import InMemoryRunner
+from google.genai import types as genai_types
+from pydantic import BaseModel, Field
+
+
+class AdkTextRunnerConfig(BaseModel):
+    """Configuration for :class:`AdkTextRunner`.
+
+    Attributes
+    ----------
+    app_name : str
+        Application id shared by the session service and runner.
+    default_user_id : str
+        Fallback user id when :meth:`~AdkTextRunner.run_text_async` is called
+        without an explicit ``user_id``.
+    fresh_session_per_message : bool
+        When ``True`` (default), each :meth:`~AdkTextRunner.run_text_async`
+        call creates a fresh ADK session and any supplied ``session_id`` is
+        ignored.  When ``False``, sessions are reused per ``user_id``
+        (sticky conversation).
+    enable_langfuse_tracing : bool
+        When ``True``, initialise Langfuse at construction time and wrap every
+        turn with ``propagate_attributes``.  Requires the ``agentic`` extra.
+    langfuse_tags : list of str or None
+        Tags forwarded to Langfuse ``propagate_attributes``.
+    langfuse_propagate_metadata : dict of str to str, or None
+        Extra key/value metadata merged with ``adk_app_name`` and forwarded
+        to ``propagate_attributes``.
+    langfuse_trace_name : str or None
+        ``trace_name`` forwarded to Langfuse ``propagate_attributes``.
+    langfuse_version : str or None
+        ``version`` forwarded to Langfuse ``propagate_attributes``.
+
+    Notes
+    -----
+    When ``enable_langfuse_tracing`` is ``True``, ``user_id``, ``session_id``,
+    ``trace_name``, and every key/value in ``langfuse_propagate_metadata`` must
+    be US-ASCII and ≤ 200 characters each; Langfuse silently drops
+    non-conforming values.
+    """
+
+    app_name: str = Field(
+        ...,
+        description="Application id shared by session service and runner.",
+    )
+    default_user_id: str = Field(
+        default="user",
+        description=(
+            "Used when ``run_text_async`` is called without ``user_id``. "
+            "If Langfuse tracing is enabled, must be US-ASCII and ≤ 200 characters."
+        ),
+    )
+    fresh_session_per_message: bool = Field(
+        default=True,
+        description=(
+            "If True, each ``run_text_async`` creates a new session (``session_id`` is ignored). "
+            "If False, turns for the same ``user_id`` reuse one session: the first call creates it, "
+            "later calls omit ``session_id`` unless switching threads; optional explicit "
+            "``session_id`` joins or replaces the sticky session for that user."
+        ),
+    )
+    enable_langfuse_tracing: bool = Field(
+        default=False,
+        description=(
+            "If True, call :func:`~aieng.forecasting.langfuse_tracing.init_langfuse_tracing` "
+            "at runner construction and wrap each turn with Langfuse "
+            "``propagate_attributes``. Forwards resolved ``user_id`` and ADK ``session_id`` "
+            "plus optional fields below. Langfuse requires propagated identifiers to be "
+            "US-ASCII and ≤ 200 characters; invalid values may be dropped with warnings. "
+            "Requires the ``agentic`` extra (``langfuse``)."
+        ),
+    )
+    langfuse_tags: list[str] | None = Field(
+        default=None,
+        description=("Optional tags for ``propagate_attributes`` to categorize observations in Langfuse."),
+    )
+    langfuse_propagate_metadata: dict[str, str] | None = Field(
+        default=None,
+        description=(
+            "Extra metadata merged with ``adk_app_name`` for ``propagate_attributes``. "
+            "Keys and values must be US-ASCII strings ≤ 200 characters each; avoid large "
+            "payloads or sensitive data (non-conforming entries may be dropped with warnings)."
+        ),
+    )
+    langfuse_trace_name: str | None = Field(
+        default=None,
+        description=("Optional ``trace_name`` for ``propagate_attributes``: US-ASCII, ≤ 200 characters."),
+    )
+    langfuse_version: str | None = Field(
+        default=None,
+        description=(
+            "Optional ``version`` for independently versioned parts of the app (e.g. agent "
+            "revision). Use short US-ASCII values suitable for span attributes."
+        ),
+    )
+
+    model_config = {"extra": "forbid"}
+
+
+class AdkTextRunner:
+    """Wrap ``InMemoryRunner`` with session helpers.
+
+    Parameters
+    ----------
+    agent : BaseAgent
+        The ADK agent to run.
+    config : AdkTextRunnerConfig
+        The configuration for the runner.
+
+    Examples
+    --------
+    >>> from aieng.forecasting.methods.agentic.adk_runner import AdkTextRunner
+    >>> from aieng.forecasting.methods.agentic.analyst_agent import (
+    ...     build_analyst_agent,
+    ...     AnalystAgentConfig,
+    ... )
+    >>> analyst_agent = build_analyst_agent(AnalystAgentConfig())
+    >>> cfg = AdkTextRunnerConfig(app_name="demo", enable_langfuse_tracing=True)
+    >>> runner = AdkTextRunner(analyst_agent, config=cfg)
+    >>> await runner.run_text_async("What is the trend in the data?")
+
+    """
+
+    def __init__(self, agent: BaseAgent, *, config: AdkTextRunnerConfig) -> None:
+        self._config = config
+        self._runner = InMemoryRunner(agent=agent, app_name=config.app_name)
+        # Sticky ADK session per user when ``fresh_session_per_message`` is False.
+        self._conversation_session_by_user: dict[str, str] = {}
+        if config.enable_langfuse_tracing:
+            from aieng.forecasting.langfuse_tracing import init_langfuse_tracing  # noqa: PLC0415
+
+            init_langfuse_tracing()
+
+    @property
+    def runner(self) -> InMemoryRunner:
+        """Underlying ADK runner (session, artifact, memory services)."""
+        return self._runner
+
+    async def _resolve_session_id(self, user_id: str | None, session_id: str | None) -> str:
+        """Return the ADK session id to use for a single turn.
+
+        Parameters
+        ----------
+        user_id : str or None
+            Resolved user id; falls back to ``default_user_id`` when ``None``.
+        session_id : str or None
+            Explicit session id from the caller.  ``None`` triggers sticky-session
+            lookup or new-session creation depending on ``fresh_session_per_message``.
+
+        Returns
+        -------
+        str
+            ADK session id for this turn.
+        """
+        if user_id is None:
+            user_id = self._config.default_user_id
+
+        if self._config.fresh_session_per_message:
+            new_session = await self._runner.session_service.create_session(
+                app_name=self._config.app_name,
+                user_id=user_id,
+            )
+            sid = new_session.id
+        elif session_id is not None:
+            sid = session_id
+            self._conversation_session_by_user[user_id] = sid
+        elif user_id in self._conversation_session_by_user:
+            sid = self._conversation_session_by_user[user_id]
+        else:
+            new_session = await self._runner.session_service.create_session(
+                app_name=self._config.app_name,
+                user_id=user_id,
+            )
+            sid = new_session.id
+            self._conversation_session_by_user[user_id] = sid
+
+        return sid
+
+    async def run_text_async(
+        self,
+        prompt: str,
+        *,
+        user_id: str | None = None,
+        session_id: str | None = None,
+        run_config: RunConfig | None = None,
+    ) -> str:
+        """Run one user turn; return the first final model text or an empty string.
+
+        Parameters
+        ----------
+        prompt : str
+            The user prompt to run.
+        user_id : str | None, optional
+            The user id to use for the session. If not provided, the default
+            user id is used. With Langfuse tracing, must be US-ASCII and ≤ 200
+            characters for propagation.
+        session_id : str | None, optional
+            The session id to use for the session. If not provided, a new session
+            is created. With Langfuse tracing, the ADK session id must remain
+            US-ASCII and ≤ 200 characters for propagation.
+        run_config : RunConfig | None, optional
+            The run configuration to use for the run. If not provided, the default
+            run configuration is used.
+
+        Returns
+        -------
+        str
+            The first final model text or an empty string.
+
+        Notes
+        -----
+        If ``fresh_session_per_message`` is True, each call uses a new ADK session and
+        ``session_id`` is ignored.
+
+        If it is False, the runner keeps a session per ``user_id``: omit ``session_id``
+        after the first message to continue the same conversation. Pass ``session_id``
+        to attach to an existing session or switch threads; that id is remembered for
+        later calls with ``session_id`` omitted (same user).
+
+        When ``enable_langfuse_tracing`` is True, each turn runs inside Langfuse
+        ``propagate_attributes`` using the resolved ``user_id`` and ADK ``session_id``.
+        """
+        user_id = user_id or self._config.default_user_id
+
+        session_id = await self._resolve_session_id(user_id, session_id)
+
+        content = genai_types.Content(role="user", parts=[genai_types.Part(text=prompt)])
+
+        async def drain_run() -> str:
+            async for event in self._runner.run_async(
+                user_id=user_id,
+                session_id=session_id,
+                new_message=content,
+                run_config=run_config,
+            ):
+                if event.is_final_response() and event.content and event.content.parts:
+                    return event.content.parts[0].text or ""
+            return ""
+
+        if self._config.enable_langfuse_tracing:
+            from langfuse import propagate_attributes  # noqa: PLC0415
+
+            metadata: dict[str, str] = {"adk_app_name": self._config.app_name}
+            if self._config.langfuse_propagate_metadata:
+                metadata = {**metadata, **self._config.langfuse_propagate_metadata}
+
+            pa_kw: dict[str, Any] = {
+                k: v
+                for k, v in {
+                    "user_id": user_id,
+                    "session_id": session_id,
+                    "metadata": metadata,
+                    "tags": self._config.langfuse_tags,
+                    "trace_name": self._config.langfuse_trace_name,
+                    "version": self._config.langfuse_version,
+                }.items()
+                if v is not None
+            }
+            with propagate_attributes(**pa_kw):
+                return await drain_run()
+
+        return await drain_run()
+
+    def clear_conversation(self, *, user_id: str | None = None) -> None:
+        """Drop sticky session id(s). Next ``run_text_async`` starts a new chat.
+
+        With ``user_id``, clear only that user. With ``None``, clear every user.
+        No effect when ``fresh_session_per_message`` is True.
+
+        Parameters
+        ----------
+        user_id : str | None, optional
+            The user id to clear the conversation for. If not provided, all users
+            are cleared. No effect when ``fresh_session_per_message`` is True.
+        """
+        if user_id is None:
+            self._conversation_session_by_user.clear()
+        else:
+            self._conversation_session_by_user.pop(user_id, None)
+
+    async def aclose(self) -> None:
+        """Close the underlying runner (plugins, toolsets)."""
+        self._conversation_session_by_user.clear()
+        await self._runner.close()  # type: ignore[no-untyped-call]
+
+    async def __aenter__(self) -> AdkTextRunner:
+        """Return self for use as an ``async with`` target."""
+        return self
+
+    async def __aexit__(
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: py_types.TracebackType | None
+    ) -> None:
+        """Close the runner when leaving the ``async with`` block."""
+        await self.aclose()

--- a/aieng-forecasting/aieng/forecasting/methods/agentic/analyst_agent/__init__.py
+++ b/aieng-forecasting/aieng/forecasting/methods/agentic/analyst_agent/__init__.py
@@ -1,0 +1,18 @@
+"""Analyst ADK agent: factory and configuration.
+
+Public API
+----------
+build_analyst_agent : callable
+    Factory that creates the analyst :class:`~google.adk.agents.LlmAgent`
+    equipped with the E2B code interpreter and the ``use-aieng-forecasting``
+    skill.
+AnalystAgentConfig : BaseModel
+    Pydantic configuration controlling the model, sandbox, generation
+    parameters, and system instruction.
+"""
+
+from .agent import build_analyst_agent
+from .config import AnalystAgentConfig
+
+
+__all__ = ["AnalystAgentConfig", "build_analyst_agent"]

--- a/aieng-forecasting/aieng/forecasting/methods/agentic/analyst_agent/agent.py
+++ b/aieng-forecasting/aieng/forecasting/methods/agentic/analyst_agent/agent.py
@@ -140,4 +140,11 @@ def build_analyst_agent(config: AnalystAgentConfig) -> LlmAgent:
     )
 
 
-root_agent = build_analyst_agent(AnalystAgentConfig())
+def __getattr__(name: str) -> Any:
+    """Lazily expose ``root_agent`` without import-time initialization.
+
+    A ``root_agent`` variable at the module level is necessary for `adk web` to work.
+    """
+    if name == "root_agent":
+        return build_analyst_agent(AnalystAgentConfig())
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/aieng-forecasting/aieng/forecasting/methods/agentic/analyst_agent/agent.py
+++ b/aieng-forecasting/aieng/forecasting/methods/agentic/analyst_agent/agent.py
@@ -1,0 +1,143 @@
+"""Analyst ADK agent.
+
+To use locally with `adk web`, run the following command:
+
+```bash
+uv run --env-file .env adk web aieng-forecasting/aieng/forecasting/methods/agentic
+```
+"""
+
+from pathlib import Path
+from typing import Any
+
+from aieng.agents.tools.code_interpreter import CodeInterpreter
+from google.adk.agents import LlmAgent
+from google.adk.skills import load_skill_from_dir
+from google.adk.tools.skill_toolset import SkillToolset
+from google.genai.types import GenerateContentConfig, ThinkingConfig
+
+from .config import AnalystAgentConfig
+
+
+_SKILL_DIR = Path(__file__).resolve().parent / "skills" / "use-aieng-forecasting"
+
+_DEFAULT_ANALYST_INSTRUCTION = """## Role
+You are an analyst agent specialized in **time-series analysis and forecasting**. You answer questions by computing over data using the code execution tool. Never invent statistics, forecasts, or metrics.
+
+## Goals
+- Deliver analyses that are correct, clearly justified, and aligned with the user's question.
+- Validate data quality and temporal integrity before modeling.
+- Use the sandbox efficiently: avoid redundant downloads and batch related work into **one code submission** when possible (each tool call starts a **new** VM).
+
+## Requirements and clarification
+Use the conversation to **reduce material uncertainty** before large downloads or long sandbox runs.
+- **Ask** when the answer would change what you build or how you evaluate it: objective, forecast horizon/frequency, target metric, data scope or definitions, deliverable format, or hard constraints (time, policy, compute).
+- **Do not stall** on minor details: state **Assumptions:** briefly and proceed when gaps are unlikely to change the approach.
+- **Prefer questions that split plausible interpretations** over generic checklists.
+- Before expensive steps, give a **one-line recap** of what you understood and what you are assuming so the user can correct you early.
+
+## Code execution environment
+The code tool runs each submission in a **fresh, ephemeral sandbox**:
+- **No carry-over between calls** — prior imports, variables, and in-memory results are unavailable in the next call.
+- **Cold start every time** — design each submission as a self-contained program.
+- **No disk hand-off between tool calls** — files written in one invocation are gone before the next. Inside a **single** submission you may still write files if it helps structure that run.
+
+## How to run code
+- **Batch work per milestone** — in one Python program, combine setup (imports), quick probes, and the main analysis for that step.
+- If code fails, inspect the error, reason about the fix, and submit a corrected self-contained program.
+- If you must split across multiple tool calls, **each program must re-establish what it needs** (re-download, re-import, or reconstruct from values you stated in chat); you cannot rely on files from a prior call.
+
+## Time and splitting work
+- Wall-clock budget per sandbox is roughly **{sandbox_timeout_seconds} seconds**.
+- If a task is likely to exceed that, use **a small number of sequential code runs**, each with a clear scope and **minimal duplicated work**.
+- You **cannot resume** a partial run; every new call starts from a clean environment.
+
+## Skills
+Before relying on `aieng.forecasting`, load the **use-aieng-forecasting** skill so calls match project conventions and APIs.
+"""
+
+
+def build_analyst_instruction(config: AnalystAgentConfig) -> str:
+    """Assemble the system instruction string for the analyst agent.
+
+    Uses ``analyst_instruction_override`` when set; otherwise formats the
+    built-in template substituting ``sandbox_timeout_seconds``.  Appends
+    ``analyst_instruction_suffix`` in both cases.
+
+    Parameters
+    ----------
+    config : AnalystAgentConfig
+        Agent configuration.
+
+    Returns
+    -------
+    str
+        Complete system instruction ready to pass to
+        :class:`~google.adk.agents.LlmAgent`.
+    """
+    if config.analyst_instruction_override is not None:
+        base = config.analyst_instruction_override
+    else:
+        t = int(config.sandbox_timeout_seconds)
+        base = _DEFAULT_ANALYST_INSTRUCTION.format(sandbox_timeout_seconds=t)
+    if config.analyst_instruction_suffix:
+        base += "\n\n" + config.analyst_instruction_suffix.lstrip("\n")
+    return base
+
+
+def _build_generate_content_config(config: AnalystAgentConfig) -> GenerateContentConfig:
+    return GenerateContentConfig(
+        seed=config.seed,
+        temperature=config.temperature,
+        max_output_tokens=config.max_output_tokens,
+        thinking_config=ThinkingConfig(
+            include_thoughts=True, thinking_budget=config.thinking_budget, thinking_level=config.thinking_level
+        ),
+    )
+
+
+def build_analyst_agent(config: AnalystAgentConfig) -> LlmAgent:
+    """Build the analyst root :class:`~google.adk.agents.LlmAgent`.
+
+    Always equips the agent with
+    :meth:`~aieng.agents.tools.code_interpreter.CodeInterpreter.run_code` and
+    the ``use-aieng-forecasting`` skill toolset loaded from the local
+    ``skills/`` directory.
+
+    Parameters
+    ----------
+    config : AnalystAgentConfig
+        Configuration controlling the model, sandbox settings, generation
+        parameters, and instruction text.
+
+    Returns
+    -------
+    ~google.adk.agents.LlmAgent
+        Analyst agent ready to be passed to
+        :class:`~aieng.forecasting.methods.agentic.AdkTextRunner`.
+    """
+    repo_skills = load_skill_from_dir(_SKILL_DIR)
+    skills = SkillToolset(skills=[repo_skills])
+    code_interpreter = CodeInterpreter(
+        template_name=config.e2b_template_name,
+        sandbox_timeout_seconds=config.sandbox_timeout_seconds,
+        code_execution_timeout_seconds=config.code_execution_timeout_seconds,
+        request_timeout_seconds=config.request_timeout_seconds,
+        envs=config.code_interpreter_envs,
+    )
+
+    tools: list[Any] = [skills, code_interpreter.run_code]
+
+    gen_cfg = _build_generate_content_config(config)
+
+    return LlmAgent(
+        name="analyst_agent",
+        description="Performs data analysis and forecasting using the code execution tool and packaged skills.",
+        model=config.model,
+        instruction=build_analyst_instruction(config),
+        tools=tools,
+        generate_content_config=gen_cfg,
+    )
+
+
+root_agent = build_analyst_agent(AnalystAgentConfig())

--- a/aieng-forecasting/aieng/forecasting/methods/agentic/analyst_agent/config.py
+++ b/aieng-forecasting/aieng/forecasting/methods/agentic/analyst_agent/config.py
@@ -1,0 +1,95 @@
+"""Pydantic configuration for the analyst agent."""
+
+from __future__ import annotations
+
+from google.genai.types import ThinkingLevel
+from pydantic import BaseModel, Field, model_validator
+
+
+class AnalystAgentConfig(BaseModel):
+    """Configuration for :func:`build_analyst_agent`.
+
+    Attributes
+    ----------
+    model : str
+        Gemini model identifier passed to :class:`~google.adk.agents.LlmAgent`.
+    e2b_template_name : str or None
+        E2B sandbox template name.  ``None`` uses the E2B default sandbox.
+    sandbox_timeout_seconds : int
+        Wall-clock VM lifetime in seconds (1–3 600, default 2 700 / 45 min).
+    code_execution_timeout_seconds : float or None
+        HTTP read budget for a single ``run_code`` call.  ``None`` defers to
+        the ``aieng-agents`` library default.
+    request_timeout_seconds : float or None
+        Overall ``httpx`` budget for a code execution request.  ``None`` falls
+        back to ``sandbox_timeout_seconds + 120``.
+    code_interpreter_envs : dict of str to str, or None
+        Extra environment variables injected into the E2B sandbox.
+    seed : int or None
+        Generation seed forwarded to the model for reproducibility.
+    temperature : float or None
+        Sampling temperature; ``None`` uses the model default.
+    max_output_tokens : int or None
+        Maximum tokens per model response; ``None`` uses the model default.
+    thinking_budget : int or None
+        Token budget for extended thinking (Gemini thinking models only).
+    thinking_level : ThinkingLevel or None
+        Thinking-level preset; overrides ``thinking_budget`` when both are set.
+    analyst_instruction_override : str or None
+        Full system instruction that replaces the built-in analyst prompt.
+    analyst_instruction_suffix : str or None
+        Text appended after the main instruction (built-in or override).
+
+    Notes
+    -----
+    ``code_execution_timeout_seconds`` is validated at construction time to be
+    at most ``sandbox_timeout_seconds``.
+    """
+
+    model: str = "gemini-3-flash-preview"
+
+    # Code interpreter / E2B (``aieng.agents.tools.code_interpreter.CodeInterpreter``).
+    e2b_template_name: str | None = "agentic-forecasting-bootcamp"
+    sandbox_timeout_seconds: int = Field(
+        default=2700,  # 45 minutes
+        ge=1,
+        le=3600,  # 1 hour
+        description="Wall-clock sandbox VM lifetime passed to AsyncSandbox.create(timeout=...).",
+    )
+    code_execution_timeout_seconds: float | None = Field(
+        default=1800.0,  # 30 minutes
+        description="HTTP read budget for a single run_code call; None uses library default.",
+    )
+    request_timeout_seconds: float | None = Field(
+        default=None,
+        description="Overall httpx budget for execute; None uses sandbox_timeout_seconds + 120.",
+    )
+    code_interpreter_envs: dict[str, str] | None = None
+
+    # Optional generation overrides (None = model/provider defaults).
+    seed: int | None = None
+    temperature: float | None = None
+    max_output_tokens: int | None = None
+    thinking_budget: int | None = None
+    thinking_level: ThinkingLevel | None = None
+
+    # Instruction: None builds the standard analyst prompt from other fields.
+    analyst_instruction_override: str | None = Field(
+        default=None,
+        description="If set, used as the full system instruction instead of the built-in template.",
+    )
+    analyst_instruction_suffix: str | None = Field(
+        default=None,
+        description="Always appended after the main instruction (built-in or override).",
+    )
+
+    model_config = {"extra": "forbid"}
+
+    @model_validator(mode="after")
+    def _timeouts_consistent(self) -> AnalystAgentConfig:
+        if self.code_execution_timeout_seconds is not None and self.code_execution_timeout_seconds > float(
+            self.sandbox_timeout_seconds
+        ):
+            msg = "code_execution_timeout_seconds cannot exceed sandbox_timeout_seconds"
+            raise ValueError(msg)
+        return self

--- a/aieng-forecasting/aieng/forecasting/methods/agentic/analyst_agent/skills/use-aieng-forecasting/SKILL.md
+++ b/aieng-forecasting/aieng/forecasting/methods/agentic/analyst_agent/skills/use-aieng-forecasting/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: use-aieng-forecasting
+description: >-
+  Operational guidance for the pip-installed `aieng.forecasting` library (DataService
+  registration, SeriesMetadata, adapters, evaluation, runtime discovery via help and
+  dir). Use when running forecasting or data analysis in a sandbox, wiring datasets
+  through aieng-forecasting adapters, or when the user references this skill for forecasting.
+---
+
+# Agentic forecasting (package-only context)
+
+## Assumptions
+
+- **Assume** `aieng.forecasting` is importable. Prefer **runtime introspection** in executed code (`help()`, `dir()`, submodule `__doc__`) over memorized APIs—the package gains adapters and sources over time.
+
+## Code execution
+
+- Tool calls should contain **only valid Python** (no prose or markdown in code cells); use `#` for notes.
+- **Minimize serial executions**: Prefer **one** `run_code` per milestone—e.g. combine several `help(X)` / `dir(X)` lines and the next substantive step in the **same** script—instead of a separate sandbox per `help()` call.
+- **Heavy IO**: StatCan (and similar) pulls can be **large**. Confirm `table_id` and filters **before** registering many series; wrong table → wasted bandwidth and time on every fresh sandbox (see [REFERENCE.md](references/REFERENCE.md)).
+- **Ephemeral runtime**: If code runs in an isolated sandbox that is **recreated per tool invocation**, nothing persists across calls—re-import, re-fetch, and re-build in-memory objects each time. Batch introspection and experiments **in a single program** when it fits the host’s **per-run time budget** (downloads plus compute).
+
+## Quick start
+
+1. **Smoke test**: `import aieng.forecasting as af` and optionally `print(af.__file__)`.
+2. **Data**: `DataService` + a concrete adapter from `aieng.forecasting.data.adapters` + `SeriesMetadata` — see [REFERENCE.md](references/REFERENCE.md) for the registration pattern and how to discover adapters in your build.
+3. **Forecasting loop**: `aieng.forecasting.evaluation` — tasks, predictors, `backtest` / `evaluate`.
+4. **Predictors**: `aieng.forecasting.methods` and subpackages (`baselines`, `numerical`, `llm_processes`, `agentic`).
+
+## Tracks (conceptual)
+
+- **Track 1**: standardized `Prediction` / evaluation harness—use `aieng.forecasting.evaluation` APIs.
+- **Track 2**: interactive analysis; same data and imports; scoring may be secondary.
+
+## More detail
+
+See **[REFERENCE.md](references/REFERENCE.md)** for submodule map, adapter workflow, illustrative StatCan/FRED examples, and optional sandbox paths.

--- a/aieng-forecasting/aieng/forecasting/methods/agentic/analyst_agent/skills/use-aieng-forecasting/references/REFERENCE.md
+++ b/aieng-forecasting/aieng/forecasting/methods/agentic/analyst_agent/skills/use-aieng-forecasting/references/REFERENCE.md
@@ -1,0 +1,110 @@
+# Reference: `aieng.forecasting` without the repo
+
+Stable orientation for an agent that only has the **installed package**—no reliance on a git checkout. New data sources and adapters may appear over time; **always confirm the live surface** with `help()` / `dir()` in executed code.
+
+## Submodule map (high level)
+
+| Area | Path | Role |
+| --- | --- | --- |
+| Data | `aieng.forecasting.data` | `DataService`, `ForecastContext`, `SeriesMetadata`, `SeriesRecord` |
+| Adapters | `aieng.forecasting.data.adapters` | Concrete `BaseAdapter` implementations (see below) |
+| Evaluation | `aieng.forecasting.evaluation` | Tasks, predictors, predictions, backtest/eval, artifacts |
+| Methods | `aieng.forecasting.methods` | Re-exported reference predictors; families in subpackages |
+
+### Discovering adapters in your build
+
+Exports are not guaranteed static across releases. After `import aieng.forecasting.data.adapters as adp`, use `dir(adp)` or enumerate submodules:
+
+```python
+import pkgutil
+import aieng.forecasting.data.adapters as adp
+
+print([m.name for m in pkgutil.iter_modules(adp.__path__)])
+```
+
+Each adapter class documents its own **constructor arguments**, **caching**, **credentials**, and **how it selects a single series** from a larger source.
+
+## Data layer pattern (all sources)
+
+1. **Construct** a concrete adapter (one series per adapter instance is the usual pattern for table- or API-backed sources).
+2. **Build** `SeriesMetadata` with the fields the model requires (see below).
+3. **Call** `DataService.register(series_id, adapter, metadata)` once per series—`register` triggers `adapter.fetch()` and stores the result.
+4. **Query** through `DataService` / `ForecastContext` for cutoff-safe views—predictors consume context, not raw services.
+
+If something fails, read the **exception message** and `help()` on the adapter you chose; adapters differ by source.
+
+### `ForecastContext` (cutoff-scoped data)
+
+Obtain a context with **`data_service.context(as_of=...)`** (a `datetime`). Predictors take **`ForecastContext`**, not a raw `DataService`. Do not treat the service like a dict keyed by dates—use **`get_series(series_id, as_of=...)`** only when exploring outside the predictor path.
+
+## Efficiency (code tool)
+
+- **Batch `help` / probes**: `help(DataService.register); help(StatCanAdapter)` in **one** run beats many tiny runs when each run spins a **new** sandbox.
+- **Register in one shot**: `DataService.register(series_id, adapter, metadata)` always needs **three** arguments—fix signatures before looping categories.
+- **Prefer harness for evaluated workflows**: For multi-origin backtests, **`backtest` / `multi_backtest`** + YAML-driven specs avoid hand-rolling loops that repeat downloads.
+
+### `SeriesMetadata` (Pydantic)
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `series_id` | yes | Logical id; typically matches the first argument to `register` |
+| `description` | yes | What the series measures |
+| `source` | yes | Provenance label (dataset or vendor name) |
+| `units` | yes | Unit of measure |
+| `frequency` | yes | Pandas offset alias, e.g. `"MS"` |
+| `table_id` | no | Source table or dataset id when applicable |
+
+### `DataService.register`
+
+Signature: `register(series_id: str, adapter: BaseAdapter, metadata: SeriesMetadata)`. The store key is `series_id`; keep it aligned with `metadata.series_id` unless you have a deliberate reason not to.
+
+## Working with adapters
+
+- **Read the adapter docstring first** (`help(AdapterClass)`). Constructor parameters, env vars, and cache directories are source-specific.
+- **Series selection is source-specific**: table joins, member filters, tickers, or API ids must match what the upstream dataset actually contains. When in doubt, **inspect a small raw sample** (or the adapter’s own examples) before registering many series in a loop.
+- **Vendor libraries**: if an adapter wraps a third-party package, import paths and function names **match that installed version**, not generic web snippets. Prefer the adapter; drop to the vendor module only when exploring, and verify with `help()` / `dir()`.
+
+## Short examples (illustrative only)
+
+These are **patterns**, not an exhaustive list of datasets. Other adapters follow the same **`DataService` + `SeriesMetadata` + `register`** shape.
+
+### Example A — Statistics Canada table row (multi-dimensional table)
+
+`StatCanAdapter` narrows a wide CPI-style table with a `member_filter` dict: keys are **column names**, values must **exactly match** strings in the published extract. See `help(StatCanAdapter)` for cache layout and the worked example in `help(DataService)`.
+
+### Example B — FRED macro series
+
+`FREDAdapter` targets one FRED series id; optional on-disk parquet cache; API key rules are in `help(FREDAdapter)`.
+
+## `aieng.forecasting.evaluation` (representative exports)
+
+Non-exhaustive—use `dir(aieng.forecasting.evaluation)` in code for the full set:
+
+- **Task / contract**: `ForecastingTask`, `Predictor`, `Prediction`, `ContinuousForecast`, `STANDARD_QUANTILES`
+- **Backtest**: `BacktestSpec`, `MultiTargetBacktestSpec`, `backtest`, `multi_backtest`, `BacktestResult`
+- **Eval**: `EvalSpec`, `MultiTargetEvalSpec`, `evaluate`, `multi_evaluate`, `EvalResult`, `EvalTracker`, `EvalBudgetExceededError`
+- **Artifacts**: `cached_backtest`, `cached_multi_backtest`, `load_*`, `save_*`, `DEFAULT_STORE_DIR`
+- **Inspection**: `describe_task`, `describe_spec`
+
+## Runtime discovery
+
+```python
+import pkgutil
+import aieng.forecasting as root
+
+for mod in pkgutil.iter_modules(root.__path__, root.__name__ + "."):
+    print(mod.name)
+```
+
+```python
+import aieng.forecasting.evaluation as ev
+print([n for n in dir(ev) if not n.startswith("_")])
+```
+
+Prefer **`help(ClassOrFn)`** after importing the class you intend to use.
+
+## Optional: sandbox workspace
+
+Some execution environments mount a writable workspace (often under `/home/user/workspace`) with a `data/` subtree for caches. **Adapter defaults** are usually relative to the process working directory. Do not assume specific host paths until the environment shows them.
+
+If the host uses **one fresh VM per code run**, that filesystem and process memory do not survive the next invocation—treat each run as standalone unless the host documents otherwise.

--- a/aieng-forecasting/pyproject.toml
+++ b/aieng-forecasting/pyproject.toml
@@ -17,8 +17,10 @@ dependencies = [
 
 [project.optional-dependencies]
 agentic = [
+    "aieng-agents[code-interpreter]>=0.3.0",
     "google-adk>=1.31.1",
     "langfuse>=3.14.6",
+    "openinference-instrumentation-google-adk>=0.1.10",
 ]
 llm = [
     "langfuse>=3.14.6",

--- a/aieng-forecasting/tests/aieng/forecasting/methods/agentic/test_adk_runner.py
+++ b/aieng-forecasting/tests/aieng/forecasting/methods/agentic/test_adk_runner.py
@@ -1,0 +1,378 @@
+"""Tests for aieng.forecasting.methods.agentic.adk_runner.
+
+Covers session-management logic, response extraction, Langfuse kwargs
+filtering, and lifecycle contracts.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aieng.forecasting.methods.agentic.adk_runner import AdkTextRunner, AdkTextRunnerConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _session(sid: str = "sess-abc") -> MagicMock:
+    s = MagicMock()
+    s.id = sid
+    return s
+
+
+def _final_event(text: str) -> MagicMock:
+    event = MagicMock()
+    event.is_final_response.return_value = True
+    part = MagicMock()
+    part.text = text
+    event.content.parts = [part]
+    return event
+
+
+def _intermediate_event() -> MagicMock:
+    event = MagicMock()
+    event.is_final_response.return_value = False
+    return event
+
+
+def _final_event_no_content() -> MagicMock:
+    event = MagicMock()
+    event.is_final_response.return_value = True
+    event.content = None
+    return event
+
+
+async def _stream(*events):
+    for e in events:
+        yield e
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def inner_runner():
+    """Stubbed InMemoryRunner: session service + run_async pre-configured."""
+    r = MagicMock()
+    r.session_service.create_session = AsyncMock(return_value=_session())
+    r.run_async = MagicMock(return_value=_stream())
+    r.close = AsyncMock()
+    return r
+
+
+@pytest.fixture
+def patch_runner_cls(inner_runner):
+    """Substitute InMemoryRunner with the stub for the duration of a test."""
+    with patch(
+        "aieng.forecasting.methods.agentic.adk_runner.InMemoryRunner",
+        return_value=inner_runner,
+    ):
+        yield inner_runner
+
+
+@pytest.fixture
+def mock_agent():
+    """Minimal stand-in ADK agent passed into ``AdkTextRunner``."""
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Session resolution — fresh_session_per_message=True
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestFreshSessionMode:
+    """Session handling when ``fresh_session_per_message`` is true."""
+
+    async def test_returns_a_new_session_id_on_each_call(self, patch_runner_cls, mock_agent) -> None:
+        """Each resolve allocates a new session id from the session service."""
+        patch_runner_cls.session_service.create_session.side_effect = [
+            _session("s1"),
+            _session("s2"),
+        ]
+        runner = AdkTextRunner(
+            mock_agent,
+            config=AdkTextRunnerConfig(app_name="app", fresh_session_per_message=True),
+        )
+        sid1 = await runner._resolve_session_id("alice", None)
+        sid2 = await runner._resolve_session_id("alice", None)
+        assert sid1 == "s1"
+        assert sid2 == "s2"
+
+    async def test_sticky_dict_is_never_written(self, patch_runner_cls, mock_agent) -> None:
+        """Per-user sticky map stays empty in fresh-session mode."""
+        runner = AdkTextRunner(
+            mock_agent,
+            config=AdkTextRunnerConfig(app_name="app", fresh_session_per_message=True),
+        )
+        await runner._resolve_session_id("alice", None)
+        assert runner._conversation_session_by_user == {}
+
+    async def test_caller_supplied_session_id_is_ignored(self, patch_runner_cls, mock_agent) -> None:
+        """Caller-provided session id is ignored; a new session is always created."""
+        patch_runner_cls.session_service.create_session.return_value = _session("fresh-sid")
+        runner = AdkTextRunner(
+            mock_agent,
+            config=AdkTextRunnerConfig(app_name="app", fresh_session_per_message=True),
+        )
+        sid = await runner._resolve_session_id("alice", "caller-supplied")
+        assert sid == "fresh-sid"
+
+
+# ---------------------------------------------------------------------------
+# Session resolution — fresh_session_per_message=False (sticky)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestStickySessionMode:
+    """Session handling when ``fresh_session_per_message`` is false (sticky)."""
+
+    async def test_first_call_creates_and_caches_session(self, patch_runner_cls, mock_agent) -> None:
+        """First resolve creates a session and stores it under the user id."""
+        patch_runner_cls.session_service.create_session.return_value = _session("s1")
+        runner = AdkTextRunner(
+            mock_agent,
+            config=AdkTextRunnerConfig(app_name="app", fresh_session_per_message=False),
+        )
+        sid = await runner._resolve_session_id("alice", None)
+        assert sid == "s1"
+        assert runner._conversation_session_by_user["alice"] == "s1"
+
+    async def test_second_call_reuses_session_without_creating_a_new_one(self, patch_runner_cls, mock_agent) -> None:
+        """Second resolve returns the cached id without another create_session call."""
+        patch_runner_cls.session_service.create_session.return_value = _session("s1")
+        runner = AdkTextRunner(
+            mock_agent,
+            config=AdkTextRunnerConfig(app_name="app", fresh_session_per_message=False),
+        )
+        await runner._resolve_session_id("alice", None)
+        sid2 = await runner._resolve_session_id("alice", None)
+        assert sid2 == "s1"
+        assert patch_runner_cls.session_service.create_session.call_count == 1
+
+    async def test_explicit_session_id_overwrites_cached_entry(self, patch_runner_cls, mock_agent) -> None:
+        """Explicit session id updates the cache without calling create_session."""
+        runner = AdkTextRunner(
+            mock_agent,
+            config=AdkTextRunnerConfig(app_name="app", fresh_session_per_message=False),
+        )
+        sid = await runner._resolve_session_id("alice", "override-sid")
+        assert sid == "override-sid"
+        assert runner._conversation_session_by_user["alice"] == "override-sid"
+        patch_runner_cls.session_service.create_session.assert_not_called()
+
+    async def test_different_users_get_independent_sessions(self, patch_runner_cls, mock_agent) -> None:
+        """Each user id gets its own sticky session id."""
+        patch_runner_cls.session_service.create_session.side_effect = [
+            _session("alice-sess"),
+            _session("bob-sess"),
+        ]
+        runner = AdkTextRunner(
+            mock_agent,
+            config=AdkTextRunnerConfig(app_name="app", fresh_session_per_message=False),
+        )
+        sid_a = await runner._resolve_session_id("alice", None)
+        sid_b = await runner._resolve_session_id("bob", None)
+        assert sid_a == "alice-sess"
+        assert sid_b == "bob-sess"
+
+    async def test_none_user_id_falls_back_to_default_user_id(self, patch_runner_cls, mock_agent) -> None:
+        """None user id resolves stickiness under ``default_user_id``."""
+        patch_runner_cls.session_service.create_session.return_value = _session("s1")
+        runner = AdkTextRunner(
+            mock_agent,
+            config=AdkTextRunnerConfig(
+                app_name="app",
+                fresh_session_per_message=False,
+                default_user_id="default-user",
+            ),
+        )
+        await runner._resolve_session_id(None, None)
+        assert "default-user" in runner._conversation_session_by_user
+
+
+# ---------------------------------------------------------------------------
+# clear_conversation
+# ---------------------------------------------------------------------------
+
+
+class TestClearConversation:
+    """``clear_conversation`` removes entries from the sticky-session map."""
+
+    @pytest.fixture
+    def runner_with_sessions(self, patch_runner_cls, mock_agent) -> AdkTextRunner:
+        """Runner with two cached users in the sticky session map."""
+        runner = AdkTextRunner(
+            mock_agent,
+            config=AdkTextRunnerConfig(app_name="app", fresh_session_per_message=False),
+        )
+        runner._conversation_session_by_user = {"alice": "s1", "bob": "s2"}
+        return runner
+
+    def test_clear_specific_user_leaves_others_intact(self, runner_with_sessions) -> None:
+        """Clearing one user removes only that user's cached session."""
+        runner_with_sessions.clear_conversation(user_id="alice")
+        assert "alice" not in runner_with_sessions._conversation_session_by_user
+        assert "bob" in runner_with_sessions._conversation_session_by_user
+
+    def test_clear_all_empties_the_dict(self, runner_with_sessions) -> None:
+        """Calling clear without a user id drops every cached session."""
+        runner_with_sessions.clear_conversation()
+        assert runner_with_sessions._conversation_session_by_user == {}
+
+    def test_clear_unknown_user_does_not_raise(self, runner_with_sessions) -> None:
+        """Clearing a user not in the map is a no-op and does not error."""
+        runner_with_sessions.clear_conversation(user_id="carol")
+        assert len(runner_with_sessions._conversation_session_by_user) == 2
+
+
+# ---------------------------------------------------------------------------
+# run_text_async — response extraction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestResponseExtraction:
+    """Extract assistant text from mocked ADK streaming events."""
+
+    async def test_returns_text_from_first_final_event(self, patch_runner_cls, mock_agent) -> None:
+        """Return text from the first event marked as final response."""
+        patch_runner_cls.run_async.return_value = _stream(
+            _intermediate_event(),
+            _final_event("hello world"),
+        )
+        runner = AdkTextRunner(mock_agent, config=AdkTextRunnerConfig(app_name="app"))
+        assert await runner.run_text_async("hi") == "hello world"
+
+    async def test_returns_empty_string_when_stream_has_no_final_event(self, patch_runner_cls, mock_agent) -> None:
+        """Stream with only non-final events yields an empty string."""
+        patch_runner_cls.run_async.return_value = _stream(_intermediate_event())
+        runner = AdkTextRunner(mock_agent, config=AdkTextRunnerConfig(app_name="app"))
+        assert await runner.run_text_async("hi") == ""
+
+    async def test_returns_empty_string_when_final_event_has_no_content(self, patch_runner_cls, mock_agent) -> None:
+        """Final event without content parts yields an empty string."""
+        patch_runner_cls.run_async.return_value = _stream(_final_event_no_content())
+        runner = AdkTextRunner(mock_agent, config=AdkTextRunnerConfig(app_name="app"))
+        assert await runner.run_text_async("hi") == ""
+
+
+# ---------------------------------------------------------------------------
+# run_text_async — Langfuse propagate_attributes kwargs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestLangfusePropagateAttributesKwargs:
+    """Verify the kwargs dict built for propagate_attributes is correct."""
+
+    @pytest.fixture
+    def patch_propagate_attributes(self):
+        """Patch ``langfuse.propagate_attributes`` as a context manager for tests."""
+        with patch("langfuse.propagate_attributes") as mock_pa:
+            yield mock_pa
+
+    @pytest.fixture
+    def langfuse_runner(self, patch_runner_cls, mock_agent) -> AdkTextRunner:
+        """Runner with Langfuse tracing on and ``init_langfuse_tracing`` patched."""
+        patch_runner_cls.session_service.create_session.return_value = _session("sess-1")
+        patch_runner_cls.run_async.return_value = _stream(_final_event("ok"))
+        config = AdkTextRunnerConfig(
+            app_name="my-app",
+            enable_langfuse_tracing=True,
+            langfuse_tags=["v1"],
+            langfuse_trace_name="trace-x",
+            langfuse_version="1.0",
+        )
+        with patch("aieng.forecasting.langfuse_tracing.init_langfuse_tracing"):
+            return AdkTextRunner(mock_agent, config=config)
+
+    async def test_user_id_and_session_id_always_present(self, langfuse_runner, patch_propagate_attributes) -> None:
+        """``propagate_attributes`` receives ``user_id`` and a ``session_id``."""
+        await langfuse_runner.run_text_async("test", user_id="alice")
+        kwargs = patch_propagate_attributes.call_args.kwargs
+        assert kwargs["user_id"] == "alice"
+        assert "session_id" in kwargs
+
+    async def test_metadata_always_contains_adk_app_name(self, langfuse_runner, patch_propagate_attributes) -> None:
+        """Propagated metadata always includes ``adk_app_name``."""
+        await langfuse_runner.run_text_async("test", user_id="alice")
+        assert patch_propagate_attributes.call_args.kwargs["metadata"]["adk_app_name"] == "my-app"
+
+    async def test_none_optional_fields_are_excluded(
+        self, patch_runner_cls, mock_agent, patch_propagate_attributes
+    ) -> None:
+        """Tags, trace_name, and version that are None must not appear in kwargs."""
+        patch_runner_cls.session_service.create_session.return_value = _session()
+        patch_runner_cls.run_async.return_value = _stream(_final_event("ok"))
+        config = AdkTextRunnerConfig(app_name="app", enable_langfuse_tracing=True)
+        with patch("aieng.forecasting.langfuse_tracing.init_langfuse_tracing"):
+            runner = AdkTextRunner(mock_agent, config=config)
+        await runner.run_text_async("test")
+        kwargs = patch_propagate_attributes.call_args.kwargs
+        assert "tags" not in kwargs
+        assert "trace_name" not in kwargs
+        assert "version" not in kwargs
+
+    async def test_extra_metadata_merged_with_app_name(
+        self, patch_runner_cls, mock_agent, patch_propagate_attributes
+    ) -> None:
+        """User ``langfuse_propagate_metadata`` merges with ``adk_app_name``."""
+        patch_runner_cls.session_service.create_session.return_value = _session()
+        patch_runner_cls.run_async.return_value = _stream(_final_event("ok"))
+        config = AdkTextRunnerConfig(
+            app_name="app",
+            enable_langfuse_tracing=True,
+            langfuse_propagate_metadata={"env": "staging"},
+        )
+        with patch("aieng.forecasting.langfuse_tracing.init_langfuse_tracing"):
+            runner = AdkTextRunner(mock_agent, config=config)
+        await runner.run_text_async("test")
+        meta = patch_propagate_attributes.call_args.kwargs["metadata"]
+        assert meta["adk_app_name"] == "app"
+        assert meta["env"] == "staging"
+
+
+# ---------------------------------------------------------------------------
+# aclose and async context manager
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestLifecycle:
+    """``aclose`` and ``async with`` lifecycle on ``AdkTextRunner``."""
+
+    async def test_aclose_clears_sticky_sessions(self, patch_runner_cls, mock_agent) -> None:
+        """``aclose`` empties the sticky session map."""
+        runner = AdkTextRunner(
+            mock_agent,
+            config=AdkTextRunnerConfig(app_name="app", fresh_session_per_message=False),
+        )
+        runner._conversation_session_by_user = {"alice": "s1"}
+        await runner.aclose()
+        assert runner._conversation_session_by_user == {}
+
+    async def test_aclose_closes_the_underlying_runner(self, patch_runner_cls, mock_agent) -> None:
+        """``aclose`` forwards to the wrapped runner's ``close``."""
+        runner = AdkTextRunner(mock_agent, config=AdkTextRunnerConfig(app_name="app"))
+        await runner.aclose()
+        patch_runner_cls.close.assert_called_once()
+
+    async def test_context_manager_calls_aclose_on_clean_exit(self, patch_runner_cls, mock_agent) -> None:
+        """Normal exit from ``async with`` runs ``aclose`` and clears sessions."""
+        async with AdkTextRunner(mock_agent, config=AdkTextRunnerConfig(app_name="app")) as runner:
+            runner._conversation_session_by_user = {"alice": "s1"}
+        assert runner._conversation_session_by_user == {}
+        patch_runner_cls.close.assert_called_once()
+
+    async def test_context_manager_calls_aclose_on_exception(self, patch_runner_cls, mock_agent) -> None:
+        """Exceptions inside the context still trigger ``aclose``."""
+        with pytest.raises(ValueError):
+            async with AdkTextRunner(mock_agent, config=AdkTextRunnerConfig(app_name="app")):
+                raise ValueError("deliberate")
+        patch_runner_cls.close.assert_called_once()

--- a/aieng-forecasting/tests/aieng/forecasting/methods/agentic/test_analyst_agent.py
+++ b/aieng-forecasting/tests/aieng/forecasting/methods/agentic/test_analyst_agent.py
@@ -1,0 +1,93 @@
+"""Tests for AnalystAgentConfig and build_analyst_instruction."""
+
+import pytest
+from aieng.forecasting.methods.agentic.analyst_agent.agent import build_analyst_instruction
+from aieng.forecasting.methods.agentic.analyst_agent.config import AnalystAgentConfig
+from pydantic import ValidationError
+
+
+# ---------------------------------------------------------------------------
+# AnalystAgentConfig — custom cross-field validator
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutConsistencyValidator:
+    """Cross-field checks tying sandbox lifetime to code execution timeout."""
+
+    def test_raises_when_execution_timeout_exceeds_sandbox(self) -> None:
+        """Reject when execution timeout exceeds sandbox lifetime."""
+        with pytest.raises(ValidationError, match="code_execution_timeout_seconds"):
+            AnalystAgentConfig(
+                sandbox_timeout_seconds=2700,
+                code_execution_timeout_seconds=2701.0,
+            )
+
+    def test_equal_timeouts_are_valid(self) -> None:
+        """Accept configs where execution timeout equals sandbox timeout."""
+        config = AnalystAgentConfig(
+            sandbox_timeout_seconds=2700,
+            code_execution_timeout_seconds=2700.0,
+        )
+        assert config.code_execution_timeout_seconds == 2700.0
+
+    def test_none_execution_timeout_skips_check(self) -> None:
+        """Skip the comparison when execution timeout is unset (library default)."""
+        # None means "use library default"; validator must not compare None to int.
+        config = AnalystAgentConfig(code_execution_timeout_seconds=None)
+        assert config.code_execution_timeout_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# build_analyst_instruction — template substitution and composition
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAnalystInstruction:
+    """``build_analyst_instruction``: defaults, overrides, and suffix handling."""
+
+    def test_default_instruction_substitutes_sandbox_timeout_seconds(self) -> None:
+        """Default template includes the configured sandbox timeout value."""
+        config = AnalystAgentConfig(sandbox_timeout_seconds=1234, code_execution_timeout_seconds=600.0)
+        instruction = build_analyst_instruction(config)
+        assert "1234" in instruction
+
+    def test_default_instruction_leaves_no_raw_format_placeholders(self) -> None:
+        """Default instruction must not leave unreplaced ``{...}`` segments."""
+        config = AnalystAgentConfig()
+        instruction = build_analyst_instruction(config)
+        assert "{" not in instruction
+
+    def test_override_replaces_default_template_entirely(self) -> None:
+        """Override replaces the default template entirely."""
+        config = AnalystAgentConfig(analyst_instruction_override="My custom prompt")
+        assert build_analyst_instruction(config) == "My custom prompt"
+
+    def test_override_is_used_verbatim_and_not_formatted(self) -> None:
+        """Override text is not run through ``str.format``; braces stay literal."""
+        config = AnalystAgentConfig(
+            analyst_instruction_override="Budget: {sandbox_timeout_seconds}s",
+        )
+        result = build_analyst_instruction(config)
+        assert "{sandbox_timeout_seconds}" in result
+
+    def test_suffix_is_appended_to_default_with_blank_line_separator(self) -> None:
+        """Suffix joins the default instruction with a blank line."""
+        config = AnalystAgentConfig(analyst_instruction_suffix="Extra rules")
+        instruction = build_analyst_instruction(config)
+        assert "\n\nExtra rules" in instruction
+
+    def test_suffix_is_appended_to_override(self) -> None:
+        """Suffix also appends after a fully overridden base instruction."""
+        config = AnalystAgentConfig(
+            analyst_instruction_override="Base",
+            analyst_instruction_suffix="Suffix",
+        )
+        assert build_analyst_instruction(config) == "Base\n\nSuffix"
+
+    def test_leading_newlines_on_suffix_are_stripped(self) -> None:
+        """Normalize suffix so leading newlines do not create triple blank lines."""
+        config = AnalystAgentConfig(
+            analyst_instruction_override="Base",
+            analyst_instruction_suffix="\n\nSuffix",
+        )
+        assert build_analyst_instruction(config) == "Base\n\nSuffix"

--- a/aieng-forecasting/tests/aieng/forecasting/test_langfuse_tracing.py
+++ b/aieng-forecasting/tests/aieng/forecasting/test_langfuse_tracing.py
@@ -1,0 +1,200 @@
+"""Tests for aieng.forecasting.langfuse_tracing.
+
+All tests run without live Langfuse, LiteLLM, or ADK connections.
+External packages are patched via sys.modules.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aieng.forecasting.langfuse_tracing import (
+    _langfuse_credentials_present,
+    _LangfuseTracingBootstrap,
+    init_langfuse_tracing,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _all_deps_present(*, litellm_callbacks: list[str] | None = None) -> dict:
+    """Return a sys.modules patch dict with all optional deps present."""
+    litellm_mod = MagicMock()
+    litellm_mod.callbacks = list(litellm_callbacks or [])
+
+    instrumentor_instance = MagicMock()
+    instrumentor_cls = MagicMock(return_value=instrumentor_instance)
+    google_adk_mod = MagicMock()
+    google_adk_mod.GoogleADKInstrumentor = instrumentor_cls
+
+    return {
+        "langfuse": MagicMock(),
+        "litellm": litellm_mod,
+        "openinference": MagicMock(),
+        "openinference.instrumentation": MagicMock(),
+        "openinference.instrumentation.google_adk": google_adk_mod,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _langfuse_credentials_present — whitespace edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestLangfuseCredentialsPresent:
+    """``_langfuse_credentials_present`` treats whitespace-only env vars as absent."""
+
+    def test_whitespace_only_public_key_treated_as_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Whitespace-only public key counts as missing credentials."""
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "   ")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-real")
+        assert _langfuse_credentials_present() is False
+
+    def test_whitespace_only_secret_key_treated_as_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Whitespace-only secret key counts as missing credentials."""
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-real")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "   ")
+        assert _langfuse_credentials_present() is False
+
+
+# ---------------------------------------------------------------------------
+# _LangfuseTracingBootstrap — graceful handling of absent / broken deps
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapMissingDeps:
+    """Bootstrap steps fail softly when optional imports or calls break."""
+
+    def test_missing_langfuse_package_does_not_raise(self) -> None:
+        """Absent ``langfuse`` module leaves client uninitialized without raising."""
+        with patch.dict(sys.modules, {"langfuse": None}):
+            bootstrap = _LangfuseTracingBootstrap()
+            bootstrap._ensure_langfuse_client()
+        assert bootstrap._langfuse_client_initialized is False
+
+    def test_get_client_exception_does_not_propagate(self) -> None:
+        """Errors from ``get_client`` are swallowed; flag stays false."""
+        langfuse_mod = MagicMock()
+        langfuse_mod.get_client.side_effect = RuntimeError("connection refused")
+        with patch.dict(sys.modules, {"langfuse": langfuse_mod}):
+            bootstrap = _LangfuseTracingBootstrap()
+            bootstrap._ensure_langfuse_client()
+        assert bootstrap._langfuse_client_initialized is False
+
+    def test_missing_litellm_package_does_not_raise(self) -> None:
+        """Absent ``litellm`` skips callback registration without raising."""
+        with patch.dict(sys.modules, {"litellm": None}):
+            bootstrap = _LangfuseTracingBootstrap()
+            bootstrap._register_litellm_langfuse_otel()
+        assert bootstrap._litellm_instrumented is False
+
+    def test_missing_openinference_package_does_not_raise(self) -> None:
+        """Missing OpenInference ADK shim skips instrumentation silently."""
+        with patch.dict(
+            sys.modules,
+            {
+                "openinference": None,
+                "openinference.instrumentation": None,
+                "openinference.instrumentation.google_adk": None,
+            },
+        ):
+            bootstrap = _LangfuseTracingBootstrap()
+            bootstrap._instrument_google_adk()
+        assert bootstrap._google_adk_instrumented is False
+
+    def test_instrumentor_exception_does_not_propagate(self) -> None:
+        """Instrumentor ``instrument()`` failures do not bubble up."""
+        instrumentor_instance = MagicMock()
+        instrumentor_instance.instrument.side_effect = RuntimeError("otel setup failed")
+        google_adk_mod = MagicMock()
+        google_adk_mod.GoogleADKInstrumentor = MagicMock(return_value=instrumentor_instance)
+        with patch.dict(
+            sys.modules,
+            {
+                "openinference": MagicMock(),
+                "openinference.instrumentation": MagicMock(),
+                "openinference.instrumentation.google_adk": google_adk_mod,
+            },
+        ):
+            bootstrap = _LangfuseTracingBootstrap()
+            bootstrap._instrument_google_adk()
+        assert bootstrap._google_adk_instrumented is False
+
+
+# ---------------------------------------------------------------------------
+# _LangfuseTracingBootstrap — contracts on litellm callback list
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapLiteLLMCallbackContract:
+    """LiteLLM global ``callbacks`` list is updated idempotently."""
+
+    def test_langfuse_otel_not_appended_when_already_present(self) -> None:
+        """Existing langfuse_otel entry must not be duplicated."""
+        litellm_mod = MagicMock()
+        litellm_mod.callbacks = ["langfuse_otel", "other_hook"]
+        with patch.dict(sys.modules, {"litellm": litellm_mod}):
+            bootstrap = _LangfuseTracingBootstrap()
+            bootstrap._register_litellm_langfuse_otel()
+        assert litellm_mod.callbacks.count("langfuse_otel") == 1
+
+    def test_existing_callbacks_are_preserved(self) -> None:
+        """Appending ``langfuse_otel`` keeps prior callback entries."""
+        litellm_mod = MagicMock()
+        litellm_mod.callbacks = ["other_hook"]
+        with patch.dict(sys.modules, {"litellm": litellm_mod}):
+            bootstrap = _LangfuseTracingBootstrap()
+            bootstrap._register_litellm_langfuse_otel()
+        assert "other_hook" in litellm_mod.callbacks
+
+
+# ---------------------------------------------------------------------------
+# _LangfuseTracingBootstrap.init — idempotency and no-creds short-circuit
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapInit:
+    """Full ``init`` path: credential gate and idempotent LiteLLM setup."""
+
+    def test_no_op_without_credentials(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With no Langfuse keys, init performs no client or instrumentation work."""
+        monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+        monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+        deps = _all_deps_present()
+        with patch.dict(sys.modules, deps):
+            bootstrap = _LangfuseTracingBootstrap()
+            bootstrap.init()
+        assert not bootstrap._langfuse_client_initialized
+        assert not bootstrap._litellm_instrumented
+        assert not bootstrap._google_adk_instrumented
+
+    def test_repeated_init_does_not_duplicate_litellm_callback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Calling ``init`` twice adds ``langfuse_otel`` at most once."""
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        deps = _all_deps_present()
+        with patch.dict(sys.modules, deps):
+            bootstrap = _LangfuseTracingBootstrap()
+            bootstrap.init()
+            bootstrap.init()
+        assert deps["litellm"].callbacks.count("langfuse_otel") == 1
+
+
+# ---------------------------------------------------------------------------
+# init_langfuse_tracing — delegates to the module-level bootstrap
+# ---------------------------------------------------------------------------
+
+
+def test_init_langfuse_tracing_is_a_no_op_without_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Smoke-test the public entry point: no credentials → no side effects."""
+    fresh = _LangfuseTracingBootstrap()
+    monkeypatch.setattr("aieng.forecasting.langfuse_tracing._bootstrap", fresh)
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    init_langfuse_tracing()
+    assert not fresh._langfuse_client_initialized

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "codecov>=2.1.13",
+    "e2b>=2.20.2",
     "mypy>=1.20.0",
     "nbqa>=1.9.1",
     "pip-audit>=2.10.0",

--- a/scripts/build_e2b_template.py
+++ b/scripts/build_e2b_template.py
@@ -1,7 +1,6 @@
 """E2B sandbox image: aieng-forecasting + repo scripts for data cache population."""
 
 import asyncio
-import os
 from pathlib import Path
 
 from e2b import AsyncTemplate, wait_for_url
@@ -46,7 +45,6 @@ _builder = (
         user="root",
     )
     .make_dir("/home/user/workspace/data")
-    .set_envs({"FRED_API_KEY": os.getenv("FRED_API_KEY") or ""})
 )
 
 for _py in _PY_SCRIPTS:

--- a/scripts/build_e2b_template.py
+++ b/scripts/build_e2b_template.py
@@ -1,0 +1,74 @@
+"""E2B sandbox image: aieng-forecasting + repo scripts for data cache population."""
+
+import asyncio
+import os
+from pathlib import Path
+
+from e2b import AsyncTemplate, wait_for_url
+from e2b.template.logger import default_build_logger
+
+
+def _repo_root() -> Path:
+    """Walk parents until this monorepo root is found (depth-independent)."""
+    start = Path(__file__).resolve()
+    for p in start.parents:
+        if (p / "aieng-forecasting" / "pyproject.toml").is_file() and (p / "scripts").is_dir():
+            return p
+    msg = (
+        "Could not find agentic-forecasting repo root "
+        f"(expected aieng-forecasting/pyproject.toml and scripts/); started from {start}"
+    )
+    raise FileNotFoundError(msg)
+
+
+_REPO_ROOT = _repo_root()
+
+# Copy package tree into the image; avoids git clone (private repo / no TTY).
+_AIENG_REL = "aieng-forecasting"
+_AIENG_CONTAINER = "/build/aieng-forecasting"
+
+_SCRIPTS_SRC = _REPO_ROOT / "scripts"
+_WORKSPACE_SCRIPTS = "/home/user/workspace/scripts"
+_PY_SCRIPTS = sorted(_SCRIPTS_SRC.glob("*.py"))
+if not _PY_SCRIPTS:
+    msg = f"Expected at least one *.py in {_SCRIPTS_SRC}"
+    raise FileNotFoundError(msg)
+
+# E2B copy() sources must be relative to file_context_path (not absolute).
+_builder = (
+    AsyncTemplate(file_context_path=_REPO_ROOT)
+    .from_image("e2bdev/code-interpreter:latest")
+    .copy(_AIENG_REL, _AIENG_CONTAINER)
+    .pip_install(f'"{_AIENG_CONTAINER}[agentic,numerical,llm]"')
+    # Fail the build if the install did not land where runtime Python can import it.
+    .run_cmd(
+        'python3 -c "import aieng.forecasting; print(aieng.forecasting.__file__)"',
+        user="root",
+    )
+    .make_dir("/home/user/workspace/data")
+    .set_envs({"FRED_API_KEY": os.getenv("FRED_API_KEY") or ""})
+)
+
+for _py in _PY_SCRIPTS:
+    _rel = _py.relative_to(_REPO_ROOT).as_posix()
+    _builder = _builder.copy(_rel, f"{_WORKSPACE_SCRIPTS}/{_py.name}")
+
+template = _builder.set_workdir("/home/user/workspace").set_start_cmd(
+    start_cmd="sudo /root/.jupyter/start-up.sh",
+    ready_cmd=wait_for_url("http://localhost:49999/health"),
+)
+
+
+async def main() -> None:
+    await AsyncTemplate.build(
+        template,
+        "agentic-forecasting-bootcamp",
+        cpu_count=8,
+        memory_mb=8192,
+        on_build_logs=default_build_logger(),
+        skip_cache=True,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "codecov" },
+    { name = "e2b" },
     { name = "mypy" },
     { name = "nbqa" },
     { name = "pip-audit" },
@@ -76,6 +77,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "codecov", specifier = ">=2.1.13" },
+    { name = "e2b", specifier = ">=2.20.2" },
     { name = "mypy", specifier = ">=1.20.0" },
     { name = "nbqa", specifier = ">=1.9.1" },
     { name = "pip-audit", specifier = ">=2.10.0" },
@@ -99,6 +101,30 @@ dependencies = [
 requires-dist = [{ name = "aieng-forecasting", extras = ["numerical", "llm", "agentic"], editable = "aieng-forecasting" }]
 
 [[package]]
+name = "aieng-agents"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "nest-asyncio" },
+    { name = "openai" },
+    { name = "openai-agents" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/e8/27f866b04cc1ce7c5c0a0d89cdb07fcc581b0116b85e9f5fb8b52cd2040c/aieng_agents-0.3.0.tar.gz", hash = "sha256:a5de575ea3a66bc1b15654ab1a6cee211d6dc0c62af1856eac75a0227cca8015", size = 54936, upload-time = "2026-04-30T19:42:43.717Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/85/342fe6f5bc387b3a0cbc75d229d1e11061d2f2b7c7e8f32f273a4c0895bf/aieng_agents-0.3.0-py3-none-any.whl", hash = "sha256:743815ab9315fa16fb13971a2fb889bd04760d77b20753d8e6336f110bb109d5", size = 71409, upload-time = "2026-04-30T19:42:42.125Z" },
+]
+
+[package.optional-dependencies]
+code-interpreter = [
+    { name = "e2b-code-interpreter" },
+]
+
+[[package]]
 name = "aieng-forecasting"
 version = "0.1.0"
 source = { editable = "aieng-forecasting" }
@@ -113,8 +139,10 @@ dependencies = [
 
 [package.optional-dependencies]
 agentic = [
+    { name = "aieng-agents", extra = ["code-interpreter"] },
     { name = "google-adk" },
     { name = "langfuse" },
+    { name = "openinference-instrumentation-google-adk" },
 ]
 llm = [
     { name = "langfuse" },
@@ -136,6 +164,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aieng-agents", extras = ["code-interpreter"], marker = "extra == 'agentic'", specifier = ">=0.3.0" },
     { name = "darts", marker = "extra == 'numerical'", specifier = ">=0.43.0" },
     { name = "fredapi", specifier = ">=0.5.2" },
     { name = "google-adk", marker = "extra == 'agentic'", specifier = ">=1.31.1" },
@@ -143,6 +172,7 @@ requires-dist = [
     { name = "langfuse", marker = "extra == 'llm'", specifier = ">=3.14.6" },
     { name = "lightgbm", marker = "extra == 'numerical'", specifier = ">=4.6.0" },
     { name = "litellm", marker = "extra == 'llm'", specifier = ">=1.83.14" },
+    { name = "openinference-instrumentation-google-adk", marker = "extra == 'agentic'", specifier = ">=0.1.10" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "properscoring", specifier = ">=0.1" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -493,6 +523,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
 ]
 
 [[package]]
@@ -1053,12 +1092,56 @@ wheels = [
 ]
 
 [[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "e2b"
+version = "2.20.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "dockerfile-parse" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "python-dateutil" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c4/c99011b3a6dcde4b0ed6f8b70052d67645c7fabb2a673efda18a2c2d1e37/e2b-2.20.2.tar.gz", hash = "sha256:ce69f65e0b07c1002ac4e386d109e4e658575efb2a774aefced92393f2cb2388", size = 157130, upload-time = "2026-04-27T21:27:00.808Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/43/9571d20355555f2eba6c17b9a43d2819070cfd92759511e7198535d83dc0/e2b-2.20.2-py3-none-any.whl", hash = "sha256:8ef964a4d1204a9fd61f4499662175a7a98ad173a81e7e848961799f77750276", size = 297073, upload-time = "2026-04-27T21:26:59.081Z" },
+]
+
+[[package]]
+name = "e2b-code-interpreter"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "e2b" },
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/ff/624d4aecaff4876abca3e507b6866e2dd421890669a99527b1aea7d5b8d1/e2b_code_interpreter-2.6.1.tar.gz", hash = "sha256:2aa7de4241b9394f61ba131c5385c81f9687a727dc40c77e14506bea21863d2c", size = 10643, upload-time = "2026-04-28T02:13:10.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/58/5b2438a4059d8333e37e54fb32a2f9fabb02b4257b8f14e426aef625a0bf/e2b_code_interpreter-2.6.1-py3-none-any.whl", hash = "sha256:2265fb7e0fc7a35f66a997e4bf7823291ad46d17b5a77bb1ce08343f5d3e9d1c", size = 13715, upload-time = "2026-04-28T02:13:09.993Z" },
 ]
 
 [[package]]
@@ -1911,6 +1994,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
     { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
     { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
+]
+
+[[package]]
+name = "griffe"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
 ]
 
 [[package]]
@@ -3599,6 +3694,66 @@ wheels = [
 ]
 
 [[package]]
+name = "openai-agents"
+version = "0.10.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffe" },
+    { name = "mcp" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "types-requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/38/f47644c5de02f1853483d1a16d1fb7d12cc2c219c5548ec26a3e9aee1c29/openai_agents-0.10.5.tar.gz", hash = "sha256:73cef5263eeb98437b874b29c800694617af7d9626be19514b4ed6f434874c1e", size = 2511640, upload-time = "2026-03-05T20:43:59.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/07/ad27018fb42d6f1e70f471a5ca3f6398a2159575b623edf86e1ddde66ce4/openai_agents-0.10.5-py3-none-any.whl", hash = "sha256:6c92491c61ba85b4790d76562b4af2e6e230c8844f9c12fed8a721400a320c86", size = 413046, upload-time = "2026-03-05T20:43:57.874Z" },
+]
+
+[[package]]
+name = "openinference-instrumentation"
+version = "0.1.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/6b/2f5bf4bb23f96f62d774af3edd2437de99fa70639eb755e4692d922a67f3/openinference_instrumentation-0.1.48.tar.gz", hash = "sha256:7682bf713a653f02e4d7c3cd3087482fa543f69d1f610418fae6f346327d25b0", size = 23936, upload-time = "2026-04-29T00:34:06.372Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/9f/e6fd710e214e85181077e21ee593c92f274ff3cddf5b32866c903c156003/openinference_instrumentation-0.1.48-py3-none-any.whl", hash = "sha256:aea9ca69abf11fb5a19195a16be81e2d2ca1f3a90b73b8f67df3006665f5d2b2", size = 30121, upload-time = "2026-04-29T00:34:05.318Z" },
+]
+
+[[package]]
+name = "openinference-instrumentation-google-adk"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-instrumentation" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/7a/bba3337066dcd391f7091d840c6d22e351a9f8412bb8de4b901cc6443aa9/openinference_instrumentation_google_adk-0.1.10.tar.gz", hash = "sha256:5ccb61d58532b2d829b71b411a997b573ddc2b03dcd5481fb2f9f67ec7368a97", size = 12383, upload-time = "2026-03-03T08:07:34.296Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/82/8ee4f5f40d2353ac643668c4f6a98e0ce51a76afeab1cfba2dab1976d7c4/openinference_instrumentation_google_adk-0.1.10-py3-none-any.whl", hash = "sha256:d97be628ce60b8eeab017f34ffaa2ec6fdaa11c64f3d0a032706ef74659e2a3e", size = 14201, upload-time = "2026-03-03T08:07:33.406Z" },
+]
+
+[[package]]
+name = "openinference-semantic-conventions"
+version = "0.1.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/6b/9ed67f9ce8c92436b297207abde730800b00bdec7e114f71b8dfe91cd26b/openinference_semantic_conventions-0.1.29.tar.gz", hash = "sha256:bbeb6472777a45a574169894bb9c4d80c6832a8befd32ab238cb875438ce1044", size = 12959, upload-time = "2026-04-22T00:39:27.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/7b/45ad1b95315b5563baa7338c8e8088bb1af66905c46e1bd1fe6ecbe30ea8/openinference_semantic_conventions-0.1.29-py3-none-any.whl", hash = "sha256:f45e0b1cf79fe407af4722bcf391a01565f0878c95be3ebcc9382245d0367cc5", size = 10582, upload-time = "2026-04-22T00:39:27.066Z" },
+]
+
+[[package]]
 name = "opentelemetry-api"
 version = "1.38.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3684,6 +3839,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/0a/debcdfb029fbd1ccd1563f7c287b89a6f7bef3b2902ade56797bfd020854/opentelemetry_exporter_otlp_proto_http-1.38.0.tar.gz", hash = "sha256:f16bd44baf15cbe07633c5112ffc68229d0edbeac7b37610be0b2def4e21e90b", size = 17282, upload-time = "2025-10-16T08:35:54.422Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/77/154004c99fb9f291f74aa0822a2f5bbf565a72d8126b3a1b63ed8e5f83c7/opentelemetry_exporter_otlp_proto_http-1.38.0-py3-none-any.whl", hash = "sha256:84b937305edfc563f08ec69b9cb2298be8188371217e867c1854d77198d0825b", size = 19579, upload-time = "2025-10-16T08:35:36.269Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.59b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/ed/9c65cd209407fd807fa05be03ee30f159bdac8d59e7ea16a8fe5a1601222/opentelemetry_instrumentation-0.59b0.tar.gz", hash = "sha256:6010f0faaacdaf7c4dff8aac84e226d23437b331dcda7e70367f6d73a7db1adc", size = 31544, upload-time = "2025-10-16T08:39:31.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/f5/7a40ff3f62bfe715dad2f633d7f1174ba1a7dd74254c15b2558b3401262a/opentelemetry_instrumentation-0.59b0-py3-none-any.whl", hash = "sha256:44082cc8fe56b0186e87ee8f7c17c327c4c2ce93bdbe86496e600985d74368ee", size = 33020, upload-time = "2025-10-16T08:38:31.463Z" },
 ]
 
 [[package]]
@@ -5633,6 +5803,18 @@ wheels = [
 ]
 
 [[package]]
+name = "types-requests"
+version = "2.33.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5766,6 +5948,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Introduces the agentic track: an ADK-based analyst agent that runs forecasting code inside an E2B sandbox, with a general-purpose AdkTextRunner for text-in/text-out turns and Langfuse/OTel tracing bootstrap for observability.

Clickup Ticket(s): https://app.clickup.com/t/868jdkmne

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [ ] 🔒 Security fix

## Changes Made

- aieng/forecasting/methods/agentic/analyst_agent/ — AnalystAgentConfig (Pydantic model), build_analyst_agent (Google ADK LlmAgent wired to an E2B code interpreter tool and a use-aieng-forecasting skill), and build_analyst_instruction (template + override/suffix composition)
- aieng/forecasting/methods/agentic/adk_runner.py — AdkTextRunner wraps InMemoryRunner with per-user sticky session management, fresh-session mode, Langfuse propagate_attributes integration, and async context manager support; AdkTextRunnerConfig exposes all options as validated Pydantic fields
- aieng/forecasting/langfuse_tracing.py — idempotent singleton bootstrap that initialises the Langfuse client, registers the langfuse_otel LiteLLM callback, and instruments Google ADK via OpenInference; safe to call multiple times and degrades gracefully when optional packages are absent
- skills/use-aieng-forecasting/ — ADK skill + reference document giving the agent runtime access to package docs, examples, and introspection helpers
- scripts/build_e2b_template.py — CLI script to build and push the E2B sandbox template (installs aieng-forecasting[agentic] and copies skill assets into the image)
- READMEs — root, aieng-forecasting/, and methods/ READMEs updated with E2B setup steps, agentic component inventory, and import examples
- pyproject.toml — new agentic optional dependency group (google-adk, langfuse, litellm, e2b-code-interpreter,
openinference-instrumentation-google-adk)
- .env.example / .gitignore — added E2B and Langfuse env var placeholders; ignored adk artifacts

## Testing

- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Type checking passes (`uv run mypy <src_dir>`)
- [x] Linting passes (`uv run ruff check src_dir/`)
- [ ] Manual testing performed (describe below)

**Manual testing details:**
<!-- Describe any manual testing performed -->

## Screenshots/Recordings

N/A

## Related Issues

N/A

## Deployment Notes

First-time agentic setup requires three additional steps not needed for the base package:

1. Create an E2B account at e2b.dev and obtain an E2B_API_KEY
2. Populate .env with E2B_API_KEY, LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, and LANGFUSE_HOST (see updated .env.example)
3. Build the sandbox image once: uv run --env-file .env scripts/build_e2b_template.py

The agentic extra must be installed explicitly (uv sync --extra agentic); the base package has no new runtime dependencies.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Documentation updated (if applicable)
- [x] No sensitive information (API keys, credentials) exposed
