### PR TITLE
docs: fix freshness/correctness in implementation READMEs

### DIFF
--- a/implementations/boc_rate_decisions/README.md
+++ b/implementations/boc_rate_decisions/README.md
@@ -57,7 +57,7 @@ the overnight rate? Outcome is the direction of the change (any size).
 - **Horizon:** 28 days — the forecast date lands exactly on the
   announcement, and cutoff enforcement excludes everything after the
   origin.
-- **Eve diagnostic:** `boc_rate_direction_eve_{smoke,backtest}.yaml` keep
+- **Eve diagnostic:** `boc_rate_direction_eve_smoke.yaml` keeps
   the T−1 framing (task id `boc_rate_direction_next_meeting_eve`) for the
   lead-time comparison in notebook 02 — the RPS gap between T−28 and T−1
   separates anticipation from eve-of-decision market reading.
@@ -70,9 +70,10 @@ the overnight rate? Outcome is the direction of the change (any size).
 - **Binary view:** `boc_rate_cut_event` (0/1, 1 = cut) remains registered
   and the binary smoke/backtest specs are kept as the compact reference.
 
-**Excluded by design:** unscheduled (emergency) announcements — there has
-been exactly one since 2009 (March 27, 2020). It is recorded in the
-calendar file and used for validation, but no forecast origin targets it.
+**Excluded by design:** unscheduled (emergency) announcements — there have
+been exactly two since 2009 (March 13 and March 27, 2020, the COVID-19
+intermeeting cuts). They are recorded in the calendar file and used for
+validation, but no forecast origin targets them.
 
 ---
 

--- a/implementations/food_price_forecasting/README.md
+++ b/implementations/food_price_forecasting/README.md
@@ -104,9 +104,11 @@ implementations/food_price_forecasting/
 ├── plots.py       # plot_trajectory_fan, plot_avgyoy_grid,
 │                  # plot_crps_disaggregated, plot_mape_distribution,
 │                  # plot_food_cpi_small_multiples
+├── predictors/    # QuantileGridLLMPredictor, SampledTrajectoryLLMPredictor (report-grounded LLMP)
+├── smoke_report.py # summarize_agent_predictions() — plain-text agent smoke-test summary
 ├── starter_agent/  # fresh, hackable agent template (toggleable search/code-exec + skills)
-├── 01_food_data_exploration.ipynb # 9-cell warm-up tour of the 9 series
-├── 02_food_cpi_experiment.ipynb   # 26-cell narrative over the helpers above
+├── 01_food_data_exploration.ipynb # warm-up tour of the 9 series
+├── 02_food_cpi_experiment.ipynb   # narrative over the helpers above
 └── 99_starter_agent.ipynb         # ← start here to build your own agent
 ```
 
@@ -183,13 +185,14 @@ uv run python scripts/extract_reports.py
 - **Context-cost estimate:** `extract_reports.py` prints per-document and total
   char/token counts (token estimate ≈ chars/4, model-agnostic) so you can gauge
   the cost of putting one — or several — reports into a prompt.
-- **Deferred (a good participant extension):** wiring these extracted reports
-  into the food-CPI LLM-P prompt behind a cutoff-aware store is still a
-  follow-up — this pipeline only produces the extracted artifacts. The
-  ingredients now exist to do it: `extract_document` here, and BoC's
-  `PressReleaseStore` as the store pattern to mirror. Generalizes directly to
-  Bank of Canada Monetary Policy Reports via the same `--source`-keyed fetcher
-  and `extract_document`.
+- **Report-grounded LLMP (now wired):** `build_food_cpi_service(reports_dir=...)`
+  builds a cutoff-aware `DocumentStore`, and `02_food_cpi_experiment.ipynb`
+  passes `report_sources=["cfpr"]` to the LLM-P predictors so the extracted
+  reports enter the prompt filtered by `publication_date <= as_of`. Measure the
+  lift over the quantitative-only baseline. **Still a good extension:**
+  generalize the same `--source`-keyed fetcher + `extract_document` to Bank of
+  Canada Monetary Policy Reports, mirroring BoC's `PressReleaseStore` pattern
+  for additional document families.
 
 ---
 

--- a/implementations/getting_started/README.md
+++ b/implementations/getting_started/README.md
@@ -73,14 +73,14 @@ This registers all 47 Canada-wide CPI series from StatCan table
 
 ### 1. Warm up - `01_cpi_data_exploration.ipynb`
 
-Nine cells.  Registers three focus series (all-items, gasoline,
+Registers three focus series (all-items, gasoline,
 shelter), shows the cutoff-enforcement pattern, plots levels and
 year-over-year change, and constructs a `ForecastingTask` by hand so
 you can see what the YAML spec turns into.
 
 ### 2. Run the backtest - `02_cpi_backtest_demo.ipynb`
 
-Ten cells.  Walks through the full cycle:
+Walks through the full cycle:
 
 1. Load `specs/cpi_gasoline_1m.yaml` into a `BacktestSpec`.
 2. Construct a `LastValuePredictor` (the floor) and a


### PR DESCRIPTION
## Why

Pre-internal-testing freshness audit of the per-implementation READMEs, cross-checking each README's claims against the actual code, specs, and notebooks. Found a handful of stale or inaccurate statements (verified against ground truth, not just flagged).

## Fixes

**BoC** (`boc_rate_decisions/README.md`)
- **Factual error:** "exactly one" unscheduled emergency announcement → there are **two** (`2020-03-13` and `2020-03-27`, the COVID-19 intermeeting cuts), as `meeting_schedule.yaml` itself documents.
- **Stale spec ref:** `boc_rate_direction_eve_{smoke,backtest}.yaml` → only `boc_rate_direction_eve_smoke.yaml` exists after the 7→5 spec simplification (#138). The "Reference specs" list was already correct; this line was missed.

**Food** (`food_price_forecasting/README.md`)
- **Stale "Deferred" claim:** report-grounded LLMP was described as a follow-up, but it's **implemented and used** — `build_food_cpi_service(reports_dir=...)` builds a cutoff-aware `DocumentStore` and `02_food_cpi_experiment.ipynb` passes `report_sources=["cfpr"]`. Rewritten to reflect reality; reframed the genuine remaining extension (generalizing to BoC Monetary Policy Reports).
- **Module tree:** added missing `predictors/` and `smoke_report.py`.

**getting_started + food**
- Dropped brittle hard cell-counts ("Nine cells", "Ten cells", "26-cell") that no longer matched the notebooks (e.g. getting_started 01 is 15 cells, not nine). They add little and go stale on any edit.

## Audited clean (no changes)
- **sp500** and **energy** READMEs verified accurate against code/specs.
- The getting_started eval window "Jan 2025 – Mar 2026" is correct (the spec's `end: 2026-04-01` is an exclusive bound → last origin March 2026).
- Energy's two `05_` notebooks are presented transparently in separate table sections.

## Verification

Each fix checked directly against source: `meeting_schedule.yaml` (emergency dates), `specs/` listing (eve spec), `data.py` + notebook 02 (`reports_dir`/`report_sources`), on-disk dir contents (module tree), notebook JSON (cell counts). `make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)