### PR TITLE
Trim trailing page furniture from BoC press-release extraction

### DIFF
--- a/implementations/boc_rate_decisions/press_releases.py
+++ b/implementations/boc_rate_decisions/press_releases.py
@@ -113,6 +113,43 @@ def press_release_entries(schedule_path: Path | None = None) -> list[PressReleas
     return entries
 
 
+# Line-anchored markers for the start of page furniture that follows the rate
+# decision on a modern BoC announcement page. The decision rationale is the
+# page's primary content and always ends at "The next scheduled date for
+# announcing the overnight rate target is ..."; everything at or after the
+# earliest of these markers is taxonomy, footnotes, bundled same-day operational
+# notices, or related-content link teasers — none of it the published rationale.
+#
+#   - "Content Type(s)" : the taxonomy footer, present on all ~139 cached pages
+#     (older 2009-2020 pages have only this); related-content teasers follow it.
+#   - "Footnotes"        : precedes the marker only when a release bundles extra
+#     same-day content (e.g. 2025-01-29, which appends operational notices after
+#     its footnotes). Rare (1/139) but cuts the bundled residual cleanly.
+#
+# Matching at line start keeps these from ever firing inside rationale prose.
+# (No trailing \b: "Content Type(s)" is followed by ")" then a newline, neither a
+# word character, so \b would never match it — the marker sits alone on its line.)
+_FOOTER_MARKERS = re.compile(r"(?m)^(?:Footnotes|Content Type\(s\))")
+
+
+def _trim_page_furniture(text: str) -> str:
+    """Drop trailing page furniture after the rate-decision rationale.
+
+    Modern BoC announcement pages render the decision inside ``<main>`` together
+    with footer content (a content-type taxonomy line, footnotes, occasionally
+    bundled same-day operational notices, and related-content link teasers).
+    The naive ``<main>`` text grab captures all of it; this truncates at the
+    earliest known footer boundary so the cached artifact is just the rationale.
+
+    Older pages (2009-2020) only carry the taxonomy line, so this trims a few
+    trailing characters; it is a no-op when no marker is present.
+    """
+    match = _FOOTER_MARKERS.search(text)
+    if match is None:
+        return text
+    return text[: match.start()].rstrip()
+
+
 def extract_press_release_html(html: str, meta: DocumentMeta) -> ExtractedDocument:
     """Extract readable body text from a BoC press-release HTML page.
 
@@ -144,6 +181,7 @@ def extract_press_release_html(html: str, meta: DocumentMeta) -> ExtractedDocume
     lines = [line.strip() for line in raw_text.splitlines()]
     kept = [line for line in lines if line and not line.lower().startswith("share this page")]
     text = re.sub(r"\n{3,}", "\n\n", "\n".join(kept)).strip()
+    text = _trim_page_furniture(text)
 
     n_chars = len(text)
     return ExtractedDocument(

--- a/implementations/tests/boc_rate_decisions/test_press_releases.py
+++ b/implementations/tests/boc_rate_decisions/test_press_releases.py
@@ -30,6 +30,29 @@ _SAMPLE_HTML = """
 """
 
 
+# A modern (2021+) page: the rate decision is followed inside <main> by footer
+# furniture — footnotes, a bundled same-day operational notice, the content-type
+# taxonomy line, and related-content link teasers. Mirrors the 2025-01-29 page,
+# whose footnotes/notices precede the taxonomy marker.
+_MODERN_HTML = """
+<html><head><title>FAD</title></head>
+<body>
+  <main>
+    <h1>Bank of Canada reduces policy rate by 25 basis points</h1>
+    <p>The Bank of Canada today reduced its target for the overnight rate to 3%.</p>
+    <p>The next scheduled date for announcing the overnight rate target is March 12, 2025.</p>
+    <p>Footnotes</p>
+    <p>1. The deposit rate is set at 2.75%.</p>
+    <p>Financial Markets Department</p>
+    <p>Operational details for the next term repo are available here.</p>
+    <p>Content Type(s): Press releases</p>
+    <p>Related information</p>
+    <p>Monetary Policy Report — January 2025</p>
+  </main>
+</body></html>
+"""
+
+
 def _meta(d: date) -> DocumentMeta:
     return DocumentMeta(
         source="boc_press_releases", doc_id=f"{d.isoformat()}_en", publication_date=d, title="t", lang="en"
@@ -69,6 +92,40 @@ def test_html_extraction_keeps_article_drops_boilerplate() -> None:
     assert doc.page_count == 1
     assert doc.n_chars == len(doc.text)
     assert doc.meta.publication_date == date(2026, 6, 10)
+
+
+def test_html_extraction_trims_footer_furniture() -> None:
+    doc = extract_press_release_html(_MODERN_HTML, _meta(date(2025, 1, 29)))
+    body = doc.text
+    # Rationale kept, through its closing "next scheduled date" sentence.
+    assert "reduced its target for the overnight rate to 3%" in body
+    assert body.rstrip().endswith("is March 12, 2025.")
+    # Everything at/after the earliest footer marker is dropped: footnotes, the
+    # bundled operational notice, the taxonomy line, and related-content teasers.
+    assert "Footnotes" not in body
+    assert "deposit rate" not in body
+    assert "Financial Markets Department" not in body
+    assert "Content Type(s)" not in body
+    assert "Related information" not in body
+    assert "Monetary Policy Report" not in body
+    assert doc.n_chars == len(doc.text)
+
+
+def test_html_extraction_trims_taxonomy_only_footer() -> None:
+    # Older (2009-2020) pages carry only the taxonomy line — no footnotes — and
+    # it renders as "Content Type(s)" alone on its line. This is the universal
+    # case and must trim even when "Footnotes" is absent.
+    html = """
+    <html><body><main>
+      <p>The Bank of Canada today held its target for the overnight rate at 1%.</p>
+      <p>The next scheduled date for announcing the overnight rate target is 4 June 2009.</p>
+      <p>Content Type(s)</p><p>:</p><p>Press</p><p>,</p><p>Press releases</p>
+    </main></body></html>
+    """
+    doc = extract_press_release_html(html, _meta(date(2009, 4, 21)))
+    assert doc.text.rstrip().endswith("is 4 June 2009.")
+    assert "Content Type(s)" not in doc.text
+    assert "Press releases" not in doc.text
 
 
 def test_store_cutoff_and_lookups() -> None:


### PR DESCRIPTION
## What

The BoC press-release HTML extractor grabbed the entire `<main>` element, so cached rationale artifacts carried trailing **page furniture** from modern (2021+) announcement pages:

- the content-type **taxonomy line** (`Content Type(s): Press releases`) — on all 139 cached releases;
- **related-content link teasers** appended after it;
- on **2025-01-29** specifically, a block of **footnotes plus a bundled same-day operational notice** (the deposit-rate/term-repo notice), which is why that file was an outlier at ~9,964 chars.

This is the text the **reasoning-alignment evaluator** (notebook 03) reads as the "official rationale," and it's the context seam available to the LLMP/agent predictors — so the cruft was participant-facing.

## Fix

Truncate the extracted body at the earliest **line-anchored** footer marker, `{Footnotes, Content Type(s)}`:

- `Content Type(s)` is the **universal** boundary — drops the taxonomy line and the teasers that follow it on every page.
- `Footnotes` is the **rare** boundary (1/139) that also strips the 2025-01-29 bundled notice, which precedes the taxonomy marker.

Both markers sit alone on their own line and never occur in rationale prose, so the cut is safe and a near no-op on older (2009–2020) pages.

Verified on the regenerated cache (`scripts/fetch_boc_press_releases.py --force`):

- **no** footer marker remains in any of the 139 releases; `Content Type(s)` appears nowhere;
- **0** non-sentence-final endings (every release now closes on its rationale sentence);
- median 3844 → **3484** chars, max 9964 → **5590** (2025-01-29: 9964 → **4590**).

## Tests

Adds two fixture tests to `test_press_releases.py`:
- modern page (footnotes + bundled notice + taxonomy + teasers) → trimmed to the rationale;
- taxonomy-only page (older releases, no footnotes) → exercises the universal cut independently.

Full BoC suite: **44 passed**. `ruff` clean.

> Note: the report cache under `data/reports/boc_press_releases/` is gitignored; reviewers regenerate it with `uv run python scripts/fetch_boc_press_releases.py --force` (HTTP only, no LLM/proxy calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
