### PR TITLE
Participant-ready docs: number the reference implementations + ship starter agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A foundation for building, evaluating, and comparing forecasting systems — con
 
 The repository pairs a small, stable core library with a set of self-contained reference implementations. The library gives you cutoff-safe data handling, a single `Predictor` interface, and a backtest/evaluation harness. Each reference implementation is a worked example of a different forecasting problem and the techniques that suit it. Start from whichever one is closest to what you want to build.
 
+> **👉 First time here? Run the environment check.** After `uv sync` (see [Setup](#setup)), open [`implementations/getting_started/00_environment_check.ipynb`](implementations/getting_started/00_environment_check.ipynb) and run it top to bottom. It's a self-guided preflight that verifies every capability — proxy LLM inference, Langfuse, E2B code execution, StatCan/FRED data access, and an end-to-end mini backtest — and tells you exactly what to fix when something isn't set up. **Do this before anything else.**
+
 ## What's here
 
 - **Core library** — `aieng-forecasting` (`aieng.forecasting`): data services, cutoff enforcement, forecasting tasks, prediction payloads, backtesting, evaluation, and artifacts.
@@ -21,17 +23,20 @@ Every method can be used in one of two modes, and the distinction runs through t
 
 ## Reference implementations
 
-Each is independent and self-contained — pick the one that matches the problem you care about, and read that directory's `README.md` for the full walkthrough. They are not meant to be worked in order.
+Each is independent and self-contained — pick the one that matches the problem you care about, and read that directory's `README.md` for the full walkthrough. They are numbered in a recommended order that mirrors the bootcamp progression — conventional numerical methods → LLM Processes → agents → agentic evaluation — but any one stands on its own, so jump straight to the problem you care about.
+
+**Start here → #0 [`getting_started/`](implementations/getting_started/)** — one CPI series, one month ahead. The smallest end-to-end loop: a `Predictor`, a `BacktestSpec` and `EvalSpec`, naive + AutoARIMA baselines, CRPS scoring. The place to learn the evaluation framework before picking a domain below.
 
 
-| Implementation                                                       | The problem                                                                     | Concepts & techniques it demonstrates                                                                                                                                                                                                                                                              |
-| -------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `[getting_started/](implementations/getting_started/)`               | One CPI series, one month ahead.                                                | The smallest end-to-end loop: a `Predictor`, a `BacktestSpec` and `EvalSpec`, naive + AutoARIMA baselines, CRPS scoring. The place to learn the evaluation framework.                                                                                                                              |
-| `[food_price_forecasting/](implementations/food_price_forecasting/)` | A multivariate food-CPI trajectory, in the style of Canada's Food Price Report. | Nine correlated sub-indices, a 12-step trajectory, a domain metric (avg/avg YoY), baselines vs LLM-Process predictors, leakage-aware backtests, and cached artifacts for fast iteration.                                                                                                           |
-| `[energy_oil_forecasting/](implementations/energy_oil_forecasting/)` | Daily WTI crude-oil price under regime-breaking news.                           | A capability progression — Prophet → LLM-Process → news-grounded agent → code-executing agent — plus an adaptive agent that learns a strategy from data and is scored before vs after. Continuous trajectories, a binary up-shock task, and interactive scenario analysis.                         |
-| `[boc_rate_decisions/](implementations/boc_rate_decisions/)`         | Will the Bank of Canada cut, hold, or hike at its next meeting?                 | Discrete-event forecasting: ordered-categorical outcomes on an irregular calendar, RPS scoring and one-vs-rest calibration (instead of CRPS), a binary (Brier) special case, cutoff-aware document ingestion, and an LLM-as-judge that scores an agent's reasoning against the official rationale. |
-| `[sp500_forecasting/](implementations/sp500_forecasting/)`           | S&P 500 returns under a macro/market covariate panel.                           | A head-to-head of conventional numerical methods (naive, ETS, Kalman, AutoARIMA, linear regression, LightGBM) plus a covariate-aware LLM-Process, all reading the same leak-safe covariate panel. Cumulative-return targets at 1/5/21-business-day horizons, CRPS + direction metrics, config-driven specs. |
+| #   | Implementation                                                       | The problem                                                                     | Concepts & techniques it demonstrates                                                                                                                                                                                                                                                                       |
+| --- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `[sp500_forecasting/](implementations/sp500_forecasting/)`           | S&P 500 returns under a macro/market covariate panel.                           | A head-to-head of conventional numerical methods (naive, ETS, Kalman, AutoARIMA, linear regression, LightGBM) plus a covariate-aware LLM-Process, all reading the same leak-safe covariate panel. Cumulative-return targets at 1/5/21-business-day horizons, CRPS + direction metrics, config-driven specs. |
+| 2   | `[food_price_forecasting/](implementations/food_price_forecasting/)` | A multivariate food-CPI trajectory, in the style of Canada's Food Price Report. | Nine correlated sub-indices, a 12-step trajectory, a domain metric (avg/avg YoY), baselines vs LLM-Process predictors, leakage-aware backtests, and cached artifacts for fast iteration.                                                                                                                    |
+| 3   | `[energy_oil_forecasting/](implementations/energy_oil_forecasting/)` | Daily WTI crude-oil price under regime-breaking news.                           | A capability progression — Prophet → LLM-Process → news-grounded agent → code-executing agent — plus an adaptive agent that learns a strategy from data and is scored before vs after. Continuous trajectories, a binary up-shock task, and interactive scenario analysis.                                  |
+| 4   | `[boc_rate_decisions/](implementations/boc_rate_decisions/)`         | Will the Bank of Canada cut, hold, or hike at its next meeting?                 | Discrete-event forecasting: ordered-categorical outcomes on an irregular calendar, RPS scoring and one-vs-rest calibration (instead of CRPS), a binary (Brier) special case, cutoff-aware document ingestion, and an LLM-as-judge that scores an agent's reasoning against the official rationale.          |
 
+
+**Not sure where to start building?** Each of the four domain implementations above ends with a `99_starter_agent.ipynb` — a fresh, hackable **starter agent** (a `starter_agent/` module) with toggleable news search and code execution, two lightweight tool-usage skills, an interactive cell, and one scored forecast. It's the consistent "continue from here" entry point for taking any reference use case in an agentic direction, and a quick end-to-end test of that use case's agent stack.
 
 ## Time Series Data sources
 
@@ -75,7 +80,7 @@ New to the project? Open [`implementations/getting_started/00_environment_check.
 
 ### Populate the data cache
 
-Data is fetched once and cached locally (gitignored). Each implementation names the fetch script(s) it needs in its own `README.md` — for example `scripts/fetch_cpi.py` (getting started), `scripts/fetch_wti.py` (energy), `scripts/fetch_boc.py` and `scripts/fetch_boc_press_releases.py` (BoC), and `scripts/fetch_sp500_market.py` + `scripts/fetch_fred.py` (S&P 500). Run the relevant one before opening that implementation's notebooks:
+Data is fetched once and cached locally (gitignored). Each implementation names the fetch script(s) it needs in its own `README.md` — for example `scripts/fetch_cpi.py` (getting started), `scripts/fetch_sp500_market.py` + `scripts/fetch_fred.py` (S&P 500), `scripts/fetch_wti.py` (energy), and `scripts/fetch_boc.py` and `scripts/fetch_boc_press_releases.py` (BoC). Run the relevant one before opening that implementation's notebooks:
 
 ```bash
 uv run python scripts/fetch_cpi.py
@@ -83,7 +88,9 @@ uv run python scripts/fetch_cpi.py
 
 ### Build the E2B sandbox image (agentic implementations only)
 
-Agentic forecasters can run code in an E2B cloud sandbox. Do this once before enabling code execution in `build_adk_agent`:
+Agentic forecasters can run code in an E2B cloud sandbox. Credentials for e2b should be automatically injected into the environment for bootcamp participants, and you can confirm successful setup by running [`00_environment_check.ipynb`](implementations/getting_started/00_environment_check.ipynb).
+
+If this was unsuccessful, or if you prefer to run with E2B in an alternative environment, do this once before enabling code execution in `build_adk_agent`:
 
 1. Create a free account at [e2b.dev](https://e2b.dev) and copy your API key.
 2. Add it to your `.env` file alongside the other keys (see `.env.example`):
@@ -136,8 +143,8 @@ uv run pre-commit run --all-files
 
 ## Documentation
 
-- Per-implementation READMEs under `implementations/<use-case>/` — the primary user surface.
-- `aieng-forecasting/README.md` and `aieng-forecasting/aieng/forecasting/methods/README.md` — the library and the method catalog.
-- `planning-docs/roadmap.md` — architecture principles and extension ideas.
+- Per-implementation READMEs under `[implementations/](implementations/)` — the primary user surface.
+- `[aieng-forecasting/README.md](aieng-forecasting/README.md)` and `[aieng-forecasting/aieng/forecasting/methods/README.md](aieng-forecasting/aieng/forecasting/methods/README.md)` — the library and the method catalog.
+- `[planning-docs/roadmap.md](planning-docs/roadmap.md)` — architecture principles and extension ideas.
 
 Keep code, notebooks, specs, and these docs in sync when you change behavior, setup, layout, or datasets.

--- a/implementations/README.md
+++ b/implementations/README.md
@@ -10,23 +10,27 @@ Some use cases are notebook-only. Others expose a small importable helper packag
 
 ## Directory layout
 
+Numbered in the recommended order (mirrors the bootcamp progression: conventional numerical methods → LLM Processes → agents → agentic evaluation). The directories are not renamed — the numbers are an ordering convention used across the docs, and each directory stays an importable package (`from sp500_forecasting.data import ...`).
+
 ```text
 implementations/
-|-- getting_started/          # CPI gasoline hello-world
-|   `-- specs/                # backtest and eval YAML
-|-- food_price_forecasting/   # CFPR-style food CPI experiment
-|   `-- specs/                # backtest YAML
-|-- energy_oil_forecasting/   # Daily WTI oil price forecasting experiment
-|   `-- specs/                # backtest and eval YAML
-|-- sp500_forecasting/        # S&P 500 multivariate numerical comparison (financial markets)
-|   `-- specs/                # backtest YAML (smoke + full)
-|-- boc_rate_decisions/       # Discrete-event reference: BoC cut/hold/hike direction
-|   `-- specs/                # direction + binary backtest / eval / smoke YAML
+|-- getting_started/          # 0 · CPI gasoline hello-world (start here)
+|   `-- specs/                #     backtest and eval YAML
+|-- sp500_forecasting/        # 1 · S&P 500 multivariate numerical comparison (financial markets)
+|   `-- specs/                #     backtest YAML (smoke + full)
+|-- food_price_forecasting/   # 2 · CFPR-style food CPI experiment
+|   `-- specs/                #     backtest YAML
+|-- energy_oil_forecasting/   # 3 · Daily WTI oil price forecasting experiment
+|   `-- specs/                #     backtest and eval YAML
+|-- boc_rate_decisions/       # 4 · Discrete-event reference: BoC cut/hold/hike direction
+|   `-- specs/                #     direction + binary backtest / eval / smoke YAML
 |-- tests/                    # tests for implementation-specific helper modules
 `-- pyproject.toml            # local workspace packaging
 ```
 
 YAML backtest and eval specs live under each use case in `specs/`. Each directory is independent; see its `README.md` for the walkthrough.
+
+Every domain use case (all except `getting_started`) also ships a `starter_agent/` module and a `99_starter_agent.ipynb` — a fresh, hackable **starter agent** that is the consistent "build your own" entry point for that use case (toggleable news search + code execution, two lightweight tool-usage skills, an interactive cell, and one scored forecast).
 
 ---
 

--- a/implementations/boc_rate_decisions/03_rationale_alignment.ipynb
+++ b/implementations/boc_rate_decisions/03_rationale_alignment.ipynb
@@ -125,7 +125,38 @@
    "id": "2f22bb20",
    "metadata": {},
    "outputs": [],
-   "source": "from boc_rate_decisions.analyst_agent import build_boc_agent_predictor, build_boc_basic_config\nfrom boc_rate_decisions.predictors import build_llmp_direction\n\n\n# Model for BOTH reasoning predictors. Flash-lite is the fast/cheap default; on\n# this window gemini-3.5-flash reasons noticeably better at higher cost/latency\n# (see the §5 note). Switch by commenting the two lines below. The LLM-as-judge\n# in §3 always uses the advanced model regardless of this choice.\nMODEL = \"gemini-3.1-flash-lite-preview\"  # fast/cheap default\n# MODEL = \"gemini-3.5-flash\"             # stronger reasoning, higher cost/slower\n\n# Run the reasoning predictors over the PROTECTED POST-2025 eval window — the same\n# honest origins as notebook 02 §10 (boc_rate_direction_eval.yaml: 12 meetings,\n# Jan 2025 – Jun 2026, at/after the model's ~Jan 2025 cutoff). evaluate() runs each\n# predictor live, emitting a fresh Langfuse trace per origin (each stamped with the\n# structured forecast). Unlike cached_backtest there's no cache to go stale: every\n# run re-traces, so the judge in section 3 always has live traces to read.\nwith (SPECS_DIR / \"boc_rate_direction_eval.yaml\").open() as f:\n    spec = EvalSpec.model_validate(yaml.safe_load(f))\n\nllmp = build_llmp_direction(model=MODEL, reasoning_effort=None)\nagent = build_boc_agent_predictor(build_boc_basic_config(model=MODEL))\nPREDICTOR_LABELS = {llmp.predictor_id: \"LLMP direction\", agent.predictor_id: \"Agent (basic)\"}\n\nresults = {}\nfor predictor in [llmp, agent]:\n    # tracker=None: a side-channel eval runs unbudgeted and does not spend the\n    # spec's max_runs accuracy-eval budget (mirrors notebook 02 §10).\n    results[predictor.predictor_id] = evaluate(predictor=predictor, spec=spec, data_service=svc, tracker=None)\nprint(f\"Loaded results ({MODEL}):\", \", \".join(PREDICTOR_LABELS[p] for p in results))"
+   "source": [
+    "from boc_rate_decisions.analyst_agent import build_boc_agent_predictor, build_boc_basic_config\n",
+    "from boc_rate_decisions.predictors import build_llmp_direction\n",
+    "\n",
+    "\n",
+    "# Model for BOTH reasoning predictors. Flash-lite is the fast/cheap default; on\n",
+    "# this window gemini-3.5-flash reasons noticeably better at higher cost/latency\n",
+    "# (see the §5 note). Switch by commenting the two lines below. The LLM-as-judge\n",
+    "# in §3 always uses the advanced model regardless of this choice.\n",
+    "MODEL = \"gemini-3.1-flash-lite-preview\"  # fast/cheap default\n",
+    "# MODEL = \"gemini-3.5-flash\"             # stronger reasoning, higher cost/slower\n",
+    "\n",
+    "# Run the reasoning predictors over the PROTECTED POST-2025 eval window — the same\n",
+    "# honest origins as notebook 02 §10 (boc_rate_direction_eval.yaml: 12 meetings,\n",
+    "# Jan 2025 – Jun 2026, at/after the model's ~Jan 2025 cutoff). evaluate() runs each\n",
+    "# predictor live, emitting a fresh Langfuse trace per origin (each stamped with the\n",
+    "# structured forecast). Unlike cached_backtest there's no cache to go stale: every\n",
+    "# run re-traces, so the judge in section 3 always has live traces to read.\n",
+    "with (SPECS_DIR / \"boc_rate_direction_eval.yaml\").open() as f:\n",
+    "    spec = EvalSpec.model_validate(yaml.safe_load(f))\n",
+    "\n",
+    "llmp = build_llmp_direction(model=MODEL, reasoning_effort=None)\n",
+    "agent = build_boc_agent_predictor(build_boc_basic_config(model=MODEL))\n",
+    "PREDICTOR_LABELS = {llmp.predictor_id: \"LLMP direction\", agent.predictor_id: \"Agent (basic)\"}\n",
+    "\n",
+    "results = {}\n",
+    "for predictor in [llmp, agent]:\n",
+    "    # tracker=None: a side-channel eval runs unbudgeted and does not spend the\n",
+    "    # spec's max_runs accuracy-eval budget (mirrors notebook 02 §10).\n",
+    "    results[predictor.predictor_id] = evaluate(predictor=predictor, spec=spec, data_service=svc, tracker=None)\n",
+    "print(f\"Loaded results ({MODEL}):\", \", \".join(PREDICTOR_LABELS[p] for p in results))"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -189,6 +220,12 @@
     "    )\n",
     "    print(summary.to_string())"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a760afb6",
+   "metadata": {},
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -649,7 +686,25 @@
    "cell_type": "markdown",
    "id": "8dc8f739",
    "metadata": {},
-   "source": "---\n## 5. Langfuse scores — review\n\nThe `rationale_alignment` and `right_for_right_reasons` scores were pushed to each\ntrace in section 3 (when `PUSH_TO_LANGFUSE = True`). This table summarises what\nlanded and links to each trace, so the verdicts are one click from the traces and\ndashboards — a step toward closing the agent feedback loop. The **Result** column\n(✅/❌) marks whether the predicted direction matched the actual decision —\n*accuracy*, distinct from *alignment* (was the reasoning sound), so you can spot\nthe revealing cases: right for the wrong reasons (✅ + low alignment) and wrong\nfor sound reasons (❌ + high alignment).\n\n> **Read the numbers with the window in mind.** This is **11 meetings per method**\n> (Jan 2025 – Jun 2026) with **no hikes** — mostly holds and a few cuts. That's\n> enough to *see* a model gap (the default `gemini-3.1-flash-lite-preview` reasons\n> visibly worse than `gemini-3.5-flash` — flip `MODEL` in §2 to compare), but too\n> small to *rank* models with confidence. Treat it as directional, not decisive."
+   "source": [
+    "---\n",
+    "## 5. Langfuse scores — review\n",
+    "\n",
+    "The `rationale_alignment` and `right_for_right_reasons` scores were pushed to each\n",
+    "trace in section 3 (when `PUSH_TO_LANGFUSE = True`). This table summarises what\n",
+    "landed and links to each trace, so the verdicts are one click from the traces and\n",
+    "dashboards — a step toward closing the agent feedback loop. The **Result** column\n",
+    "(✅/❌) marks whether the predicted direction matched the actual decision —\n",
+    "*accuracy*, distinct from *alignment* (was the reasoning sound), so you can spot\n",
+    "the revealing cases: right for the wrong reasons (✅ + low alignment) and wrong\n",
+    "for sound reasons (❌ + high alignment).\n",
+    "\n",
+    "> **Read the numbers with the window in mind.** This is **11 meetings per method**\n",
+    "> (Jan 2025 – Jun 2026) with **no hikes** — mostly holds and a few cuts. That's\n",
+    "> enough to *see* a model gap (the default `gemini-3.1-flash-lite-preview` reasons\n",
+    "> visibly worse than `gemini-3.5-flash` — flip `MODEL` in §2 to compare), but too\n",
+    "> small to *rank* models with confidence. Treat it as directional, not decisive."
+   ]
   },
   {
    "cell_type": "code",

--- a/implementations/boc_rate_decisions/99_starter_agent.ipynb
+++ b/implementations/boc_rate_decisions/99_starter_agent.ipynb
@@ -1,0 +1,246 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {},
+   "source": [
+    "# Bank of Canada Rate Decisions — Your Starter Agent\n",
+    "\n",
+    "**If you're not sure what to do next, continue from here.**\n",
+    "\n",
+    "This notebook is a fresh, hackable agent for the BoC rate-decision use case — deliberately *not* wired into the numbered curriculum. It gives you our common building blocks behind simple toggles, so you can start building something of your own:\n",
+    "\n",
+    "- **optional news search** — bounded, cutoff-aware Google Search (proxy-only)\n",
+    "- **optional code execution** — an E2B Python sandbox\n",
+    "- **two lightweight skills** — *tool-usage playbooks* in `starter_agent/skills/`\n",
+    "\n",
+    "It does two things: lets you **talk to the agent** (open-ended, Track 2) and **score one real forecast** (Track 1). The live cells are gated by `RUN_AGENT` so a fresh `Run All` is safe and free; flip it to `True` to actually call the model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "from pathlib import Path\n",
+    "\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "\n",
+    "# Repo root holds the .env with PROXY_* creds the agent needs.\n",
+    "ROOT = Path.cwd().resolve().parents[1]\n",
+    "load_dotenv(ROOT / \".env\")\n",
+    "\n",
+    "# ── Model selection ───────────────────────────────────\n",
+    "# Two project models: \"gemini-3.1-flash-lite-preview\" (lite/default) and\n",
+    "# \"gemini-3.5-flash\" (advanced). Lite is the default.\n",
+    "AGENT_MODEL = \"gemini-3.1-flash-lite-preview\"\n",
+    "# AGENT_MODEL = \"gemini-3.5-flash\"  # advanced (higher cost/latency)\n",
+    "\n",
+    "# ── Run guard ──────────────────────────────────────\n",
+    "# Live agent calls cost tokens and need PROXY_* in the repo-root .env, plus warm\n",
+    "# data caches. Default False so `Run All` is safe; set True to call the model.\n",
+    "RUN_AGENT = False\n",
+    "\n",
+    "from boc_rate_decisions.starter_agent import (\n",
+    "    build_starter_agent_config,\n",
+    "    build_starter_agent_predictor,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "print(\"RUN_AGENT =\", RUN_AGENT, \"| model =\", AGENT_MODEL)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-02",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 1. Meet your agent\n",
+    "\n",
+    "`build_starter_agent_config` returns an `AgentConfig` with two toggles. The default turns **news search on** (proxy-only, no extra key) and **code execution off** (it needs `E2B_API_KEY` and is slower). Flip them and re-run — the loaded skills follow the enabled tools.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = build_starter_agent_config(\n",
+    "    model=AGENT_MODEL,\n",
+    "    enable_search=True,  # ← cutoff-aware Google Search (proxy-only)\n",
+    "    enable_code_exec=False,  # ← E2B Python sandbox (needs E2B_API_KEY); try True!\n",
+    ")\n",
+    "\n",
+    "print(\"Agent:\", config.name)\n",
+    "print(\"Search enabled:    \", config.context_retrieval.enabled)\n",
+    "print(\"Code-exec enabled: \", config.code_execution.enabled)\n",
+    "print(\"Skills loaded:     \", [p.name for p in config.skills_dirs])\n",
+    "print(\"\\n── System instruction (edit this in starter_agent/agent.py) ──\\n\")\n",
+    "print(config.instruction[:1200], \"...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-04",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2. Talk to it  *(Track 2 — open-ended analysis)*\n",
+    "\n",
+    "Ask the agent anything. This is the interactive mode: no scoring, no schema — just reasoning (and a web search, since search is on). Edit the question and explore.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from aieng.forecasting.methods.agentic import build_adk_agent\n",
+    "from aieng.forecasting.methods.agentic.adk_runner import AdkTextRunner, AdkTextRunnerConfig\n",
+    "\n",
+    "\n",
+    "QUESTION = (\n",
+    "    \"What is the case for a cut versus a hold at the Bank of Canada\\u2019s next \"\n",
+    "    \"rate decision, and which looks more likely? Be concise.\"\n",
+    ")\n",
+    "\n",
+    "if RUN_AGENT:\n",
+    "    chat_agent = build_adk_agent(config)  # schema-free: plain text in, text out\n",
+    "    runner = AdkTextRunner(chat_agent, config=AdkTextRunnerConfig(app_name=\"boc_starter_chat\"))\n",
+    "    reply = await runner.run_text_async(QUESTION)  # noqa: F704, PLE1142\n",
+    "    print(reply)\n",
+    "else:\n",
+    "    print(\"RUN_AGENT is False — set it to True in the setup cell to talk to the agent.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-06",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 3. Score one prediction against a known outcome  *(Track 1)*\n",
+    "\n",
+    "Now run the agent as a `Predictor`. We pick the **most recent already-resolved** decision, forecast it from 28 days out, and print the agent's distribution next to **what the Bank actually did** — so you can see whether it was any good. (One decision can't tell you if the agent is *calibrated*; that's what the leaderboard + reliability curves in `02_boc_rate_direction_experiment.ipynb` are for.) Live, so gated by `RUN_AGENT`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime, timezone\n",
+    "\n",
+    "\n",
+    "if RUN_AGENT:\n",
+    "    from aieng.forecasting.evaluation.task import ForecastingTask\n",
+    "    from aieng.forecasting.methods import CategoricalFrequencyPredictor\n",
+    "    from boc_rate_decisions.data import (\n",
+    "        DIRECTION_SERIES_ID,\n",
+    "        DIRECTION_TASK_CATEGORIES,\n",
+    "        build_boc_service,\n",
+    "    )\n",
+    "\n",
+    "    svc = build_boc_service(\n",
+    "        statcan_cache_dir=ROOT / \"data\" / \"statcan\",\n",
+    "        fred_cache_dir=ROOT / \"data\" / \"fred\",\n",
+    "    )\n",
+    "    now = datetime.now(tz=timezone.utc).replace(tzinfo=None)\n",
+    "\n",
+    "    # Most recent already-resolved decision = last point in the realized direction series.\n",
+    "    dir_df = svc.get_series(DIRECTION_SERIES_ID, as_of=now)\n",
+    "    last = dir_df.iloc[-1]\n",
+    "    ANNOUNCEMENT = pd.Timestamp(last[\"timestamp\"])\n",
+    "    realized = {-1.0: \"cut\", 0.0: \"hold\", 1.0: \"hike\"}[float(last[\"value\"])]\n",
+    "    AS_OF = ANNOUNCEMENT - pd.Timedelta(days=28)\n",
+    "\n",
+    "    task = ForecastingTask(\n",
+    "        task_id=\"boc_starter_direction\",\n",
+    "        target_series_id=DIRECTION_SERIES_ID,\n",
+    "        horizons=[28],\n",
+    "        frequency=\"D\",\n",
+    "        payload_type=\"categorical\",\n",
+    "        categories=DIRECTION_TASK_CATEGORIES,\n",
+    "        description=\"BoC rate decision direction (cut/hold/hike), 28 days ahead (starter).\",\n",
+    "    )\n",
+    "    ctx = svc.context(as_of=AS_OF)\n",
+    "    pred = build_starter_agent_predictor(config).predict(task, ctx)[0]\n",
+    "    floor = CategoricalFrequencyPredictor().predict(task, ctx)[0]\n",
+    "\n",
+    "    probs = pred.payload.probabilities\n",
+    "    print(f\"Decision {ANNOUNCEMENT.date()} forecast from as_of={AS_OF.date()} (T-28)\")\n",
+    "    print(f\"Actual outcome: {realized.upper()}\\n\")\n",
+    "    print(\"  outcome   agent prob   climatology\")\n",
+    "    for label in (\"cut\", \"hold\", \"hike\"):\n",
+    "        mark = \"   <- ACTUAL\" if label == realized else \"\"\n",
+    "        print(f\"  {label:<7}   {probs[label]:7.2%}     {floor.payload.probabilities[label]:7.2%}{mark}\")\n",
+    "    top = max(probs, key=probs.get)\n",
+    "    print(\n",
+    "        f\"\\nAgent put {probs[realized]:.0%} on what happened \"\n",
+    "        f\"({'its top pick ✓' if top == realized else f'top pick was {top}'}).\"\n",
+    "    )\n",
+    "    if pred.metadata.get(\"reasoning\"):\n",
+    "        print(\"\\nReasoning:\", pred.metadata[\"reasoning\"][:300])\n",
+    "else:\n",
+    "    print(\"RUN_AGENT is False — set it to True to score a live forecast against a known outcome.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-08",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 4. Make it yours\n",
+    "\n",
+    "This agent is a starting point. Here are concrete next steps, easiest first — each is a small edit, then re-run the cells above.\n",
+    "\n",
+    "1. **Flip code execution on.** Set `enable_code_exec=True` in §1 (needs `E2B_API_KEY`). The agent loads the `code-analysis-playbook` skill and can compute its own diagnostics before forecasting. Compare the rationale.\n",
+    "2. **Edit the agent's personality.** Open `starter_agent/agent.py` and change `_build_starter_instruction()` — make it more cautious, more contrarian, focused on one driver. Re-run §1 to see the new instruction.\n",
+    "3. **Sharpen the skills.** The two files in `starter_agent/skills/` are short on purpose. Add your best queries to `research-playbook`, or a new diagnostic to `code-analysis-playbook`. The agent picks them up automatically.\n",
+    "4. **Change the question and the origin.** Try a different `QUESTION` in §2 and a different origin in §3.\n",
+    "5. **Mind the leakage.** News grounding on historical origins can leak the outcome — keep `cutoff_date` honest, and prefer genuinely upcoming meetings.\n",
+    "6. **Judge the reasoning, not just the number.** Notebook 03 scores the agent's `reasoning`/`key_signals` against the Bank's published rationale (`rationale_eval.py`) — a process metric that complements RPS.\n",
+    "\n",
+    "Bigger ideas — press releases as forecast context (not just the evaluator), live forecasting of upcoming meetings — are in the use-case `README.md` and `planning-docs/roadmap.md`.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/implementations/boc_rate_decisions/README.md
+++ b/implementations/boc_rate_decisions/README.md
@@ -1,5 +1,7 @@
 # BoC Rate Decisions
 
+> **Reference implementation 4 of 4.** Recommended order: [getting_started](../getting_started/) → [S&P 500](../sp500_forecasting/) → [food CPI](../food_price_forecasting/) → [energy / WTI](../energy_oil_forecasting/) → **BoC rate decisions**. Each stands on its own.
+
 Predicts the **direction of the Bank of Canada's decision at the next fixed
 announcement date** — cut, hold, or hike — as a calibrated probability
 distribution issued **four weeks (28 days) before the announcement**. This
@@ -167,13 +169,15 @@ implementations/boc_rate_decisions/
 ├── press_releases.py      # PressReleaseStore: cutoff-aware press-release store + HTML extraction/caching helpers
 ├── predictors/            # (multinomial) logistic baseline; direction + binary LLMP recipes
 ├── analyst_agent/         # AgentConfig factories + prompt builder + predictor factory
+├── starter_agent/         # fresh, hackable agent template (toggleable search/code-exec + skills)
 ├── analysis.py            # score leaderboard, one-vs-rest frames, calibration bins, rationales
 ├── rationale_eval.py      # LLM-as-judge reasoning-alignment evaluator; reads Langfuse traces, pushes scores back
 ├── plots.py               # decision timeline, reliability curve, rate-path chart
 ├── specs/                 # direction + binary backtest / eval / smoke YAML
 ├── 01_boc_data_exploration.ipynb           # framing, direction derivation, cutoff walkthrough
 ├── 02_boc_rate_direction_experiment.ipynb  # binary warm-up + the 3-way experiment
-└── 03_rationale_alignment.ipynb            # reasoning-alignment evaluation (LLM-as-judge over traces)
+├── 03_rationale_alignment.ipynb            # reasoning-alignment evaluation (LLM-as-judge over traces)
+└── 99_starter_agent.ipynb                  # ← start here to build your own agent
 ```
 
 Tests live under `implementations/tests/boc_rate_decisions/` (direction and
@@ -188,6 +192,7 @@ event derivation semantics; feature leak-safety).
 | `01_boc_data_exploration.ipynb` | Problem framing (ordered decision vs time series), policy-rate history with cut/hold/hike markers, direction derivation + schedule validation, class imbalance and the climatology RPS floor (with the cumulative-Brier decomposition), cutoff discipline at a real origin. |
 | `02_boc_rate_direction_experiment.ipynb` | **Main experiment.** Binary warm-up (the copy-paste reference + RPS(K=2) ≡ Brier check), smoke/full config switch, cached backtests for all four predictors at the canonical T−28 lead, RPS leaderboard with skill scores, the T−28 vs T−1 lead-time comparison ("anticipation gap"), decision timeline (P(cut) and P(hike)), one-vs-rest reliability curves, agent-reasoning inspection, budget-gated protected eval. |
 | `03_rationale_alignment.ipynb` | **Reasoning-alignment evaluation.** Runs traced LLMP/agent forecasts, then judges each trace's `reasoning`/`key_signals` against the Bank's published press release with an LLM-as-judge (`rationale_eval.py`), pushing `rationale_alignment` (0–1) and `right_for_right_reasons` scores back to Langfuse. A *process* metric that complements RPS — most valuable exactly where backtest scores are least trustworthy (see the leakage note above). |
+| `99_starter_agent.ipynb` | **Your starter agent.** A fresh, hackable cut/hold/hike agent — *not* part of the experiment above. Toggleable news search + code execution and two lightweight tool-usage skills, with an interactive (Track 2) cell, one scored prediction (Track 1), and a "make it yours" guide. The place to start building your own. |
 
 ---
 
@@ -208,16 +213,15 @@ event derivation semantics; feature leak-safety).
 
 ### Remaining extensions — good participant projects
 
-Each has an explicit seam in the code:
+**Start in [`99_starter_agent.ipynb`](99_starter_agent.ipynb)** — it ships a
+fresh, hackable agent and a hands-on "make it yours" guide for going further.
+Two substantive projects, each with an explicit seam in the code, are
+catalogued in [`planning-docs/roadmap.md`](../../planning-docs/roadmap.md):
 
-1. **Press releases as predictor context.** Today the predictors are
-   quantitative-only (so the agent/logistic comparison stays clean), and the
-   press releases feed the *evaluator*. Feeding them into the *forecast*
-   instead is a one-seam change: inject release excerpts through
-   `CategoricalProbabilityLLMPredictorConfig.user_prompt_suffix` or swap the
-   `build_boc_news_config` retrieval instruction for press-release/MPR
-   retrieval. Measure the lift against the quantitative-only baseline.
-2. **Live forecasting.** Extend `meeting_schedule.yaml` with the Bank's
-   published future dates and forecast each announcement the day before it
-   happens — eight genuinely out-of-sample observations per year, and the
-   honest test that backtest leakage makes impossible.
+1. **Press releases as predictor context** — feed cutoff-filtered release
+   excerpts into the *forecast* (not just the evaluator) via
+   `CategoricalProbabilityLLMPredictorConfig.user_prompt_suffix` or the
+   `build_boc_news_config` retrieval seam, and measure the lift.
+2. **Live forecasting** — forecast each upcoming announcement the day before it
+   happens: genuinely out-of-sample, and the honest test backtest leakage
+   precludes.

--- a/implementations/boc_rate_decisions/starter_agent/__init__.py
+++ b/implementations/boc_rate_decisions/starter_agent/__init__.py
@@ -1,0 +1,16 @@
+"""BoC starter agent — a fresh, hackable template for your own exploration.
+
+Exports the toggle-driven :class:`AgentConfig` factory and the predictor
+convenience factory. See ``99_starter_agent.ipynb`` and ``agent.py``.
+"""
+
+from boc_rate_decisions.starter_agent.agent import (
+    build_starter_agent_config,
+    build_starter_agent_predictor,
+)
+
+
+__all__ = [
+    "build_starter_agent_config",
+    "build_starter_agent_predictor",
+]

--- a/implementations/boc_rate_decisions/starter_agent/agent.py
+++ b/implementations/boc_rate_decisions/starter_agent/agent.py
@@ -1,0 +1,232 @@
+"""BoC starter agent — a fresh, hackable template for your own exploration.
+
+This is **not** part of the notebook 01–03 curriculum. It is a clean starting
+point: the smallest agent that still has room to grow. It ships with our common
+building blocks wired behind simple toggles —
+
+- **optional news search** (``enable_search``, on by default) — bounded,
+  cutoff-aware Google Search through the Vector proxy;
+- **optional code execution** (``enable_code_exec``, off by default) — an E2B
+  Python sandbox;
+- **two lightweight skills** (:mod:`skills/`) that are *tool-usage playbooks*:
+  how to get good results out of search and code execution.
+
+Everything routes through the Vector proxy — no direct provider keys. See
+``planning-docs/vector-llm-proxy.md``.
+
+The prompt builder and output schema are reused from the
+:mod:`~boc_rate_decisions.analyst_agent` module (they are just task
+serialisation — no need to duplicate them); the *agent identity* here is fresh
+and yours to edit. The output is a calibrated distribution over
+``cut / hold / hike``. Pair this with ``99_starter_agent.ipynb``.
+
+Module-level ``__getattr__`` exposes ``root_agent`` lazily so ``adk web`` can
+load this module for interactive (schema-free) use.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+from aieng.forecasting.data.context import ForecastContext
+from aieng.forecasting.evaluation.task import ForecastingTask
+from aieng.forecasting.methods.agentic import (
+    AgentPredictor,
+    CategoricalAgentForecastOutput,
+    build_adk_agent,
+)
+from aieng.forecasting.methods.agentic.agent_factory import (
+    AgentConfig,
+    CodeExecutionConfig,
+    ContextRetrievalConfig,
+)
+from aieng.forecasting.models import LITE_MODEL
+
+# Reuse the existing BoC prompt builder — it serialises the rate path, decision
+# history, and macro snapshot into the agent's JSON payload.
+from boc_rate_decisions.analyst_agent import BoCDecisionPromptBuilder
+
+
+# Skills live next to this module.
+_SKILLS_ROOT = Path(__file__).parent / "skills"
+_FORECASTING_SKILL = _SKILLS_ROOT / "forecasting"
+_RESEARCH_SKILL = _SKILLS_ROOT / "research-playbook"
+_CODE_ANALYSIS_SKILL = _SKILLS_ROOT / "code-analysis-playbook"
+
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+
+def _build_starter_instruction() -> str:
+    """Build the task-agnostic, skill-agnostic starter persona.
+
+    Just the analyst's identity and how to behave — no output schema, no payload
+    contract, no skill or tool mechanics. ADK injects the name + description of
+    every attached skill (and every tool) into the system prompt, so the agent
+    already knows what it can load and call; repeating that here would only
+    duplicate dynamically-injected information. The forecasting *contract* lives
+    in the loadable ``forecasting`` skill. Edit the persona freely.
+    """
+    return (
+        "## Role\n\n"
+        "You are a Bank of Canada monetary-policy analyst — fluent in the "
+        "policy-rate path, the 2% CPI inflation target, labour-market and "
+        "bond-market conditions, and the Bank's institutional behaviour "
+        "(gradualism, data dependence, reluctance to surprise markets). This is "
+        "a starter agent: keep your reasoning transparent and your claims honest.\n\n"
+        "## How to respond\n\n"
+        "- For open-ended questions, scenario analysis, or anything "
+        "conversational, answer directly and concisely — do NOT ask for a JSON "
+        "payload.\n"
+        "- When you are handed a task that asks for a structured probability "
+        "distribution over the next decision, produce a calibrated one."
+    )
+
+
+_STARTER_INSTRUCTION = _build_starter_instruction()
+
+
+_CONTEXT_RETRIEVAL_INSTRUCTION = """\
+You are a Canadian monetary-policy intelligence specialist with web search.
+
+Return a concise structured markdown summary (3-5 paragraphs) covering, as the
+query warrants: recent Bank of Canada communications (statements, speeches,
+Monetary Policy Reports); Canadian CPI and core inflation vs the 2% target; the
+labour market; market pricing of the upcoming decision (OIS, economist surveys);
+and macro shocks relevant to Canada (oil, exchange rate, US policy, trade).
+
+Ground every claim in the search results you actually retrieve. When a cutoff
+date is specified, never report or speculate about events after it.\
+"""
+
+
+# ---------------------------------------------------------------------------
+# Config factory
+# ---------------------------------------------------------------------------
+
+
+def build_starter_agent_config(
+    model: str = LITE_MODEL,
+    search_model: str = LITE_MODEL,
+    *,
+    enable_search: bool = True,
+    enable_code_exec: bool = False,
+) -> AgentConfig:
+    """Build the BoC starter :class:`AgentConfig`.
+
+    Parameters
+    ----------
+    model : str
+        Model for the analyst agent (default: lite). Pass the advanced model
+        (``"gemini-3.5-flash"``) for higher-quality runs.
+    search_model : str
+        Model for the bounded web-search sub-tool.
+    enable_search : bool, default=True
+        Wire a cutoff-aware ``search_web`` tool and load the
+        ``research-playbook`` skill. Proxy-only — no extra API key. Note: news
+        grounding on historical origins carries leakage risk, so keep
+        `cutoff_date` honest.
+    enable_code_exec : bool, default=False
+        Wire an E2B Python sandbox and load the ``code-analysis-playbook``
+        skill. Needs ``E2B_API_KEY`` and is slower, so it is off by default.
+
+    Returns
+    -------
+    AgentConfig
+    """
+    # Every attached skill is loaded on demand: ADK injects each skill's name +
+    # description into the system prompt, and the agent reads the full SKILL.md
+    # only when relevant — so toggling a tool just adds its skill, no persona edits.
+    skills_dirs: list[Path] = [_FORECASTING_SKILL]
+    if enable_search:
+        skills_dirs.append(_RESEARCH_SKILL)
+    if enable_code_exec:
+        skills_dirs.append(_CODE_ANALYSIS_SKILL)
+
+    context_retrieval = (
+        ContextRetrievalConfig(
+            enabled=True,
+            instruction=_CONTEXT_RETRIEVAL_INSTRUCTION,
+            search_model=search_model,
+        )
+        if enable_search
+        else ContextRetrievalConfig()
+    )
+
+    return AgentConfig(
+        name="boc_starter_agent",
+        model=model,
+        instruction=_STARTER_INSTRUCTION,
+        # 16k headroom: enough for a complete run_code script + structured output.
+        max_output_tokens=16_384 if enable_code_exec else None,
+        context_retrieval=context_retrieval,
+        code_execution=CodeExecutionConfig(enabled=enable_code_exec),
+        skills_dirs=skills_dirs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Predictor convenience factory
+# ---------------------------------------------------------------------------
+
+
+class _StarterForecastPromptBuilder:
+    """Add the output schema + a forecast directive to a base builder's payload.
+
+    The exact JSON schema is generated at call time from the output class
+    (drift-free) and injected into the user payload — never into the system
+    prompt — so the agent stays conversational until it is actually asked to
+    forecast. Implements the
+    :class:`~aieng.forecasting.methods.agentic.predictor.ForecastPromptBuilder`
+    protocol structurally.
+    """
+
+    def __init__(self, inner: Callable[..., str], output_schema_json: str) -> None:
+        self._inner = inner
+        self._schema_json = output_schema_json
+
+    def __call__(self, *, task: ForecastingTask, context: ForecastContext) -> str:
+        payload = json.loads(self._inner(task=task, context=context))
+        payload["instructions"] = (
+            "Produce a calibrated probability distribution for this decision and return "
+            "it by calling `set_model_response` with a `json_response` string matching "
+            "`output_schema` exactly."
+        )
+        payload["output_schema"] = self._schema_json
+        return json.dumps(payload, indent=2)
+
+
+def build_starter_agent_predictor(config: AgentConfig) -> AgentPredictor:
+    """Wrap a starter :class:`AgentConfig` in an :class:`AgentPredictor`.
+
+    Reuses :class:`~boc_rate_decisions.analyst_agent.BoCDecisionPromptBuilder`
+    for data serialisation, wrapped so the (drift-free) categorical output schema
+    and a forecast directive ride in the payload — keeping the schema out of the
+    persona. ``predict(task, context)`` returns one
+    :class:`~aieng.forecasting.evaluation.prediction.Prediction` carrying the
+    cut/hold/hike distribution.
+    """
+    return AgentPredictor(
+        agent_config=config,
+        prompt_builder=_StarterForecastPromptBuilder(
+            BoCDecisionPromptBuilder(),
+            CategoricalAgentForecastOutput.prompt_schema_json(labels=["cut", "hold", "hike"]),
+        ),
+        output_schema=CategoricalAgentForecastOutput,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lazy root_agent for `adk web` interactive use
+# ---------------------------------------------------------------------------
+
+
+def __getattr__(name: str) -> Any:
+    """Expose ``root_agent`` lazily for schema-free interactive use via ``adk web``."""
+    if name == "root_agent":
+        return build_adk_agent(build_starter_agent_config())
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/implementations/boc_rate_decisions/starter_agent/skills/code-analysis-playbook/SKILL.md
+++ b/implementations/boc_rate_decisions/starter_agent/skills/code-analysis-playbook/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: code-analysis-playbook
+description: >-
+  How to use the code execution sandbox well — parse the JSON payload (not
+  disk files), compute a couple of useful diagnostics before forecasting, and
+  keep the session stateful within a turn. Load this before writing code. No
+  scripts.
+---
+
+# Code-analysis playbook
+
+A short guide to using the `run_code` sandbox productively. This is a starter
+skill — extend it with the diagnostics that matter for your problem.
+
+## Where your data lives
+
+All data comes from the **JSON payload in your context** — there are no disk
+files and no network. The history arrives as a CSV *string* (e.g.
+`target_history_csv`). Parse it with `io.StringIO`, never as a file path:
+
+```python
+import io, pandas as pd
+df = pd.read_csv(io.StringIO(payload["target_history_csv"]))
+```
+
+The sandbox is **stateful within a turn**: parse once in your first code block,
+then reuse the DataFrame in later blocks instead of re-parsing.
+
+## Compute before you forecast
+
+Run a couple of cheap diagnostics so your forecast is grounded in arithmetic,
+not vibes:
+
+1. **Recent trend** — slope/return over the last N observations.
+2. **Volatility** — recent standard deviation of changes; it sets how wide your
+   quantile bands should be.
+3. **Sanity check** — does your point forecast sit within a plausible multiple
+   of recent moves? If not, revisit it.
+
+Use the printed numbers to set the point forecast and to *calibrate the spread*
+between your low and high quantiles — wider when recent volatility is high.
+
+## Domain focus (edit this for your use case)
+
+For a BoC rate decision your payload is categorical: it carries the policy-rate
+change points, the per-outcome base rates, and a macro snapshot — not a price
+CSV, so adapt the parsing above to those fields. Useful diagnostics: recompute
+the empirical base rates, measure how far the current macro snapshot sits from
+typical pre-cut vs pre-hold conditions, and count how often the Bank reversed
+direction between adjacent meetings.
+
+## Room to grow
+
+- Add your own diagnostic patterns (regime detection, seasonality, covariates).
+- Drop reusable reference values into a `references/` file and `load_skill_resource` them.

--- a/implementations/boc_rate_decisions/starter_agent/skills/forecasting/SKILL.md
+++ b/implementations/boc_rate_decisions/starter_agent/skills/forecasting/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: forecasting
+description: >-
+  The output contract for producing a structured probability distribution over
+  the rate decision (cut / hold / hike) — the JSON shape, the calibration rules,
+  and how to submit it. Load this ONLY when your task payload asks for a
+  forecast; ignore it for open-ended questions. No scripts.
+---
+
+# Forecasting skill
+
+Load this when your task payload asks for a structured forecast. For open-ended
+questions, ignore it and just answer.
+
+## What you'll receive
+
+A JSON payload describing the task: the `task` and `as_of` cutoff date, the
+`announcement_date` being predicted, the `policy_rate` path, `meeting_outcomes`
+(decision history + historical base rates), a `macro_snapshot`, and an
+`output_schema` showing the exact JSON to return.
+
+## The output contract
+
+1. Assign one probability to each of **`cut`, `hold`, `hike`**; the three must
+   **sum to 1**.
+2. Report **calibrated** probabilities — across many decisions where you say
+   0.7, that outcome should occur about 70% of the time.
+3. Anchor on the **historical base rates**, then adjust for the macro snapshot
+   and recent decisions. Direct cut→hike reversals between adjacent meetings
+   essentially never happen, so recent history shapes which tail is plausible.
+4. Use ONLY information available on or before `as_of`.
+5. Put your reasoning in `reasoning` and the decisive inputs in `key_signals`.
+
+Submit by calling `set_model_response` with a `json_response` string that
+matches the payload's `output_schema` **exactly**. Omit any field not shown.
+
+## Domain focus (edit this for your use case)
+
+The 2-year GoC yield trading well below the policy rate means the bond market is
+pricing cuts; well above means hikes. CPI relative to the 2% target and
+labour-market momentum tell you whether you are in an easing or tightening
+cycle. Weigh those against the Bank's gradualism and reluctance to surprise
+markets.
+
+## Room to grow
+
+- Add your own calibration notes from the backtest leaderboard.
+- Encode any decision rules you trust (e.g. how much a soft CPI print moves P(cut)).

--- a/implementations/boc_rate_decisions/starter_agent/skills/research-playbook/SKILL.md
+++ b/implementations/boc_rate_decisions/starter_agent/skills/research-playbook/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: research-playbook
+description: >-
+  How to use the search_web tool well when grounding a forecast in recent
+  news — phrase cutoff-aware queries, decide what is worth searching for, and
+  weigh sources. Load this before your first search_web call. No scripts.
+---
+
+# Research playbook
+
+A short guide to getting real signal out of `search_web`. This is a starter
+skill — extend it with the queries and sources that work for your problem.
+
+## The one rule that matters
+
+Always pass `cutoff_date` equal to the `as_of` date in your payload. It is the
+temporal fence that keeps post-origin information out of a historical forecast.
+A forecast that "knew" what happened after `as_of` is not a forecast.
+
+## How to search
+
+- **Search before you forecast, not after.** Gather context first, then reason.
+- **One topic per query.** Several focused queries beat one broad one. Stop when
+  new queries stop returning new facts.
+- **Ask for the present state, not a prediction.** "current OPEC+ production
+  policy" returns facts; "will oil go up" returns noise.
+- **Weigh sources.** Prefer primary releases and major outlets; treat a single
+  blog or forum post as a lead to confirm, not a fact.
+
+## Domain focus (edit this for your use case)
+
+For a Bank of Canada rate decision, the signals that move the odds: recent CPI
+and core-inflation prints vs the 2% target, the labour market (employment,
+unemployment, wages), market pricing (overnight index swaps, economist surveys),
+recent BoC communications, and macro shocks (oil, the loonie, US policy, trade).
+Search for the *current state* of these, then let the base rates set the prior.
+
+## Room to grow
+
+- Add a curated list of go-to sources for your domain.
+- Track which queries paid off and prune the ones that didn't.
+- Add a `references/` file with example high-signal searches.

--- a/implementations/energy_oil_forecasting/99_starter_agent.ipynb
+++ b/implementations/energy_oil_forecasting/99_starter_agent.ipynb
@@ -1,0 +1,232 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {},
+   "source": [
+    "# WTI Crude Oil — Your Starter Agent\n",
+    "\n",
+    "**If you're not sure what to do next, continue from here.**\n",
+    "\n",
+    "This notebook is a fresh, hackable agent for the WTI crude-oil use case — deliberately *not* wired into the numbered curriculum. It gives you our common building blocks behind simple toggles, so you can start building something of your own:\n",
+    "\n",
+    "- **optional news search** — bounded, cutoff-aware Google Search (proxy-only)\n",
+    "- **optional code execution** — an E2B Python sandbox\n",
+    "- **two lightweight skills** — *tool-usage playbooks* in `starter_agent/skills/`\n",
+    "\n",
+    "It does two things: lets you **talk to the agent** (open-ended, Track 2) and **score one real forecast** (Track 1). The live cells are gated by `RUN_AGENT` so a fresh `Run All` is safe and free; flip it to `True` to actually call the model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "from pathlib import Path\n",
+    "\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "\n",
+    "# Repo root holds the .env with PROXY_* creds the agent needs.\n",
+    "ROOT = Path.cwd().resolve().parents[1]\n",
+    "load_dotenv(ROOT / \".env\")\n",
+    "\n",
+    "# ── Model selection ───────────────────────────────────\n",
+    "# Two project models: \"gemini-3.1-flash-lite-preview\" (lite/default) and\n",
+    "# \"gemini-3.5-flash\" (advanced). Lite is the default.\n",
+    "AGENT_MODEL = \"gemini-3.1-flash-lite-preview\"\n",
+    "# AGENT_MODEL = \"gemini-3.5-flash\"  # advanced (higher cost/latency)\n",
+    "\n",
+    "# ── Run guard ──────────────────────────────────────\n",
+    "# Live agent calls cost tokens and need PROXY_* in the repo-root .env, plus warm\n",
+    "# data caches. Default False so `Run All` is safe; set True to call the model.\n",
+    "RUN_AGENT = False\n",
+    "\n",
+    "from energy_oil_forecasting.starter_agent import (\n",
+    "    build_starter_agent_config,\n",
+    "    build_starter_agent_predictor,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "print(\"RUN_AGENT =\", RUN_AGENT, \"| model =\", AGENT_MODEL)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-02",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 1. Meet your agent\n",
+    "\n",
+    "`build_starter_agent_config` returns an `AgentConfig` with two toggles. The default turns **news search on** (proxy-only, no extra key) and **code execution off** (it needs `E2B_API_KEY` and is slower). Flip them and re-run — the loaded skills follow the enabled tools.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = build_starter_agent_config(\n",
+    "    model=AGENT_MODEL,\n",
+    "    enable_search=True,  # ← cutoff-aware Google Search (proxy-only)\n",
+    "    enable_code_exec=False,  # ← E2B Python sandbox (needs E2B_API_KEY); try True!\n",
+    ")\n",
+    "\n",
+    "print(\"Agent:\", config.name)\n",
+    "print(\"Search enabled:    \", config.context_retrieval.enabled)\n",
+    "print(\"Code-exec enabled: \", config.code_execution.enabled)\n",
+    "print(\"Skills loaded:     \", [p.name for p in config.skills_dirs])\n",
+    "print(\"\\n── System instruction (edit this in starter_agent/agent.py) ──\\n\")\n",
+    "print(config.instruction[:1200], \"...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-04",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2. Talk to it  *(Track 2 — open-ended analysis)*\n",
+    "\n",
+    "Ask the agent anything. This is the interactive mode: no scoring, no schema — just reasoning (and a web search, since search is on). Edit the question and explore.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from aieng.forecasting.methods.agentic import build_adk_agent\n",
+    "from aieng.forecasting.methods.agentic.adk_runner import AdkTextRunner, AdkTextRunnerConfig\n",
+    "\n",
+    "\n",
+    "QUESTION = (\n",
+    "    \"What are the two or three forces most likely to move WTI crude over the \"\n",
+    "    \"next month, and which direction does each push? Be concise.\"\n",
+    ")\n",
+    "\n",
+    "if RUN_AGENT:\n",
+    "    chat_agent = build_adk_agent(config)  # schema-free: plain text in, text out\n",
+    "    runner = AdkTextRunner(chat_agent, config=AdkTextRunnerConfig(app_name=\"wti_starter_chat\"))\n",
+    "    reply = await runner.run_text_async(QUESTION)  # noqa: F704, PLE1142\n",
+    "    print(reply)\n",
+    "else:\n",
+    "    print(\"RUN_AGENT is False — set it to True in the setup cell to talk to the agent.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-06",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 3. Score one prediction against known outcomes  *(Track 1)*\n",
+    "\n",
+    "Now run the agent as a `Predictor`. We pick the **most recent origin whose horizons have already resolved**, forecast it, and check whether each actual price landed inside the agent's 80% band — so you can see whether it was any good. (One origin can't tell you if the agent is *calibrated*; that's what the backtest in `04_systematic_backtest_eval.ipynb` is for.) Live, so gated by `RUN_AGENT`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if RUN_AGENT:\n",
+    "    from aieng.forecasting.evaluation.task import ForecastingTask\n",
+    "    from energy_oil_forecasting.data import WTI_SERIES_ID, build_wti_service, naive_utc_now\n",
+    "\n",
+    "    svc = build_wti_service()\n",
+    "    full = svc.get_series(WTI_SERIES_ID, as_of=naive_utc_now())\n",
+    "    full[\"timestamp\"] = pd.to_datetime(full[\"timestamp\"])\n",
+    "    last_date = full[\"timestamp\"].iloc[-1]\n",
+    "\n",
+    "    HORIZONS = [5, 10, 21]\n",
+    "    # Most recent origin whose longest horizon has already resolved.\n",
+    "    AS_OF = last_date - pd.offsets.BDay(max(HORIZONS) + 1)\n",
+    "\n",
+    "    task = ForecastingTask(\n",
+    "        task_id=\"wti_starter_forecast\",\n",
+    "        target_series_id=WTI_SERIES_ID,\n",
+    "        horizons=HORIZONS,\n",
+    "        frequency=\"B\",\n",
+    "        description=\"WTI front-month futures — 5/10/21 business days ahead (starter).\",\n",
+    "    )\n",
+    "    ctx = svc.context(as_of=AS_OF)\n",
+    "    preds = build_starter_agent_predictor(config).predict(task, ctx)\n",
+    "\n",
+    "    def realized_at(h):\n",
+    "        rows = full[full[\"timestamp\"] >= AS_OF + pd.offsets.BDay(h)]\n",
+    "        return float(rows[\"value\"].iloc[0]) if not rows.empty else None\n",
+    "\n",
+    "    print(f\"Origin as_of={AS_OF.date()}  (latest data {last_date.date()})\\n\")\n",
+    "    print(\"   h    agent point   agent 80% CI           actual   in band?\")\n",
+    "    for i, h in enumerate(HORIZONS):\n",
+    "        fc = preds[i].payload\n",
+    "        lo, hi = fc.quantiles[0.10], fc.quantiles[0.90]\n",
+    "        act = realized_at(h)\n",
+    "        inb = \"—\" if act is None else (\"yes ✓\" if lo <= act <= hi else \"no ✗\")\n",
+    "        acts = \"  N/A\" if act is None else f\"${act:7.2f}\"\n",
+    "        print(f\"  {h:>2}d   ${fc.point_forecast:7.2f}   [${lo:6.2f}, ${hi:6.2f}]   {acts}   {inb}\")\n",
+    "    if preds[0].metadata.get(\"rationale\"):\n",
+    "        print(\"\\nRationale:\", preds[0].metadata[\"rationale\"][:300])\n",
+    "else:\n",
+    "    print(\"RUN_AGENT is False — set it to True to score a live forecast against known outcomes.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-08",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 4. Make it yours\n",
+    "\n",
+    "This agent is a starting point. Here are concrete next steps, easiest first — each is a small edit, then re-run the cells above.\n",
+    "\n",
+    "1. **Flip code execution on.** Set `enable_code_exec=True` in §1 (needs `E2B_API_KEY`). The agent loads the `code-analysis-playbook` skill and can compute its own diagnostics before forecasting. Compare the rationale.\n",
+    "2. **Edit the agent's personality.** Open `starter_agent/agent.py` and change `_build_starter_instruction()` — make it more cautious, more contrarian, focused on one driver. Re-run §1 to see the new instruction.\n",
+    "3. **Sharpen the skills.** The two files in `starter_agent/skills/` are short on purpose. Add your best queries to `research-playbook`, or a new diagnostic to `code-analysis-playbook`. The agent picks them up automatically.\n",
+    "4. **Change the question and the origin.** Try a different `QUESTION` in §2 and a different origin in §3.\n",
+    "5. **Add a tool.** Give the agent a conventional forecast tool as a statistical anchor — see `analyst_agent.build_wti_tool_config` for the `ForecastTool` pattern.\n",
+    "6. **Score it properly.** Run it across several origins with `backtest()` (see `04_systematic_backtest_eval.ipynb`) and compare CRPS against the baselines.\n",
+    "\n",
+    "Bigger ideas — an agent that *learns* a strategy (notebooks 05–06), news vs. no-news lift, live prospective forecasting — are in the use-case `README.md` and `planning-docs/roadmap.md`.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/implementations/energy_oil_forecasting/README.md
+++ b/implementations/energy_oil_forecasting/README.md
@@ -1,5 +1,7 @@
 # WTI Crude Oil Price Forecasting
 
+> **Reference implementation 3 of 4.** Recommended order: [getting_started](../getting_started/) → [S&P 500](../sp500_forecasting/) → [food CPI](../food_price_forecasting/) → **energy / WTI** → [BoC rate decisions](../boc_rate_decisions/). Each stands on its own.
+
 The **high-frequency, context-driven** reference implementation. Unlike long-horizon annual CPI forecasting, the daily resolution of oil markets makes genuinely prospective, real-time evaluation practical: you can lock an agent configuration today and measure its accuracy on unresolved horizons within weeks.
 
 WTI Crude Oil is highly liquid and sensitive to geopolitical risk, macroeconomic policy, and supply disruptions. This implementation works through a progression of forecasting approaches:
@@ -40,6 +42,12 @@ introduced in notebook 2.
 | Notebook | Focus | Agents? |
 |----------|-------|---------|
 | **[`05_forecast_tool_demo.ipynb`](05_forecast_tool_demo.ipynb)** | **The Forecast Tool** — a standalone demo (not part of the main sequence) of a conventional AutoARIMA function tool (`build_wti_tool_config`) as a controlled, auditable alternative to open-ended code execution | Yes |
+
+### Build your own
+
+| Notebook | Focus | Agents? |
+|----------|-------|---------|
+| **[`99_starter_agent.ipynb`](99_starter_agent.ipynb)** | **Your starter agent** — a fresh, hackable WTI agent (*not* part of the curriculum) with toggleable news search + code execution and two lightweight tool-usage skills. Interactive (Track 2) cell, one scored prediction (Track 1), and a "make it yours" guide. **If you're not sure what to do next, start here.** | Yes |
 
 An earlier set of information-session notebooks is archived in [`playground/energy_case_study/`](../../playground/energy_case_study/); the notebooks here are the maintained reference.
 
@@ -82,8 +90,9 @@ implementations/energy_oil_forecasting/
 ├── tasks.py                # task specs, multitask prompt builders
 ├── analyst_agent/          # stateless AgentConfig factories (agent identity only)
 ├── adaptive_agent/         # the learning agent: strategy state, mutation tools, curriculum, seed/trained skills
+├── starter_agent/          # fresh, hackable agent template (toggleable search/code-exec + skills)
 ├── specs/                  # YAML backtest + eval specs
-└── 01–06 notebooks (+ 05_forecast_tool_demo side demo)
+└── 01–06 notebooks (+ 05_forecast_tool_demo side demo, 99_starter_agent build-your-own)
 ```
 
 `adaptive_agent/` holds `agent.py` (the adaptive `AgentConfig` + predictor factory),

--- a/implementations/energy_oil_forecasting/starter_agent/__init__.py
+++ b/implementations/energy_oil_forecasting/starter_agent/__init__.py
@@ -1,0 +1,16 @@
+"""WTI starter agent — a fresh, hackable template for your own exploration.
+
+Exports the toggle-driven :class:`AgentConfig` factory and the predictor
+convenience factory. See ``99_starter_agent.ipynb`` and ``agent.py``.
+"""
+
+from energy_oil_forecasting.starter_agent.agent import (
+    build_starter_agent_config,
+    build_starter_agent_predictor,
+)
+
+
+__all__ = [
+    "build_starter_agent_config",
+    "build_starter_agent_predictor",
+]

--- a/implementations/energy_oil_forecasting/starter_agent/agent.py
+++ b/implementations/energy_oil_forecasting/starter_agent/agent.py
@@ -1,0 +1,227 @@
+"""WTI starter agent — a fresh, hackable template for your own exploration.
+
+This is **not** part of the notebook 01–06 curriculum. It is a clean starting
+point: the smallest agent that still has room to grow. It ships with our common
+building blocks wired behind simple toggles —
+
+- **optional news search** (``enable_search``, on by default) — bounded,
+  cutoff-aware Google Search through the Vector proxy;
+- **optional code execution** (``enable_code_exec``, off by default) — an E2B
+  Python sandbox;
+- **two lightweight skills** (:mod:`skills/`) that are *tool-usage playbooks*:
+  how to get good results out of search and code execution.
+
+Everything routes through the Vector proxy — no direct provider keys. See
+``planning-docs/vector-llm-proxy.md``.
+
+The prompt builder and output schema are reused from the
+:mod:`~energy_oil_forecasting.analyst_agent` module (they are just task
+serialisation — no need to duplicate them); the *agent identity* here is fresh
+and yours to edit. Pair this with ``99_starter_agent.ipynb``.
+
+Module-level ``__getattr__`` exposes ``root_agent`` lazily so ``adk web`` can
+load this module for interactive (schema-free) use.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+from aieng.forecasting.data.context import ForecastContext
+from aieng.forecasting.evaluation.task import ForecastingTask
+from aieng.forecasting.methods.agentic import (
+    AgentPredictor,
+    ContinuousAgentForecastOutput,
+    build_adk_agent,
+)
+from aieng.forecasting.methods.agentic.agent_factory import (
+    AgentConfig,
+    CodeExecutionConfig,
+    ContextRetrievalConfig,
+)
+from aieng.forecasting.models import LITE_MODEL
+
+# Reuse the existing WTI prompt builder + history compression — these serialise
+# the task/context into the agent's JSON payload and are not worth duplicating.
+from energy_oil_forecasting.analyst_agent import WtiPriceForecastPromptBuilder
+
+
+# Skills live next to this module.
+_SKILLS_ROOT = Path(__file__).parent / "skills"
+_FORECASTING_SKILL = _SKILLS_ROOT / "forecasting"
+_RESEARCH_SKILL = _SKILLS_ROOT / "research-playbook"
+_CODE_ANALYSIS_SKILL = _SKILLS_ROOT / "code-analysis-playbook"
+
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+
+def _build_starter_instruction() -> str:
+    """Build the task-agnostic, skill-agnostic starter persona.
+
+    Just the analyst's identity and how to behave — no output schema, no payload
+    contract, no skill or tool mechanics. ADK injects the name + description of
+    every attached skill (and every tool) into the system prompt, so the agent
+    already knows what it can load and call; repeating that here would only
+    duplicate dynamically-injected information. The forecasting *contract* lives
+    in the loadable ``forecasting`` skill. Edit the persona freely.
+    """
+    return (
+        "## Role\n\n"
+        "You are a WTI crude oil market analyst — fluent in supply/demand "
+        "fundamentals, OPEC+ policy, geopolitical and shipping-lane risk, and "
+        "price dynamics. This is a starter agent: keep your reasoning "
+        "transparent and your claims honest.\n\n"
+        "## How to respond\n\n"
+        "- For open-ended questions, scenario analysis, or anything "
+        "conversational, answer directly and concisely — do NOT ask for a JSON "
+        "payload.\n"
+        "- When you are handed a task that asks for a structured probabilistic "
+        "forecast, produce a calibrated one."
+    )
+
+
+_STARTER_INSTRUCTION = _build_starter_instruction()
+
+
+_CONTEXT_RETRIEVAL_INSTRUCTION = """\
+You are an oil-market intelligence specialist with web search.
+
+Return a concise structured markdown summary (3-5 paragraphs) covering, as the
+query warrants: WTI/Brent price level and trend; OPEC+ supply decisions;
+geopolitical risk in the Persian Gulf and key shipping lanes; US SPR / energy
+policy; notable supply-disruption signals; and published analyst price targets.
+
+Ground every claim in the search results you actually retrieve. When a cutoff
+date is specified, never report or speculate about events after it.\
+"""
+
+
+# ---------------------------------------------------------------------------
+# Config factory
+# ---------------------------------------------------------------------------
+
+
+def build_starter_agent_config(
+    model: str = LITE_MODEL,
+    search_model: str = LITE_MODEL,
+    *,
+    enable_search: bool = True,
+    enable_code_exec: bool = False,
+) -> AgentConfig:
+    """Build the WTI starter :class:`AgentConfig`.
+
+    Parameters
+    ----------
+    model : str
+        Model for the analyst agent (default: lite). Pass the advanced model
+        (``"gemini-3.5-flash"``) for higher-quality runs.
+    search_model : str
+        Model for the bounded web-search sub-tool.
+    enable_search : bool, default=True
+        Wire a cutoff-aware ``search_web`` tool and load the
+        ``research-playbook`` skill. Proxy-only — no extra API key.
+    enable_code_exec : bool, default=False
+        Wire an E2B Python sandbox and load the ``code-analysis-playbook``
+        skill. Needs ``E2B_API_KEY`` and is slower, so it is off by default —
+        flip it on to let the agent compute its own diagnostics.
+
+    Returns
+    -------
+    AgentConfig
+    """
+    # Every attached skill is loaded on demand: ADK injects each skill's name +
+    # description into the system prompt, and the agent reads the full SKILL.md
+    # only when relevant — so toggling a tool just adds its skill, no persona edits.
+    skills_dirs: list[Path] = [_FORECASTING_SKILL]
+    if enable_search:
+        skills_dirs.append(_RESEARCH_SKILL)
+    if enable_code_exec:
+        skills_dirs.append(_CODE_ANALYSIS_SKILL)
+
+    context_retrieval = (
+        ContextRetrievalConfig(
+            enabled=True,
+            instruction=_CONTEXT_RETRIEVAL_INSTRUCTION,
+            search_model=search_model,
+        )
+        if enable_search
+        else ContextRetrievalConfig()
+    )
+
+    return AgentConfig(
+        name="wti_starter_agent",
+        model=model,
+        instruction=_STARTER_INSTRUCTION,
+        # 16k headroom: enough for a complete run_code script + structured output.
+        max_output_tokens=16_384 if enable_code_exec else None,
+        context_retrieval=context_retrieval,
+        code_execution=CodeExecutionConfig(enabled=enable_code_exec),
+        skills_dirs=skills_dirs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Predictor convenience factory
+# ---------------------------------------------------------------------------
+
+
+class _StarterForecastPromptBuilder:
+    """Add the output schema + a forecast directive to a base builder's payload.
+
+    The exact JSON schema is generated at call time from the output class
+    (drift-free) and injected into the user payload — never into the system
+    prompt — so the agent stays conversational until it is actually asked to
+    forecast. Implements the
+    :class:`~aieng.forecasting.methods.agentic.predictor.ForecastPromptBuilder`
+    protocol structurally.
+    """
+
+    def __init__(self, inner: Callable[..., str], output_schema_json: str) -> None:
+        self._inner = inner
+        self._schema_json = output_schema_json
+
+    def __call__(self, *, task: ForecastingTask, context: ForecastContext) -> str:
+        payload = json.loads(self._inner(task=task, context=context))
+        payload["instructions"] = (
+            "Produce a calibrated probabilistic forecast for this task and return it by "
+            "calling `set_model_response` with a `json_response` string matching "
+            "`output_schema` exactly."
+        )
+        payload["output_schema"] = self._schema_json
+        return json.dumps(payload, indent=2)
+
+
+def build_starter_agent_predictor(config: AgentConfig) -> AgentPredictor:
+    """Wrap a starter :class:`AgentConfig` in an :class:`AgentPredictor`.
+
+    Reuses :class:`~energy_oil_forecasting.analyst_agent.WtiPriceForecastPromptBuilder`
+    for data serialisation, wrapped so the (drift-free) continuous output schema
+    and a forecast directive ride in the payload — keeping the schema out of the
+    persona. ``predict(task, context)`` returns one
+    :class:`~aieng.forecasting.evaluation.prediction.Prediction` per horizon.
+    """
+    return AgentPredictor(
+        agent_config=config,
+        prompt_builder=_StarterForecastPromptBuilder(
+            WtiPriceForecastPromptBuilder(),
+            ContinuousAgentForecastOutput.prompt_schema_json(),
+        ),
+        output_schema=ContinuousAgentForecastOutput,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lazy root_agent for `adk web` interactive use
+# ---------------------------------------------------------------------------
+
+
+def __getattr__(name: str) -> Any:
+    """Expose ``root_agent`` lazily for schema-free interactive use via ``adk web``."""
+    if name == "root_agent":
+        return build_adk_agent(build_starter_agent_config())
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/implementations/energy_oil_forecasting/starter_agent/skills/code-analysis-playbook/SKILL.md
+++ b/implementations/energy_oil_forecasting/starter_agent/skills/code-analysis-playbook/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: code-analysis-playbook
+description: >-
+  How to use the code execution sandbox well — parse the JSON payload (not
+  disk files), compute a couple of useful diagnostics before forecasting, and
+  keep the session stateful within a turn. Load this before writing code. No
+  scripts.
+---
+
+# Code-analysis playbook
+
+A short guide to using the `run_code` sandbox productively. This is a starter
+skill — extend it with the diagnostics that matter for your problem.
+
+## Where your data lives
+
+All data comes from the **JSON payload in your context** — there are no disk
+files and no network. The history arrives as a CSV *string* (e.g.
+`target_history_csv`). Parse it with `io.StringIO`, never as a file path:
+
+```python
+import io, pandas as pd
+df = pd.read_csv(io.StringIO(payload["target_history_csv"]))
+```
+
+The sandbox is **stateful within a turn**: parse once in your first code block,
+then reuse the DataFrame in later blocks instead of re-parsing.
+
+## Compute before you forecast
+
+Run a couple of cheap diagnostics so your forecast is grounded in arithmetic,
+not vibes:
+
+1. **Recent trend** — slope/return over the last N observations.
+2. **Volatility** — recent standard deviation of changes; it sets how wide your
+   quantile bands should be.
+3. **Sanity check** — does your point forecast sit within a plausible multiple
+   of recent moves? If not, revisit it.
+
+Use the printed numbers to set the point forecast and to *calibrate the spread*
+between your low and high quantiles — wider when recent volatility is high.
+
+## Domain focus (edit this for your use case)
+
+For WTI crude, daily moves are usually within a few percent; multi-day moves
+fan out roughly with the square root of the horizon. Let recent realised
+volatility, not a fixed guess, set your interval widths.
+
+## Room to grow
+
+- Add your own diagnostic patterns (regime detection, seasonality, covariates).
+- Drop reusable reference values into a `references/` file and `load_skill_resource` them.

--- a/implementations/energy_oil_forecasting/starter_agent/skills/forecasting/SKILL.md
+++ b/implementations/energy_oil_forecasting/starter_agent/skills/forecasting/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: forecasting
+description: >-
+  The output contract for producing a structured probabilistic forecast — the
+  JSON shape, the calibration and quantile rules, and how to submit it. Load
+  this ONLY when your task payload asks for a forecast; ignore it for
+  open-ended questions. No scripts.
+---
+
+# Forecasting skill
+
+Load this when your task payload asks for a structured forecast. For open-ended
+questions, ignore it and just answer.
+
+## What you'll receive
+
+A JSON payload describing the task: a `task` id, the `as_of` cutoff date,
+`horizons` (steps ahead), the `standard_quantiles` grid, a `target_summary`, the
+recent `target_history_csv`, and an `output_schema` showing the exact JSON to
+return.
+
+## The output contract
+
+1. Produce **one forecast per horizon** in `horizons`.
+2. Use **exactly** the levels in `standard_quantiles` — no additions or omissions.
+3. `point_forecast` must equal the **0.50 quantile** value.
+4. Quantile values must be **non-decreasing** as the quantile level rises.
+5. Use ONLY information available on or before `as_of`.
+6. Put your reasoning in the `rationale` fields.
+
+Submit by calling `set_model_response` with a `json_response` string that
+matches the payload's `output_schema` **exactly** — use `"horizon"` (an
+integer), and make `"quantiles"` a **list** of `{"quantile": <level>, "value":
+<number>}` objects. Omit any field not shown in the schema.
+
+## Calibration
+
+Report calibrated intervals, not false precision: across many forecasts where
+your 80% band is stated, the truth should land inside it about 80% of the time.
+Anchor the point on the recent level and trend; let recent **volatility** set
+how wide the bands are, and widen them as the horizon grows.
+
+## Domain focus (edit this for your use case)
+
+For WTI crude, anchor on the last close and recent daily moves (usually a few
+percent); multi-day uncertainty fans out roughly with the square root of the
+horizon. Adjust the point for OPEC+/​supply or geopolitical signals you have
+real evidence for — and say so in the rationale.
+
+## Room to grow
+
+- Tighten the calibration guidance with your own backtest findings.
+- Add worked examples of good vs. over-confident forecasts.

--- a/implementations/energy_oil_forecasting/starter_agent/skills/research-playbook/SKILL.md
+++ b/implementations/energy_oil_forecasting/starter_agent/skills/research-playbook/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: research-playbook
+description: >-
+  How to use the search_web tool well when grounding a forecast in recent
+  news — phrase cutoff-aware queries, decide what is worth searching for, and
+  weigh sources. Load this before your first search_web call. No scripts.
+---
+
+# Research playbook
+
+A short guide to getting real signal out of `search_web`. This is a starter
+skill — extend it with the queries and sources that work for your problem.
+
+## The one rule that matters
+
+Always pass `cutoff_date` equal to the `as_of` date in your payload. It is the
+temporal fence that keeps post-origin information out of a historical forecast.
+A forecast that "knew" what happened after `as_of` is not a forecast.
+
+## How to search
+
+- **Search before you forecast, not after.** Gather context first, then reason.
+- **One topic per query.** Several focused queries beat one broad one. Stop when
+  new queries stop returning new facts.
+- **Ask for the present state, not a prediction.** "current OPEC+ production
+  policy" returns facts; "will oil go up" returns noise.
+- **Weigh sources.** Prefer primary releases and major outlets; treat a single
+  blog or forum post as a lead to confirm, not a fact.
+
+## Domain focus (edit this for your use case)
+
+For WTI crude, the signals that move price: OPEC+ supply decisions, Persian
+Gulf / shipping-lane geopolitical risk, US SPR and inventory data, USD strength,
+and global demand outlook. Search for the *current state* of these, then let the
+price history tell you the baseline.
+
+## Room to grow
+
+- Add a curated list of go-to sources for your domain.
+- Track which queries paid off and prune the ones that didn't.
+- Add a `references/` file with example high-signal searches.

--- a/implementations/food_price_forecasting/99_starter_agent.ipynb
+++ b/implementations/food_price_forecasting/99_starter_agent.ipynb
@@ -1,0 +1,237 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {},
+   "source": [
+    "# Food Price (CPI) — Your Starter Agent\n",
+    "\n",
+    "**If you're not sure what to do next, continue from here.**\n",
+    "\n",
+    "This notebook is a fresh, hackable agent for the Canadian food-CPI use case — deliberately *not* wired into the numbered curriculum. It gives you our common building blocks behind simple toggles, so you can start building something of your own:\n",
+    "\n",
+    "- **optional news search** — bounded, cutoff-aware Google Search (proxy-only)\n",
+    "- **optional code execution** — an E2B Python sandbox\n",
+    "- **two lightweight skills** — *tool-usage playbooks* in `starter_agent/skills/`\n",
+    "\n",
+    "It does two things: lets you **talk to the agent** (open-ended, Track 2) and **score one real forecast** (Track 1). The live cells are gated by `RUN_AGENT` so a fresh `Run All` is safe and free; flip it to `True` to actually call the model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "from pathlib import Path\n",
+    "\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "\n",
+    "# Repo root holds the .env with PROXY_* creds the agent needs.\n",
+    "ROOT = Path.cwd().resolve().parents[1]\n",
+    "load_dotenv(ROOT / \".env\")\n",
+    "\n",
+    "# ── Model selection ───────────────────────────────────\n",
+    "# Two project models: \"gemini-3.1-flash-lite-preview\" (lite/default) and\n",
+    "# \"gemini-3.5-flash\" (advanced). Lite is the default.\n",
+    "AGENT_MODEL = \"gemini-3.1-flash-lite-preview\"\n",
+    "# AGENT_MODEL = \"gemini-3.5-flash\"  # advanced (higher cost/latency)\n",
+    "\n",
+    "# ── Run guard ──────────────────────────────────────\n",
+    "# Live agent calls cost tokens and need PROXY_* in the repo-root .env, plus warm\n",
+    "# data caches. Default False so `Run All` is safe; set True to call the model.\n",
+    "RUN_AGENT = False\n",
+    "\n",
+    "from food_price_forecasting.starter_agent import (\n",
+    "    build_starter_agent_config,\n",
+    "    build_starter_agent_predictor,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "print(\"RUN_AGENT =\", RUN_AGENT, \"| model =\", AGENT_MODEL)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-02",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 1. Meet your agent\n",
+    "\n",
+    "`build_starter_agent_config` returns an `AgentConfig` with two toggles. The default turns **news search on** (proxy-only, no extra key) and **code execution off** (it needs `E2B_API_KEY` and is slower). Flip them and re-run — the loaded skills follow the enabled tools.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = build_starter_agent_config(\n",
+    "    model=AGENT_MODEL,\n",
+    "    enable_search=True,  # ← cutoff-aware Google Search (proxy-only)\n",
+    "    enable_code_exec=False,  # ← E2B Python sandbox (needs E2B_API_KEY); try True!\n",
+    ")\n",
+    "\n",
+    "print(\"Agent:\", config.name)\n",
+    "print(\"Search enabled:    \", config.context_retrieval.enabled)\n",
+    "print(\"Code-exec enabled: \", config.code_execution.enabled)\n",
+    "print(\"Skills loaded:     \", [p.name for p in config.skills_dirs])\n",
+    "print(\"\\n── System instruction (edit this in starter_agent/agent.py) ──\\n\")\n",
+    "print(config.instruction[:1200], \"...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-04",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2. Talk to it  *(Track 2 — open-ended analysis)*\n",
+    "\n",
+    "Ask the agent anything. This is the interactive mode: no scoring, no schema — just reasoning (and a web search, since search is on). Edit the question and explore.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from aieng.forecasting.methods.agentic import build_adk_agent\n",
+    "from aieng.forecasting.methods.agentic.adk_runner import AdkTextRunner, AdkTextRunnerConfig\n",
+    "\n",
+    "\n",
+    "QUESTION = (\n",
+    "    \"What is driving Canadian food inflation right now, and where is the food \"\n",
+    "    \"CPI headed over the next year? Be concise.\"\n",
+    ")\n",
+    "\n",
+    "if RUN_AGENT:\n",
+    "    chat_agent = build_adk_agent(config)  # schema-free: plain text in, text out\n",
+    "    runner = AdkTextRunner(chat_agent, config=AdkTextRunnerConfig(app_name=\"food_starter_chat\"))\n",
+    "    reply = await runner.run_text_async(QUESTION)  # noqa: F704, PLE1142\n",
+    "    print(reply)\n",
+    "else:\n",
+    "    print(\"RUN_AGENT is False — set it to True in the setup cell to talk to the agent.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-06",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 3. Score one prediction against known outcomes  *(Track 1)*\n",
+    "\n",
+    "Now run the agent as a `Predictor`. We pick the **most recent origin whose horizons have already resolved**, forecast the food-overall CPI index, and check whether each actual index landed inside the agent's 80% band. (One origin can't tell you if the agent is *calibrated*; that's what the backtest in `02_food_cpi_experiment.ipynb` is for.) Live, so gated by `RUN_AGENT`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime, timezone\n",
+    "\n",
+    "\n",
+    "if RUN_AGENT:\n",
+    "    from aieng.forecasting.evaluation.task import ForecastingTask\n",
+    "    from food_price_forecasting.data import FOOD_CPI_SERIES, build_food_cpi_service\n",
+    "\n",
+    "    FOOD_SERIES_ID = FOOD_CPI_SERIES[0][0]  # cpi_food_canada (food overall)\n",
+    "    svc = build_food_cpi_service()\n",
+    "    now = datetime.now(tz=timezone.utc).replace(tzinfo=None)\n",
+    "    full = svc.get_series(FOOD_SERIES_ID, as_of=now)\n",
+    "    full[\"timestamp\"] = pd.to_datetime(full[\"timestamp\"])\n",
+    "    last_date = full[\"timestamp\"].iloc[-1]\n",
+    "\n",
+    "    HORIZONS = [1, 3, 6, 12]\n",
+    "    # Most recent month-start origin whose longest horizon has already resolved.\n",
+    "    AS_OF = (last_date - pd.DateOffset(months=max(HORIZONS))).replace(day=1)\n",
+    "\n",
+    "    task = ForecastingTask(\n",
+    "        task_id=\"food_cpi_starter_forecast\",\n",
+    "        target_series_id=FOOD_SERIES_ID,\n",
+    "        horizons=HORIZONS,\n",
+    "        frequency=\"MS\",\n",
+    "        description=\"Canadian food CPI index — 1/3/6/12 months ahead (starter).\",\n",
+    "    )\n",
+    "    ctx = svc.context(as_of=AS_OF)\n",
+    "    preds = build_starter_agent_predictor(config).predict(task, ctx)\n",
+    "\n",
+    "    def realized_at(h):\n",
+    "        rows = full[full[\"timestamp\"] >= AS_OF + pd.DateOffset(months=h)]\n",
+    "        return float(rows[\"value\"].iloc[0]) if not rows.empty else None\n",
+    "\n",
+    "    print(f\"Origin as_of={AS_OF.date()}  series={FOOD_SERIES_ID}  (latest data {last_date.date()})\\n\")\n",
+    "    print(\"  h(mo)  agent index   agent 80% CI            actual   in band?\")\n",
+    "    for i, h in enumerate(HORIZONS):\n",
+    "        fc = preds[i].payload\n",
+    "        lo, hi = fc.quantiles[0.10], fc.quantiles[0.90]\n",
+    "        act = realized_at(h)\n",
+    "        inb = \"—\" if act is None else (\"yes ✓\" if lo <= act <= hi else \"no ✗\")\n",
+    "        acts = \"   N/A\" if act is None else f\"{act:8.2f}\"\n",
+    "        print(f\"  {h:>3}    {fc.point_forecast:8.2f}   [{lo:7.2f}, {hi:7.2f}]   {acts}   {inb}\")\n",
+    "    if preds[0].metadata.get(\"rationale\"):\n",
+    "        print(\"\\nRationale:\", preds[0].metadata[\"rationale\"][:300])\n",
+    "else:\n",
+    "    print(\"RUN_AGENT is False — set it to True to score a live forecast against known outcomes.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-08",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 4. Make it yours\n",
+    "\n",
+    "This agent is a starting point. Here are concrete next steps, easiest first — each is a small edit, then re-run the cells above.\n",
+    "\n",
+    "1. **Flip code execution on.** Set `enable_code_exec=True` in §1 (needs `E2B_API_KEY`). The agent loads the `code-analysis-playbook` skill and can compute its own diagnostics before forecasting. Compare the rationale.\n",
+    "2. **Edit the agent's personality.** Open `starter_agent/agent.py` and change `_build_starter_instruction()` — make it more cautious, more contrarian, focused on one driver. Re-run §1 to see the new instruction.\n",
+    "3. **Sharpen the skills.** The two files in `starter_agent/skills/` are short on purpose. Add your best queries to `research-playbook`, or a new diagnostic to `code-analysis-playbook`. The agent picks them up automatically.\n",
+    "4. **Change the question and the origin.** Try a different `QUESTION` in §2 and a different origin in §3.\n",
+    "5. **Forecast all nine series.** This starter does food-overall; loop over `FOOD_CPI_SERIES` for the full CFPR basket (see `02_food_cpi_experiment.ipynb`).\n",
+    "6. **Add report context.** Build the service with `build_food_cpi_service(reports_dir=...)` and feed cutoff-filtered CFPR report text into the prompt builder.\n",
+    "\n",
+    "Bigger ideas — report-grounded forecasting, the avg/avg YoY metric, the full multi-target leaderboard — are in the use-case `README.md` and `planning-docs/roadmap.md`.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/implementations/food_price_forecasting/README.md
+++ b/implementations/food_price_forecasting/README.md
@@ -1,5 +1,7 @@
 # Food Price CPI Forecasting
 
+> **Reference implementation 2 of 4.** Recommended order: [getting_started](../getting_started/) → [S&P 500](../sp500_forecasting/) → **food CPI** → [energy / WTI](../energy_oil_forecasting/) → [BoC rate decisions](../boc_rate_decisions/). Each stands on its own.
+
 Replicates the **Canada's Food Price Report (CFPR)** forecasting methodology —
 an annual estimate of the year-over-year percentage change in Canadian food
 prices across nine CPI sub-categories.
@@ -102,8 +104,10 @@ implementations/food_price_forecasting/
 ├── plots.py       # plot_trajectory_fan, plot_avgyoy_grid,
 │                  # plot_crps_disaggregated, plot_mape_distribution,
 │                  # plot_food_cpi_small_multiples
+├── starter_agent/  # fresh, hackable agent template (toggleable search/code-exec + skills)
 ├── 01_food_data_exploration.ipynb # 9-cell warm-up tour of the 9 series
-└── 02_food_cpi_experiment.ipynb   # 26-cell narrative over the helpers above
+├── 02_food_cpi_experiment.ipynb   # 26-cell narrative over the helpers above
+└── 99_starter_agent.ipynb         # ← start here to build your own agent
 ```
 
 Unit tests for the analysis helpers live under
@@ -195,6 +199,7 @@ uv run python scripts/extract_reports.py
 |----------|---------|
 | `01_food_data_exploration.ipynb` | Short warm-up tour: register the 9 series, small-multiples history, YoY overlay, coverage table. |
 | `02_food_cpi_experiment.ipynb`   | **Main experiment.** Selectable via `EXPERIMENT_CONFIG` (`"full"` / `"mini_recent"` / `"mini_single"`). Runs cached backtests for two baselines (`LastValuePredictor`, `DartsAutoARIMAPredictor`) and two LLMPs. Plots trajectory fans, avg/avg YoY grid, and CRPS/MAPE leaderboards. |
+| `99_starter_agent.ipynb`         | **Your starter agent.** This use case's first agent — a fresh, hackable food-CPI forecaster (toggleable news search + code execution, two lightweight tool-usage skills). Interactive (Track 2) cell, one scored trajectory (Track 1), and a "make it yours" guide pointing at the bigger projects (all 9 series, report-grounded context). |
 
 ---
 

--- a/implementations/food_price_forecasting/starter_agent/__init__.py
+++ b/implementations/food_price_forecasting/starter_agent/__init__.py
@@ -1,0 +1,19 @@
+"""Food CPI starter agent — a fresh, hackable template for your own exploration.
+
+Exports the toggle-driven :class:`AgentConfig` factory, the predictor
+convenience factory, and the self-contained prompt builder. See
+``99_starter_agent.ipynb`` and ``agent.py``.
+"""
+
+from food_price_forecasting.starter_agent.agent import (
+    FoodCpiStarterPromptBuilder,
+    build_starter_agent_config,
+    build_starter_agent_predictor,
+)
+
+
+__all__ = [
+    "FoodCpiStarterPromptBuilder",
+    "build_starter_agent_config",
+    "build_starter_agent_predictor",
+]

--- a/implementations/food_price_forecasting/starter_agent/agent.py
+++ b/implementations/food_price_forecasting/starter_agent/agent.py
@@ -1,0 +1,264 @@
+"""Food CPI starter agent — a fresh, hackable template for your own exploration.
+
+This is the food use case's **first** agent, and it is deliberately minimal: a
+clean starting point with our common building blocks behind simple toggles —
+
+- **optional news search** (``enable_search``, on by default) — bounded,
+  cutoff-aware Google Search through the Vector proxy;
+- **optional code execution** (``enable_code_exec``, off by default) — an E2B
+  Python sandbox;
+- **two lightweight skills** (:mod:`skills/`) that are *tool-usage playbooks*:
+  how to get good results out of search and code execution.
+
+Everything routes through the Vector proxy — no direct provider keys. See
+``planning-docs/vector-llm-proxy.md``.
+
+Unlike energy/boc, this use case had no agent to borrow a prompt builder from,
+so :class:`FoodCpiStarterPromptBuilder` below is a small, self-contained
+serialiser — read it, then extend it (more history, covariates, report context).
+The output is a probabilistic CPI-index trajectory. Pair this with
+``99_starter_agent.ipynb``.
+
+Module-level ``__getattr__`` exposes ``root_agent`` lazily so ``adk web`` can
+load this module for interactive (schema-free) use.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+import pandas as pd
+from aieng.forecasting.data.context import ForecastContext
+from aieng.forecasting.evaluation.prediction import STANDARD_QUANTILES
+from aieng.forecasting.evaluation.task import ForecastingTask
+from aieng.forecasting.methods.agentic import (
+    AgentPredictor,
+    ContinuousAgentForecastOutput,
+    build_adk_agent,
+)
+from aieng.forecasting.methods.agentic.agent_factory import (
+    AgentConfig,
+    CodeExecutionConfig,
+    ContextRetrievalConfig,
+)
+from aieng.forecasting.models import LITE_MODEL
+from pydantic import BaseModel
+
+
+# Skills live next to this module.
+_SKILLS_ROOT = Path(__file__).parent / "skills"
+_FORECASTING_SKILL = _SKILLS_ROOT / "forecasting"
+_RESEARCH_SKILL = _SKILLS_ROOT / "research-playbook"
+_CODE_ANALYSIS_SKILL = _SKILLS_ROOT / "code-analysis-playbook"
+
+
+# ---------------------------------------------------------------------------
+# Prompt builder (self-contained — this use case has no analyst_agent to reuse)
+# ---------------------------------------------------------------------------
+
+
+class FoodCpiStarterPromptBuilder(BaseModel):
+    """Serialise a single food-CPI series + task into the agent's JSON payload.
+
+    Minimal on purpose: the most recent ``history_months`` of the target index,
+    plus the task spec and the exact quantile grid the agent must produce.
+    Implements the
+    :class:`~aieng.forecasting.methods.agentic.predictor.ForecastPromptBuilder`
+    protocol structurally — extend it with covariates or report context.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    history_months: int = 120
+
+    def __call__(self, *, task: ForecastingTask, context: ForecastContext) -> str:
+        df = context.get_series(task.target_series_id).tail(self.history_months)
+        rows = ["date,index"] + [
+            f"{pd.Timestamp(ts).date()},{float(v):.2f}" for ts, v in zip(df["timestamp"], df["value"])
+        ]
+        last_row = df.iloc[-1]
+        payload: dict[str, Any] = {
+            "task": task.task_id,
+            "as_of": str(context.as_of)[:10],
+            "horizons": list(task.horizons),
+            "standard_quantiles": list(STANDARD_QUANTILES),
+            "target_summary": {
+                "last_index": float(last_row["value"]),
+                "last_date": str(pd.Timestamp(last_row["timestamp"]).date()),
+                "n_months": int(len(df)),
+            },
+            "target_history_csv": "\n".join(rows),
+        }
+        return json.dumps(payload, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+
+def _build_starter_instruction() -> str:
+    """Build the task-agnostic, skill-agnostic starter persona.
+
+    Just the analyst's identity and how to behave — no output schema, no payload
+    contract, no skill or tool mechanics. ADK injects the name + description of
+    every attached skill (and every tool) into the system prompt, so the agent
+    already knows what it can load and call; repeating that here would only
+    duplicate dynamically-injected information. The forecasting *contract* lives
+    in the loadable ``forecasting`` skill. Edit the persona freely.
+    """
+    return (
+        "## Role\n\n"
+        "You are a Canadian food-price analyst — fluent in food CPI dynamics, "
+        "seasonality, commodity and input costs, and the headline inflation "
+        "backdrop. This is a starter agent: keep your reasoning transparent and "
+        "your claims honest.\n\n"
+        "## How to respond\n\n"
+        "- For open-ended questions, scenario analysis, or anything "
+        "conversational, answer directly and concisely — do NOT ask for a JSON "
+        "payload.\n"
+        "- When you are handed a task that asks for a structured probabilistic "
+        "forecast, produce a calibrated one."
+    )
+
+
+_STARTER_INSTRUCTION = _build_starter_instruction()
+
+
+_CONTEXT_RETRIEVAL_INSTRUCTION = """\
+You are a Canadian food-inflation intelligence specialist with web search.
+
+Return a concise structured markdown summary (3-5 paragraphs) covering, as the
+query warrants: recent food-CPI and headline-CPI prints vs the 2% target;
+commodity and input costs (grains, energy, fertiliser); supply-chain and weather
+disruptions; and the CAD exchange rate.
+
+Ground every claim in the search results you actually retrieve. When a cutoff
+date is specified, never report or speculate about events after it.\
+"""
+
+
+# ---------------------------------------------------------------------------
+# Config factory
+# ---------------------------------------------------------------------------
+
+
+def build_starter_agent_config(
+    model: str = LITE_MODEL,
+    search_model: str = LITE_MODEL,
+    *,
+    enable_search: bool = True,
+    enable_code_exec: bool = False,
+) -> AgentConfig:
+    """Build the food-CPI starter :class:`AgentConfig`.
+
+    Parameters
+    ----------
+    model : str
+        Model for the analyst agent (default: lite). Pass the advanced model
+        (``"gemini-3.5-flash"``) for higher-quality runs.
+    search_model : str
+        Model for the bounded web-search sub-tool.
+    enable_search : bool, default=True
+        Wire a cutoff-aware ``search_web`` tool and load the
+        ``research-playbook`` skill. Proxy-only — no extra API key.
+    enable_code_exec : bool, default=False
+        Wire an E2B Python sandbox and load the ``code-analysis-playbook``
+        skill. Needs ``E2B_API_KEY`` and is slower, so it is off by default.
+
+    Returns
+    -------
+    AgentConfig
+    """
+    # Every attached skill is loaded on demand: ADK injects each skill's name +
+    # description into the system prompt, and the agent reads the full SKILL.md
+    # only when relevant — so toggling a tool just adds its skill, no persona edits.
+    skills_dirs: list[Path] = [_FORECASTING_SKILL]
+    if enable_search:
+        skills_dirs.append(_RESEARCH_SKILL)
+    if enable_code_exec:
+        skills_dirs.append(_CODE_ANALYSIS_SKILL)
+
+    context_retrieval = (
+        ContextRetrievalConfig(
+            enabled=True,
+            instruction=_CONTEXT_RETRIEVAL_INSTRUCTION,
+            search_model=search_model,
+        )
+        if enable_search
+        else ContextRetrievalConfig()
+    )
+
+    return AgentConfig(
+        name="food_cpi_starter_agent",
+        model=model,
+        instruction=_STARTER_INSTRUCTION,
+        # 16k headroom: enough for a complete run_code script + structured output.
+        max_output_tokens=16_384 if enable_code_exec else None,
+        context_retrieval=context_retrieval,
+        code_execution=CodeExecutionConfig(enabled=enable_code_exec),
+        skills_dirs=skills_dirs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Predictor convenience factory
+# ---------------------------------------------------------------------------
+
+
+class _StarterForecastPromptBuilder:
+    """Add the output schema + a forecast directive to a base builder's payload.
+
+    The exact JSON schema is generated at call time from the output class
+    (drift-free) and injected into the user payload — never into the system
+    prompt — so the agent stays conversational until it is actually asked to
+    forecast. Implements the
+    :class:`~aieng.forecasting.methods.agentic.predictor.ForecastPromptBuilder`
+    protocol structurally.
+    """
+
+    def __init__(self, inner: Callable[..., str], output_schema_json: str) -> None:
+        self._inner = inner
+        self._schema_json = output_schema_json
+
+    def __call__(self, *, task: ForecastingTask, context: ForecastContext) -> str:
+        payload = json.loads(self._inner(task=task, context=context))
+        payload["instructions"] = (
+            "Produce a calibrated probabilistic forecast for this task and return it by "
+            "calling `set_model_response` with a `json_response` string matching "
+            "`output_schema` exactly."
+        )
+        payload["output_schema"] = self._schema_json
+        return json.dumps(payload, indent=2)
+
+
+def build_starter_agent_predictor(config: AgentConfig) -> AgentPredictor:
+    """Wrap a starter :class:`AgentConfig` in an :class:`AgentPredictor`.
+
+    Wraps :class:`FoodCpiStarterPromptBuilder` so the (drift-free) continuous
+    output schema and a forecast directive ride in the payload — keeping the
+    schema out of the persona. ``predict(task, context)`` returns one
+    :class:`~aieng.forecasting.evaluation.prediction.Prediction` per horizon.
+    """
+    return AgentPredictor(
+        agent_config=config,
+        prompt_builder=_StarterForecastPromptBuilder(
+            FoodCpiStarterPromptBuilder(),
+            ContinuousAgentForecastOutput.prompt_schema_json(),
+        ),
+        output_schema=ContinuousAgentForecastOutput,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lazy root_agent for `adk web` interactive use
+# ---------------------------------------------------------------------------
+
+
+def __getattr__(name: str) -> Any:
+    """Expose ``root_agent`` lazily for schema-free interactive use via ``adk web``."""
+    if name == "root_agent":
+        return build_adk_agent(build_starter_agent_config())
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/implementations/food_price_forecasting/starter_agent/skills/code-analysis-playbook/SKILL.md
+++ b/implementations/food_price_forecasting/starter_agent/skills/code-analysis-playbook/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: code-analysis-playbook
+description: >-
+  How to use the code execution sandbox well — parse the JSON payload (not
+  disk files), compute a couple of useful diagnostics before forecasting, and
+  keep the session stateful within a turn. Load this before writing code. No
+  scripts.
+---
+
+# Code-analysis playbook
+
+A short guide to using the `run_code` sandbox productively. This is a starter
+skill — extend it with the diagnostics that matter for your problem.
+
+## Where your data lives
+
+All data comes from the **JSON payload in your context** — there are no disk
+files and no network. The history arrives as a CSV *string* (e.g.
+`target_history_csv`). Parse it with `io.StringIO`, never as a file path:
+
+```python
+import io, pandas as pd
+df = pd.read_csv(io.StringIO(payload["target_history_csv"]))
+```
+
+The sandbox is **stateful within a turn**: parse once in your first code block,
+then reuse the DataFrame in later blocks instead of re-parsing.
+
+## Compute before you forecast
+
+Run a couple of cheap diagnostics so your forecast is grounded in arithmetic,
+not vibes:
+
+1. **Recent trend** — slope/return over the last N observations.
+2. **Volatility** — recent standard deviation of changes; it sets how wide your
+   quantile bands should be.
+3. **Sanity check** — does your point forecast sit within a plausible multiple
+   of recent moves? If not, revisit it.
+
+Use the printed numbers to set the point forecast and to *calibrate the spread*
+between your low and high quantiles — wider when recent volatility is high.
+
+## Domain focus (edit this for your use case)
+
+For monthly food CPI, the series is an index (base 2002=100) that moves slowly
+and seasonally; month-over-month changes are typically small. Use recent
+year-over-year change and seasonality, not a fixed guess, to set your trajectory
+and the width of your interval bands.
+
+## Room to grow
+
+- Add your own diagnostic patterns (regime detection, seasonality, covariates).
+- Drop reusable reference values into a `references/` file and `load_skill_resource` them.

--- a/implementations/food_price_forecasting/starter_agent/skills/forecasting/SKILL.md
+++ b/implementations/food_price_forecasting/starter_agent/skills/forecasting/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: forecasting
+description: >-
+  The output contract for producing a structured probabilistic forecast — the
+  JSON shape, the calibration and quantile rules, and how to submit it. Load
+  this ONLY when your task payload asks for a forecast; ignore it for
+  open-ended questions. No scripts.
+---
+
+# Forecasting skill
+
+Load this when your task payload asks for a structured forecast. For open-ended
+questions, ignore it and just answer.
+
+## What you'll receive
+
+A JSON payload describing the task: a `task` id, the `as_of` cutoff date,
+`horizons` (steps ahead), the `standard_quantiles` grid, a `target_summary`, the
+recent `target_history_csv`, and an `output_schema` showing the exact JSON to
+return.
+
+## The output contract
+
+1. Produce **one forecast per horizon** in `horizons`.
+2. Use **exactly** the levels in `standard_quantiles` — no additions or omissions.
+3. `point_forecast` must equal the **0.50 quantile** value.
+4. Quantile values must be **non-decreasing** as the quantile level rises.
+5. Use ONLY information available on or before `as_of`.
+6. Put your reasoning in the `rationale` fields.
+
+Submit by calling `set_model_response` with a `json_response` string that
+matches the payload's `output_schema` **exactly** — use `"horizon"` (an
+integer), and make `"quantiles"` a **list** of `{"quantile": <level>, "value":
+<number>}` objects. Omit any field not shown in the schema.
+
+## Calibration
+
+Report calibrated intervals, not false precision: across many forecasts where
+your 80% band is stated, the truth should land inside it about 80% of the time.
+Anchor the point on the recent level and trend; let recent **volatility** set
+how wide the bands are, and widen them as the horizon grows.
+
+## Domain focus (edit this for your use case)
+
+For monthly food CPI, anchor on the last index value and its recent
+year-over-year change; the index moves slowly and seasonally, so month-to-month
+jumps are small. Widen the bands with the horizon, and adjust for food-inflation
+or input-cost signals you have real evidence for — and say so in the rationale.
+
+## Room to grow
+
+- Tighten the calibration guidance with your own backtest findings.
+- Add worked examples of good vs. over-confident forecasts.

--- a/implementations/food_price_forecasting/starter_agent/skills/research-playbook/SKILL.md
+++ b/implementations/food_price_forecasting/starter_agent/skills/research-playbook/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: research-playbook
+description: >-
+  How to use the search_web tool well when grounding a forecast in recent
+  news — phrase cutoff-aware queries, decide what is worth searching for, and
+  weigh sources. Load this before your first search_web call. No scripts.
+---
+
+# Research playbook
+
+A short guide to getting real signal out of `search_web`. This is a starter
+skill — extend it with the queries and sources that work for your problem.
+
+## The one rule that matters
+
+Always pass `cutoff_date` equal to the `as_of` date in your payload. It is the
+temporal fence that keeps post-origin information out of a historical forecast.
+A forecast that "knew" what happened after `as_of` is not a forecast.
+
+## How to search
+
+- **Search before you forecast, not after.** Gather context first, then reason.
+- **One topic per query.** Several focused queries beat one broad one. Stop when
+  new queries stop returning new facts.
+- **Ask for the present state, not a prediction.** "current OPEC+ production
+  policy" returns facts; "will oil go up" returns noise.
+- **Weigh sources.** Prefer primary releases and major outlets; treat a single
+  blog or forum post as a lead to confirm, not a fact.
+
+## Domain focus (edit this for your use case)
+
+For Canadian food CPI, the signals: recent food-inflation prints and the
+headline CPI trend vs the 2% target, commodity and input costs (grains, energy,
+fertiliser), supply-chain and weather disruptions, and the CAD exchange rate.
+Search for the *current state* of these, then let the series trend set the baseline.
+
+## Room to grow
+
+- Add a curated list of go-to sources for your domain.
+- Track which queries paid off and prune the ones that didn't.
+- Add a `references/` file with example high-signal searches.

--- a/implementations/getting_started/01_cpi_data_exploration.ipynb
+++ b/implementations/getting_started/01_cpi_data_exploration.ipynb
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "24ba4b45",
    "metadata": {
     "execution": {
@@ -77,51 +77,8 @@
      "shell.execute_reply": "2026-04-17T19:06:02.630586Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Registered: cpi_all_items_canada\n",
-      "  Registered: cpi_gasoline_canada\n",
-      "  Registered: cpi_shelter_canada\n",
-      "\n",
-      "Done.\n"
-     ]
-    }
-   ],
-   "source": [
-    "CPI_TABLE_ID = \"18-10-0004-11\"\n",
-    "CACHE_DIR = Path(\"../../../data/statcan\")\n",
-    "\n",
-    "# (series_id, StatCan product-group label, short label)\n",
-    "CPI_SERIES = [\n",
-    "    (\"cpi_all_items_canada\", \"All-items\", \"All-items\"),\n",
-    "    (\"cpi_gasoline_canada\", \"Gasoline\", \"Gasoline\"),\n",
-    "    (\"cpi_shelter_canada\", \"Shelter\", \"Shelter\"),\n",
-    "]\n",
-    "\n",
-    "svc = DataService()\n",
-    "\n",
-    "for series_id, product_group, short_label in CPI_SERIES:\n",
-    "    adapter = StatCanAdapter(\n",
-    "        table_id=CPI_TABLE_ID,\n",
-    "        member_filter={\"GEO\": \"Canada\", \"Products and product groups\": product_group},\n",
-    "        cache_dir=CACHE_DIR,\n",
-    "    )\n",
-    "    metadata = SeriesMetadata(\n",
-    "        series_id=series_id,\n",
-    "        description=f\"CPI {short_label}, Canada (2002=100)\",\n",
-    "        source=\"StatCan\",\n",
-    "        units=\"Index 2002=100\",\n",
-    "        frequency=\"MS\",\n",
-    "        table_id=CPI_TABLE_ID,\n",
-    "    )\n",
-    "    svc.register(series_id, adapter, metadata)\n",
-    "    print(f\"  Registered: {series_id}\")\n",
-    "\n",
-    "print(\"\\nDone.\")"
-   ]
+   "outputs": [],
+   "source": "CPI_TABLE_ID = \"18-10-0004-11\"\n# Resolve the repo-root data cache the same way 00/02 do, so this notebook\n# reuses the cache populated by `scripts/fetch_cpi.py` regardless of CWD.\nROOT = Path.cwd().resolve().parents[1]\nCACHE_DIR = ROOT / \"data\" / \"statcan\"\n\n# (series_id, StatCan product-group label, short label)\nCPI_SERIES = [\n    (\"cpi_all_items_canada\", \"All-items\", \"All-items\"),\n    (\"cpi_gasoline_canada\", \"Gasoline\", \"Gasoline\"),\n    (\"cpi_shelter_canada\", \"Shelter\", \"Shelter\"),\n]\n\nsvc = DataService()\n\nfor series_id, product_group, short_label in CPI_SERIES:\n    adapter = StatCanAdapter(\n        table_id=CPI_TABLE_ID,\n        member_filter={\"GEO\": \"Canada\", \"Products and product groups\": product_group},\n        cache_dir=CACHE_DIR,\n    )\n    metadata = SeriesMetadata(\n        series_id=series_id,\n        description=f\"CPI {short_label}, Canada (2002=100)\",\n        source=\"StatCan\",\n        units=\"Index 2002=100\",\n        frequency=\"MS\",\n        table_id=CPI_TABLE_ID,\n    )\n    svc.register(series_id, adapter, metadata)\n    print(f\"  Registered: {series_id}\")\n\nprint(\"\\nDone.\")"
   },
   {
    "cell_type": "markdown",

--- a/implementations/sp500_forecasting/99_starter_agent.ipynb
+++ b/implementations/sp500_forecasting/99_starter_agent.ipynb
@@ -1,0 +1,239 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {},
+   "source": [
+    "# S&P 500 — Your Starter Agent\n",
+    "\n",
+    "**If you're not sure what to do next, continue from here.**\n",
+    "\n",
+    "This notebook is a fresh, hackable agent for the S&P 500 use case — deliberately *not* wired into the numbered curriculum. It gives you our common building blocks behind simple toggles, so you can start building something of your own:\n",
+    "\n",
+    "- **optional news search** — bounded, cutoff-aware Google Search (proxy-only)\n",
+    "- **optional code execution** — an E2B Python sandbox\n",
+    "- **two lightweight skills** — *tool-usage playbooks* in `starter_agent/skills/`\n",
+    "\n",
+    "It does two things: lets you **talk to the agent** (open-ended, Track 2) and **score one real forecast** (Track 1). The live cells are gated by `RUN_AGENT` so a fresh `Run All` is safe and free; flip it to `True` to actually call the model.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "from pathlib import Path\n",
+    "\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "\n",
+    "# Repo root holds the .env with PROXY_* creds the agent needs.\n",
+    "ROOT = Path.cwd().resolve().parents[1]\n",
+    "load_dotenv(ROOT / \".env\")\n",
+    "\n",
+    "# ── Model selection ───────────────────────────────────\n",
+    "# Two project models: \"gemini-3.1-flash-lite-preview\" (lite/default) and\n",
+    "# \"gemini-3.5-flash\" (advanced). Lite is the default.\n",
+    "AGENT_MODEL = \"gemini-3.1-flash-lite-preview\"\n",
+    "# AGENT_MODEL = \"gemini-3.5-flash\"  # advanced (higher cost/latency)\n",
+    "\n",
+    "# ── Run guard ──────────────────────────────────────\n",
+    "# Live agent calls cost tokens and need PROXY_* in the repo-root .env, plus warm\n",
+    "# data caches. Default False so `Run All` is safe; set True to call the model.\n",
+    "RUN_AGENT = False\n",
+    "\n",
+    "from sp500_forecasting.starter_agent import (\n",
+    "    build_starter_agent_config,\n",
+    "    build_starter_agent_predictor,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "print(\"RUN_AGENT =\", RUN_AGENT, \"| model =\", AGENT_MODEL)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-02",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 1. Meet your agent\n",
+    "\n",
+    "`build_starter_agent_config` returns an `AgentConfig` with two toggles. The default turns **news search on** (proxy-only, no extra key) and **code execution off** (it needs `E2B_API_KEY` and is slower). Flip them and re-run — the loaded skills follow the enabled tools.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = build_starter_agent_config(\n",
+    "    model=AGENT_MODEL,\n",
+    "    enable_search=True,  # ← cutoff-aware Google Search (proxy-only)\n",
+    "    enable_code_exec=False,  # ← E2B Python sandbox (needs E2B_API_KEY); try True!\n",
+    ")\n",
+    "\n",
+    "print(\"Agent:\", config.name)\n",
+    "print(\"Search enabled:    \", config.context_retrieval.enabled)\n",
+    "print(\"Code-exec enabled: \", config.code_execution.enabled)\n",
+    "print(\"Skills loaded:     \", [p.name for p in config.skills_dirs])\n",
+    "print(\"\\n── System instruction (edit this in starter_agent/agent.py) ──\\n\")\n",
+    "print(config.instruction[:1200], \"...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-04",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2. Talk to it  *(Track 2 — open-ended analysis)*\n",
+    "\n",
+    "Ask the agent anything. This is the interactive mode: no scoring, no schema — just reasoning (and a web search, since search is on). Edit the question and explore.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from aieng.forecasting.methods.agentic import build_adk_agent\n",
+    "from aieng.forecasting.methods.agentic.adk_runner import AdkTextRunner, AdkTextRunnerConfig\n",
+    "\n",
+    "\n",
+    "QUESTION = (\n",
+    "    \"What are the key macro risks for U.S. equities over the next month, and how \"\n",
+    "    \"should they shape the spread of a 1-week S&P 500 return forecast? Be concise.\"\n",
+    ")\n",
+    "\n",
+    "if RUN_AGENT:\n",
+    "    chat_agent = build_adk_agent(config)  # schema-free: plain text in, text out\n",
+    "    runner = AdkTextRunner(chat_agent, config=AdkTextRunnerConfig(app_name=\"sp500_starter_chat\"))\n",
+    "    reply = await runner.run_text_async(QUESTION)  # noqa: F704, PLE1142\n",
+    "    print(reply)\n",
+    "else:\n",
+    "    print(\"RUN_AGENT is False — set it to True in the setup cell to talk to the agent.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-06",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 3. Score one prediction against a known outcome  *(Track 1)*\n",
+    "\n",
+    "Now run the agent as a `Predictor`. We pick the **most recent origin whose horizon has already resolved**, forecast the 1-week S&P 500 return, and check whether the actual return landed inside the agent's 80% band. (One origin can't tell you if the agent is *calibrated*; that's what the backtest in `01_sp500_multivariate_backtest.ipynb` is for.) Live, so gated by `RUN_AGENT`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime, timezone\n",
+    "\n",
+    "\n",
+    "if RUN_AGENT:\n",
+    "    from aieng.forecasting.evaluation.task import ForecastingTask\n",
+    "    from sp500_forecasting import build_sp500_multivariate_service\n",
+    "    from sp500_forecasting.data import sp500_logret_series_id\n",
+    "\n",
+    "    HORIZON = 5\n",
+    "    COVARIATES = [\"vix_level_l1b\", \"ust10y_level_l1b\", \"oil_log_ret_1b_l1b\"]\n",
+    "    svc = build_sp500_multivariate_service(covariate_series_ids=COVARIATES)\n",
+    "    now = datetime.now(tz=timezone.utc).replace(tzinfo=None)\n",
+    "    tgt = sp500_logret_series_id(HORIZON)\n",
+    "    full = svc.get_series(tgt, as_of=now)\n",
+    "    full[\"timestamp\"] = pd.to_datetime(full[\"timestamp\"])\n",
+    "    last_date = full[\"timestamp\"].iloc[-1]\n",
+    "\n",
+    "    # Most recent origin whose horizon return has already resolved.\n",
+    "    AS_OF = last_date - pd.offsets.BDay(HORIZON + 1)\n",
+    "\n",
+    "    task = ForecastingTask(\n",
+    "        task_id=f\"sp500_logret_{HORIZON}b\",\n",
+    "        target_series_id=tgt,\n",
+    "        horizons=[HORIZON],\n",
+    "        frequency=\"B\",\n",
+    "        description=f\"S&P 500 cumulative log return, {HORIZON} business days ahead (starter).\",\n",
+    "    )\n",
+    "    ctx = svc.context(as_of=AS_OF)\n",
+    "    pred = build_starter_agent_predictor(config, covariate_series_ids=COVARIATES).predict(task, ctx)[0]\n",
+    "\n",
+    "    rows = full[full[\"timestamp\"] >= AS_OF + pd.offsets.BDay(HORIZON)]\n",
+    "    actual = float(rows[\"value\"].iloc[0]) if not rows.empty else None\n",
+    "\n",
+    "    fc = pred.payload\n",
+    "    lo, hi = fc.quantiles[0.10], fc.quantiles[0.90]\n",
+    "    print(f\"Origin as_of={AS_OF.date()}  horizon={HORIZON}b (1 week)  (latest data {last_date.date()})\\n\")\n",
+    "    print(f\"  agent point  : {fc.point_forecast:+.4f}  ({fc.point_forecast * 100:+.2f}%)\")\n",
+    "    print(f\"  agent 80% CI : [{lo:+.4f}, {hi:+.4f}]\")\n",
+    "    if actual is None:\n",
+    "        print(\"  actual       : N/A (not yet resolved)\")\n",
+    "    else:\n",
+    "        inb = \"yes ✓\" if lo <= actual <= hi else \"no ✗\"\n",
+    "        print(f\"  actual       : {actual:+.4f}  ({actual * 100:+.2f}%)   in 80% band? {inb}\")\n",
+    "    if pred.metadata.get(\"rationale\"):\n",
+    "        print(\"\\nRationale:\", pred.metadata[\"rationale\"][:300])\n",
+    "else:\n",
+    "    print(\"RUN_AGENT is False — set it to True to score a live forecast against a known outcome.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-08",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 4. Make it yours\n",
+    "\n",
+    "This agent is a starting point. Here are concrete next steps, easiest first — each is a small edit, then re-run the cells above.\n",
+    "\n",
+    "1. **Flip code execution on.** Set `enable_code_exec=True` in §1 (needs `E2B_API_KEY`). The agent loads the `code-analysis-playbook` skill and can compute its own diagnostics before forecasting. Compare the rationale.\n",
+    "2. **Edit the agent's personality.** Open `starter_agent/agent.py` and change `_build_starter_instruction()` — make it more cautious, more contrarian, focused on one driver. Re-run §1 to see the new instruction.\n",
+    "3. **Sharpen the skills.** The two files in `starter_agent/skills/` are short on purpose. Add your best queries to `research-playbook`, or a new diagnostic to `code-analysis-playbook`. The agent picks them up automatically.\n",
+    "4. **Change the question and the origin.** Try a different `QUESTION` in §2 and a different origin in §3.\n",
+    "5. **Widen the covariate panel.** Pass `DEFAULT_COVARIATE_SERIES_IDS` (11 series) to both the service and `build_starter_agent_predictor(...)` and see if the extra context helps.\n",
+    "6. **Forecast other horizons.** Swap `HORIZON` to 1 (next session) or 21 (1 month) — each maps to its own `sp500_logret_{h}b` target.\n",
+    "\n",
+    "Bigger ideas — the full conventional-vs-LLM-Process comparison and direction metrics in `01_sp500_multivariate_backtest.ipynb` — are in the use-case `README.md` and `planning-docs/roadmap.md`.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/implementations/sp500_forecasting/README.md
+++ b/implementations/sp500_forecasting/README.md
@@ -1,5 +1,7 @@
 # S&P 500 multivariate forecasting (leak-safe covariates)
 
+> **Reference implementation 1 of 4.** Recommended order: [getting_started](../getting_started/) → **S&P 500** → [food CPI](../food_price_forecasting/) → [energy / WTI](../energy_oil_forecasting/) → [BoC rate decisions](../boc_rate_decisions/). Each stands on its own.
+
 The **financial-markets** reference: a head-to-head comparison of conventional
 time-series methods on a daily equity index, all reading the **same leak-safe
 covariate panel**, plus an LLM-Process forecaster that can read those covariates
@@ -153,8 +155,10 @@ implementations/sp500_forecasting/
 ├── analysis.py                # style_results_dataframe(); direction metrics
 ├── plots.py                   # target history; per-horizon CRPS; forecast vs realised return
 ├── backtest_grid.py           # run_horizon_grid() + run_horizon_eval(); per-model rows; live progress
+├── starter_agent/             # fresh, hackable agent template (toggleable search/code-exec + skills)
 ├── specs/                     # sp500_smoke / sp500_backtest_2025 / sp500_eval_2026 / sp500_stress_2020
 ├── 01_sp500_multivariate_backtest.ipynb
+├── 99_starter_agent.ipynb     # ← start here to build your own agent
 └── README.md
 ```
 
@@ -208,5 +212,17 @@ The default smoke run keeps the LLM-Process rows on in the 2025 backtest (the
 headline comparison) but **off in the 2026 eval**, so a first Run All isn't a
 long/expensive surprise. Enable the eval's `llmp_*` rows in `sp500_eval_2026.yaml`
 when you're ready to spend the proxy tokens on the protected scoreboard.
+
+---
+
+## Build your own — `99_starter_agent.ipynb`
+
+Not sure what to do next? [`99_starter_agent.ipynb`](99_starter_agent.ipynb) is
+this use case's first **agent** and a fresh, hackable starting point — *not*
+part of the backtest above. It wires our common building blocks behind simple
+toggles (cutoff-aware news search, an E2B code sandbox) plus two lightweight
+tool-usage skills, and walks through talking to the agent (Track 2), scoring one
+real return forecast (Track 1), and a "make it yours" guide. Live cells are
+gated by `RUN_AGENT` (default `False`), so a first Run All is safe.
 
 ---

--- a/implementations/sp500_forecasting/starter_agent/__init__.py
+++ b/implementations/sp500_forecasting/starter_agent/__init__.py
@@ -1,0 +1,19 @@
+"""S&P 500 starter agent — a fresh, hackable template for your own exploration.
+
+Exports the toggle-driven :class:`AgentConfig` factory, the predictor
+convenience factory, and the self-contained prompt builder. See
+``99_starter_agent.ipynb`` and ``agent.py``.
+"""
+
+from sp500_forecasting.starter_agent.agent import (
+    Sp500StarterPromptBuilder,
+    build_starter_agent_config,
+    build_starter_agent_predictor,
+)
+
+
+__all__ = [
+    "Sp500StarterPromptBuilder",
+    "build_starter_agent_config",
+    "build_starter_agent_predictor",
+]

--- a/implementations/sp500_forecasting/starter_agent/agent.py
+++ b/implementations/sp500_forecasting/starter_agent/agent.py
@@ -1,0 +1,292 @@
+"""S&P 500 starter agent — a fresh, hackable template for your own exploration.
+
+This is the S&P 500 use case's **first** agent, and it is deliberately minimal:
+a clean starting point with our common building blocks behind simple toggles —
+
+- **optional news search** (``enable_search``, on by default) — bounded,
+  cutoff-aware Google Search through the Vector proxy;
+- **optional code execution** (``enable_code_exec``, off by default) — an E2B
+  Python sandbox;
+- **two lightweight skills** (:mod:`skills/`) that are *tool-usage playbooks*:
+  how to get good results out of search and code execution.
+
+Everything routes through the Vector proxy — no direct provider keys. See
+``planning-docs/vector-llm-proxy.md``.
+
+This use case had no agent to borrow a prompt builder from, so
+:class:`Sp500StarterPromptBuilder` below is a small, self-contained serialiser —
+read it, then extend it (more covariates, richer panels, report context). The
+target is a single-horizon cumulative log return; the output is a probabilistic
+forecast of that return. Pair this with ``99_starter_agent.ipynb``.
+
+Module-level ``__getattr__`` exposes ``root_agent`` lazily so ``adk web`` can
+load this module for interactive (schema-free) use.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+import pandas as pd
+from aieng.forecasting.data.context import ForecastContext
+from aieng.forecasting.evaluation.prediction import STANDARD_QUANTILES
+from aieng.forecasting.evaluation.task import ForecastingTask
+from aieng.forecasting.methods.agentic import (
+    AgentPredictor,
+    ContinuousAgentForecastOutput,
+    build_adk_agent,
+)
+from aieng.forecasting.methods.agentic.agent_factory import (
+    AgentConfig,
+    CodeExecutionConfig,
+    ContextRetrievalConfig,
+)
+from aieng.forecasting.models import LITE_MODEL
+from pydantic import BaseModel
+
+
+# Skills live next to this module.
+_SKILLS_ROOT = Path(__file__).parent / "skills"
+_FORECASTING_SKILL = _SKILLS_ROOT / "forecasting"
+_RESEARCH_SKILL = _SKILLS_ROOT / "research-playbook"
+_CODE_ANALYSIS_SKILL = _SKILLS_ROOT / "code-analysis-playbook"
+
+
+# ---------------------------------------------------------------------------
+# Prompt builder (self-contained — this use case has no analyst_agent to reuse)
+# ---------------------------------------------------------------------------
+
+
+class Sp500StarterPromptBuilder(BaseModel):
+    """Serialise the target log-return series (+ optional covariate snapshot).
+
+    Minimal on purpose: the recent history of the cumulative-log-return target,
+    the task spec, the exact quantile grid, and — when ``covariate_series_ids``
+    are supplied and present in the context — the latest value of each covariate
+    as a leak-safe macro snapshot. Implements the
+    :class:`~aieng.forecasting.methods.agentic.predictor.ForecastPromptBuilder`
+    protocol structurally — extend it with richer covariate panels.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    history: int = 64
+    covariate_series_ids: list[str] = []
+
+    def __call__(self, *, task: ForecastingTask, context: ForecastContext) -> str:
+        df = context.get_series(task.target_series_id).tail(self.history)
+        rows = ["date,log_return"] + [
+            f"{pd.Timestamp(ts).date()},{float(v):.6f}" for ts, v in zip(df["timestamp"], df["value"])
+        ]
+
+        covariate_snapshot: dict[str, float] = {}
+        for cov_id in self.covariate_series_ids:
+            try:
+                cov_df = context.get_series(cov_id)
+            except Exception:  # noqa: BLE001 — a missing covariate just drops out of the snapshot
+                continue
+            if not cov_df.empty:
+                covariate_snapshot[cov_id] = round(float(cov_df["value"].iloc[-1]), 6)
+
+        payload: dict[str, Any] = {
+            "task": task.task_id,
+            "as_of": str(context.as_of)[:10],
+            "horizons": list(task.horizons),
+            "standard_quantiles": list(STANDARD_QUANTILES),
+            "target_summary": {
+                "last_log_return": float(df["value"].iloc[-1]),
+                "last_date": str(pd.Timestamp(df["timestamp"].iloc[-1]).date()),
+                "n_obs": int(len(df)),
+            },
+            "target_history_csv": "\n".join(rows),
+        }
+        if covariate_snapshot:
+            payload["covariate_snapshot"] = covariate_snapshot
+        return json.dumps(payload, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+
+def _build_starter_instruction() -> str:
+    """Build the task-agnostic, skill-agnostic starter persona.
+
+    Just the analyst's identity and how to behave — no output schema, no payload
+    contract, no skill or tool mechanics. ADK injects the name + description of
+    every attached skill (and every tool) into the system prompt, so the agent
+    already knows what it can load and call; repeating that here would only
+    duplicate dynamically-injected information. The forecasting *contract* lives
+    in the loadable ``forecasting`` skill. Edit the persona freely.
+    """
+    return (
+        "## Role\n\n"
+        "You are an equity-market analyst — fluent in the rate path and Fed "
+        "guidance, inflation and jobs data, volatility and credit conditions, "
+        "and how macro catalysts move the S&P 500. This is a starter agent: keep "
+        "your reasoning transparent and your claims honest, and remember returns "
+        "are close to a random walk.\n\n"
+        "## How to respond\n\n"
+        "- For open-ended questions, scenario analysis, or anything "
+        "conversational, answer directly and concisely — do NOT ask for a JSON "
+        "payload.\n"
+        "- When you are handed a task that asks for a structured probabilistic "
+        "forecast, produce a calibrated one."
+    )
+
+
+_STARTER_INSTRUCTION = _build_starter_instruction()
+
+
+_CONTEXT_RETRIEVAL_INSTRUCTION = """\
+You are an equity-market intelligence specialist with web search.
+
+Return a concise structured markdown summary (3-5 paragraphs) covering, as the
+query warrants: the rate path and Fed guidance; recent inflation and jobs data;
+the VIX and credit spreads; earnings-season tone; and major geopolitical or
+policy shocks.
+
+Ground every claim in the search results you actually retrieve. When a cutoff
+date is specified, never report or speculate about events after it.\
+"""
+
+
+# ---------------------------------------------------------------------------
+# Config factory
+# ---------------------------------------------------------------------------
+
+
+def build_starter_agent_config(
+    model: str = LITE_MODEL,
+    search_model: str = LITE_MODEL,
+    *,
+    enable_search: bool = True,
+    enable_code_exec: bool = False,
+) -> AgentConfig:
+    """Build the S&P 500 starter :class:`AgentConfig`.
+
+    Parameters
+    ----------
+    model : str
+        Model for the analyst agent (default: lite). Pass the advanced model
+        (``"gemini-3.5-flash"``) for higher-quality runs.
+    search_model : str
+        Model for the bounded web-search sub-tool.
+    enable_search : bool, default=True
+        Wire a cutoff-aware ``search_web`` tool and load the
+        ``research-playbook`` skill. Proxy-only — no extra API key.
+    enable_code_exec : bool, default=False
+        Wire an E2B Python sandbox and load the ``code-analysis-playbook``
+        skill. Needs ``E2B_API_KEY`` and is slower, so it is off by default.
+
+    Returns
+    -------
+    AgentConfig
+    """
+    # Every attached skill is loaded on demand: ADK injects each skill's name +
+    # description into the system prompt, and the agent reads the full SKILL.md
+    # only when relevant — so toggling a tool just adds its skill, no persona edits.
+    skills_dirs: list[Path] = [_FORECASTING_SKILL]
+    if enable_search:
+        skills_dirs.append(_RESEARCH_SKILL)
+    if enable_code_exec:
+        skills_dirs.append(_CODE_ANALYSIS_SKILL)
+
+    context_retrieval = (
+        ContextRetrievalConfig(
+            enabled=True,
+            instruction=_CONTEXT_RETRIEVAL_INSTRUCTION,
+            search_model=search_model,
+        )
+        if enable_search
+        else ContextRetrievalConfig()
+    )
+
+    return AgentConfig(
+        name="sp500_starter_agent",
+        model=model,
+        instruction=_STARTER_INSTRUCTION,
+        # 16k headroom: enough for a complete run_code script + structured output.
+        max_output_tokens=16_384 if enable_code_exec else None,
+        context_retrieval=context_retrieval,
+        code_execution=CodeExecutionConfig(enabled=enable_code_exec),
+        skills_dirs=skills_dirs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Predictor convenience factory
+# ---------------------------------------------------------------------------
+
+
+class _StarterForecastPromptBuilder:
+    """Add the output schema + a forecast directive to a base builder's payload.
+
+    The exact JSON schema is generated at call time from the output class
+    (drift-free) and injected into the user payload — never into the system
+    prompt — so the agent stays conversational until it is actually asked to
+    forecast. Implements the
+    :class:`~aieng.forecasting.methods.agentic.predictor.ForecastPromptBuilder`
+    protocol structurally.
+    """
+
+    def __init__(self, inner: Callable[..., str], output_schema_json: str) -> None:
+        self._inner = inner
+        self._schema_json = output_schema_json
+
+    def __call__(self, *, task: ForecastingTask, context: ForecastContext) -> str:
+        payload = json.loads(self._inner(task=task, context=context))
+        payload["instructions"] = (
+            "Produce a calibrated probabilistic forecast for this task and return it by "
+            "calling `set_model_response` with a `json_response` string matching "
+            "`output_schema` exactly."
+        )
+        payload["output_schema"] = self._schema_json
+        return json.dumps(payload, indent=2)
+
+
+def build_starter_agent_predictor(
+    config: AgentConfig,
+    *,
+    covariate_series_ids: list[str] | None = None,
+) -> AgentPredictor:
+    """Wrap a starter :class:`AgentConfig` in an :class:`AgentPredictor`.
+
+    Wraps :class:`Sp500StarterPromptBuilder` so the (drift-free) continuous
+    output schema and a forecast directive ride in the payload — keeping the
+    schema out of the persona. ``predict(task, context)`` returns one
+    :class:`~aieng.forecasting.evaluation.prediction.Prediction` for the task's
+    single horizon.
+
+    Parameters
+    ----------
+    config : AgentConfig
+        A config from :func:`build_starter_agent_config`.
+    covariate_series_ids : list[str] or None
+        Covariates to include as a leak-safe snapshot in the prompt. They must be
+        registered on the data service used to build the context. ``None`` keeps
+        the starter target-only.
+    """
+    return AgentPredictor(
+        agent_config=config,
+        prompt_builder=_StarterForecastPromptBuilder(
+            Sp500StarterPromptBuilder(covariate_series_ids=covariate_series_ids or []),
+            ContinuousAgentForecastOutput.prompt_schema_json(),
+        ),
+        output_schema=ContinuousAgentForecastOutput,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lazy root_agent for `adk web` interactive use
+# ---------------------------------------------------------------------------
+
+
+def __getattr__(name: str) -> Any:
+    """Expose ``root_agent`` lazily for schema-free interactive use via ``adk web``."""
+    if name == "root_agent":
+        return build_adk_agent(build_starter_agent_config())
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/implementations/sp500_forecasting/starter_agent/skills/code-analysis-playbook/SKILL.md
+++ b/implementations/sp500_forecasting/starter_agent/skills/code-analysis-playbook/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: code-analysis-playbook
+description: >-
+  How to use the code execution sandbox well — parse the JSON payload (not
+  disk files), compute a couple of useful diagnostics before forecasting, and
+  keep the session stateful within a turn. Load this before writing code. No
+  scripts.
+---
+
+# Code-analysis playbook
+
+A short guide to using the `run_code` sandbox productively. This is a starter
+skill — extend it with the diagnostics that matter for your problem.
+
+## Where your data lives
+
+All data comes from the **JSON payload in your context** — there are no disk
+files and no network. The history arrives as a CSV *string* (e.g.
+`target_history_csv`). Parse it with `io.StringIO`, never as a file path:
+
+```python
+import io, pandas as pd
+df = pd.read_csv(io.StringIO(payload["target_history_csv"]))
+```
+
+The sandbox is **stateful within a turn**: parse once in your first code block,
+then reuse the DataFrame in later blocks instead of re-parsing.
+
+## Compute before you forecast
+
+Run a couple of cheap diagnostics so your forecast is grounded in arithmetic,
+not vibes:
+
+1. **Recent trend** — slope/return over the last N observations.
+2. **Volatility** — recent standard deviation of changes; it sets how wide your
+   quantile bands should be.
+3. **Sanity check** — does your point forecast sit within a plausible multiple
+   of recent moves? If not, revisit it.
+
+Use the printed numbers to set the point forecast and to *calibrate the spread*
+between your low and high quantiles — wider when recent volatility is high.
+
+## Domain focus (edit this for your use case)
+
+For S&P 500 log-returns, the series is near-unforecastable in the mean: recent
+realised volatility is far more predictable than direction. Let recent vol, not a
+directional hunch, set the *width* of your quantile bands, and keep the point
+forecast close to zero unless you have real signal.
+
+## Room to grow
+
+- Add your own diagnostic patterns (regime detection, seasonality, covariates).
+- Drop reusable reference values into a `references/` file and `load_skill_resource` them.

--- a/implementations/sp500_forecasting/starter_agent/skills/forecasting/SKILL.md
+++ b/implementations/sp500_forecasting/starter_agent/skills/forecasting/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: forecasting
+description: >-
+  The output contract for producing a structured probabilistic forecast — the
+  JSON shape, the calibration and quantile rules, and how to submit it. Load
+  this ONLY when your task payload asks for a forecast; ignore it for
+  open-ended questions. No scripts.
+---
+
+# Forecasting skill
+
+Load this when your task payload asks for a structured forecast. For open-ended
+questions, ignore it and just answer.
+
+## What you'll receive
+
+A JSON payload describing the task: a `task` id, the `as_of` cutoff date,
+`horizons` (steps ahead), the `standard_quantiles` grid, a `target_summary`, the
+recent `target_history_csv`, and an `output_schema` showing the exact JSON to
+return.
+
+## The output contract
+
+1. Produce **one forecast per horizon** in `horizons`.
+2. Use **exactly** the levels in `standard_quantiles` — no additions or omissions.
+3. `point_forecast` must equal the **0.50 quantile** value.
+4. Quantile values must be **non-decreasing** as the quantile level rises.
+5. Use ONLY information available on or before `as_of`.
+6. Put your reasoning in the `rationale` fields.
+
+Submit by calling `set_model_response` with a `json_response` string that
+matches the payload's `output_schema` **exactly** — use `"horizon"` (an
+integer), and make `"quantiles"` a **list** of `{"quantile": <level>, "value":
+<number>}` objects. Omit any field not shown in the schema.
+
+## Calibration
+
+Report calibrated intervals, not false precision: across many forecasts where
+your 80% band is stated, the truth should land inside it about 80% of the time.
+Anchor the point on the recent level and trend; let recent **volatility** set
+how wide the bands are, and widen them as the horizon grows.
+
+## Domain focus (edit this for your use case)
+
+For S&P 500 log-returns, keep the point forecast near zero unless you have real
+signal — returns are close to a random walk. Let recent realised volatility set
+how WIDE the quantile bands are; it is far more predictable than direction. Note
+any macro catalyst you lean on in the rationale.
+
+## Room to grow
+
+- Tighten the calibration guidance with your own backtest findings.
+- Add worked examples of good vs. over-confident forecasts.

--- a/implementations/sp500_forecasting/starter_agent/skills/research-playbook/SKILL.md
+++ b/implementations/sp500_forecasting/starter_agent/skills/research-playbook/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: research-playbook
+description: >-
+  How to use the search_web tool well when grounding a forecast in recent
+  news — phrase cutoff-aware queries, decide what is worth searching for, and
+  weigh sources. Load this before your first search_web call. No scripts.
+---
+
+# Research playbook
+
+A short guide to getting real signal out of `search_web`. This is a starter
+skill — extend it with the queries and sources that work for your problem.
+
+## The one rule that matters
+
+Always pass `cutoff_date` equal to the `as_of` date in your payload. It is the
+temporal fence that keeps post-origin information out of a historical forecast.
+A forecast that "knew" what happened after `as_of` is not a forecast.
+
+## How to search
+
+- **Search before you forecast, not after.** Gather context first, then reason.
+- **One topic per query.** Several focused queries beat one broad one. Stop when
+  new queries stop returning new facts.
+- **Ask for the present state, not a prediction.** "current OPEC+ production
+  policy" returns facts; "will oil go up" returns noise.
+- **Weigh sources.** Prefer primary releases and major outlets; treat a single
+  blog or forum post as a lead to confirm, not a fact.
+
+## Domain focus (edit this for your use case)
+
+For S&P 500 returns, the signals: the rate path and Fed guidance, recent
+inflation and jobs prints, the VIX and credit spreads, earnings-season tone, and
+major geopolitical or policy shocks. Search for the *current state* of these,
+then remember returns are close to a random walk — be humble about direction.
+
+## Room to grow
+
+- Add a curated list of go-to sources for your domain.
+- Track which queries paid off and prune the ones that didn't.
+- Add a `references/` file with example high-signal searches.

--- a/planning-docs/roadmap.md
+++ b/planning-docs/roadmap.md
@@ -32,7 +32,7 @@ The agent backbone supports two modes:
 
 A common decomposition is a Gemini-backed **Context Retrieval Agent** for search grounding and source-aware context, and a provider-flexible **Analyst Agent** for reasoning, code execution, and synthesis.
 
-**LLM routing.** The Vector proxy (`proxy.vectorinstitute.ai`) does not support the Gemini-native search and code-execution features the agents use; keep those on direct Gemini sub-agents, and use the proxy for LLM Processes if adopted. See [`vector-llm-proxy.md`](vector-llm-proxy.md).
+**LLM routing.** Everything routes through the Vector proxy (`proxy.vectorinstitute.ai`) — there are no direct-Gemini sub-agents. Web search is a `search_web` tool backed by the proxy's `{"googleSearch": {}}` extension; code execution runs in an E2B sandbox (provider-independent); the analyst/reasoning model is auto-wrapped in `LiteLlm` pointing at the proxy. LLM Processes use the same proxy seam. See [`vector-llm-proxy.md`](vector-llm-proxy.md) for the full convention and the history of the proxy fixes that made this possible.
 
 ## Extension ideas
 
@@ -46,7 +46,7 @@ The repository is a foundation. Each reference implementation's README ends with
 
 ### Agent and analyst depth
 
-ADK skills reintroduction (see [`../docs/adk-skills-guide.md`](../docs/adk-skills-guide.md) for the design rules), richer E2B code-execution configs, prompt and context-formatting optimization, and Track 2 interactive analyst configurations per use case.
+Every domain implementation (S&P 500, food, energy, BoC) now ships a **`starter_agent/` module + `99_starter_agent.ipynb`** — a fresh, participant-owned agent template with toggleable proxy news search and E2B code execution, two lightweight tool-usage skills, an interactive (Track 2) cell, and one scored (Track 1) prediction. It is the canonical "build your own" entry point and doubles as a quick end-to-end smoke test of each use case's agent stack. Natural next steps from here: richer E2B code-execution configs, prompt and context-formatting optimization, and deeper Track 2 interactive analyst configurations per use case (see [`../docs/adk-skills-guide.md`](../docs/adk-skills-guide.md) for the skill design rules).
 
 ### Broaden coverage
 


### PR DESCRIPTION
## Why

Getting the repo ready to onboard new participants ahead of the Learn Days. Three gaps closed:

1. **No canonical order.** The reference implementations were enumerated inconsistently across docs, and the top-level README said they were "not meant to be worked in order" — but the Learn Days present them in a deliberate order.
2. **Starter agents weren't shipped.** Each domain implementation's `starter_agent/` module + `99_starter_agent.ipynb` (the "build your own" entry point) was untracked and unevenly presented.
3. **Thin hyperlinking / minor staleness** in the top-level README and per-implementation docs.

## What

**Canonical order** (matches the bootcamp progression: conventional numerical methods → LLM Processes → agents → agentic evaluation), with `getting_started` as #0:

| # | Implementation | Learn Day framing |
|---|---|---|
| 0 | `getting_started` | preflight / hello-world — *start here* |
| 1 | `sp500_forecasting` | conventional numerical methods (Day 1) |
| 2 | `food_price_forecasting` | LLM Processes / CFPR (Day 1) |
| 3 | `energy_oil_forecasting` | Analyst + Adaptive Agent (Day 1 pt 1 / Day 2 pt 2) |
| 4 | `boc_rate_decisions` | agentic evaluation (Day 2) |

- **Soft, docs-only ordering — no directory renames.** The use-case dirs are imported as top-level Python packages (`from boc_rate_decisions.data import ...`) across ~60 sites in `.py`, `.ipynb`, and tests; Python identifiers can't start with a digit, so numeric directory prefixes would break every import. The numbers live in the docs.
- **Top-level README:** reorder + number the implementations table, surface `getting_started` as a #0 "start here" callout, replace the "not meant to be worked in order" line with a recommended-order signpost, hyperlink the Documentation section.
- **`implementations/README.md`:** reorder the directory-layout block with index numbers in comments.
- **Per-implementation READMEs:** consistent "N of 4" navigation breadcrumb cross-linking the set; aligned starter-agent wording.
- **`roadmap.md`:** aligned the enumeration to the canonical order.
- **Shipped the starter agents:** committed `starter_agent/` (module + research / forecasting / code-analysis skills) and `99_starter_agent.ipynb` for each of sp500, food, energy, boc.

## Verification

- `make lint` — passes (added the existing `# noqa: F704, PLE1142` top-level-await convention to the new notebooks).
- Sanity import: `from sp500_forecasting.starter_agent.agent import build_starter_agent_config` — ok.

## Known follow-up (not in this PR)

- `energy_oil_forecasting/` has two `05_` notebooks (`05_adaptive_agent_training` + `05_forecast_tool_demo`). Left as-is here to avoid renaming notebooks (reintroduces the import/reference blast radius); worth a dedicated cleanup later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)