### PR TITLE
docs: add FRED API key request instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A foundation for building, evaluating, and comparing forecasting systems — con
 
 The repository pairs a small, stable core library with a set of self-contained reference implementations. The library gives you cutoff-safe data handling, a single `Predictor` interface, and a backtest/evaluation harness. Each reference implementation is a worked example of a different forecasting problem and the techniques that suit it. Start from whichever one is closest to what you want to build.
 
-> **👉 First time here? Run the environment check.** After `uv sync` (see [Setup](#setup)), open `[implementations/getting_started/00_environment_check.ipynb](implementations/getting_started/00_environment_check.ipynb)` and run it top to bottom. It's a self-guided preflight that verifies every capability — proxy LLM inference, Langfuse, E2B code execution, StatCan/FRED data access, and an end-to-end mini backtest — and tells you exactly what to fix when something isn't set up. **Do this before anything else.**
+> **👉 First time here? Run the environment check.** After `uv sync` (see [Setup](#setup)), open [`implementations/getting_started/00_environment_check.ipynb`](implementations/getting_started/00_environment_check.ipynb) and run it top to bottom. It's a self-guided preflight that verifies every capability — proxy LLM inference, Langfuse, E2B code execution, StatCan/FRED data access, and an end-to-end mini backtest — and tells you exactly what to fix when something isn't set up. **Do this before anything else.**
 
 ## What's here
 
@@ -25,15 +25,15 @@ Every method can be used in one of two modes, and the distinction runs through t
 
 Each is independent and self-contained — pick the one that matches the problem you care about, and read that directory's `README.md` for the full walkthrough. They are numbered in a recommended order that mirrors the bootcamp progression — conventional numerical methods → LLM Processes → agents → agentic evaluation — but any one stands on its own, so jump straight to the problem you care about.
 
-**Start here → #0 `[getting_started/](implementations/getting_started/)`** — one CPI series, one month ahead. The smallest end-to-end loop: a `Predictor`, a `BacktestSpec` and `EvalSpec`, naive + AutoARIMA baselines, CRPS scoring. The place to learn the evaluation framework before picking a domain below.
+**Start here → #0 [`getting_started/`](implementations/getting_started/)** — one CPI series, one month ahead. The smallest end-to-end loop: a `Predictor`, a `BacktestSpec` and `EvalSpec`, naive + AutoARIMA baselines, CRPS scoring. The place to learn the evaluation framework before picking a domain below.
 
 
 | #   | Implementation                                                       | The problem                                                                     | Concepts & techniques it demonstrates                                                                                                                                                                                                                                                                       |
 | --- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | `[sp500_forecasting/](implementations/sp500_forecasting/)`           | S&P 500 returns under a macro/market covariate panel.                           | A head-to-head of conventional numerical methods (naive, ETS, Kalman, AutoARIMA, linear regression, LightGBM) plus a covariate-aware LLM-Process, all reading the same leak-safe covariate panel. Cumulative-return targets at 1/5/21-business-day horizons, CRPS + direction metrics, config-driven specs. |
-| 2   | `[food_price_forecasting/](implementations/food_price_forecasting/)` | A multivariate food-CPI trajectory, in the style of Canada's Food Price Report. | Nine correlated sub-indices, a 12-step trajectory, a domain metric (avg/avg YoY), baselines vs LLM-Process predictors, leakage-aware backtests, and cached artifacts for fast iteration.                                                                                                                    |
-| 3   | `[energy_oil_forecasting/](implementations/energy_oil_forecasting/)` | Daily WTI crude-oil price under regime-breaking news.                           | A capability progression — Prophet → LLM-Process → news-grounded agent → code-executing agent — plus an adaptive agent that learns a strategy from data and is scored before vs after. Continuous trajectories, a binary up-shock task, and interactive scenario analysis.                                  |
-| 4   | `[boc_rate_decisions/](implementations/boc_rate_decisions/)`         | Will the Bank of Canada cut, hold, or hike at its next meeting?                 | Discrete-event forecasting: ordered-categorical outcomes on an irregular calendar, RPS scoring and one-vs-rest calibration (instead of CRPS), a binary (Brier) special case, cutoff-aware document ingestion, and an LLM-as-judge that scores an agent's reasoning against the official rationale.          |
+| 1   | [`sp500_forecasting/`](implementations/sp500_forecasting/)           | S&P 500 returns under a macro/market covariate panel.                           | A head-to-head of conventional numerical methods (naive, ETS, Kalman, AutoARIMA, linear regression, LightGBM) plus a covariate-aware LLM-Process, all reading the same leak-safe covariate panel. Cumulative-return targets at 1/5/21-business-day horizons, CRPS + direction metrics, config-driven specs. |
+| 2   | [`food_price_forecasting/`](implementations/food_price_forecasting/) | A multivariate food-CPI trajectory, in the style of Canada's Food Price Report. | Nine correlated sub-indices, a 12-step trajectory, a domain metric (avg/avg YoY), baselines vs LLM-Process predictors, leakage-aware backtests, and cached artifacts for fast iteration.                                                                                                                    |
+| 3   | [`energy_oil_forecasting/`](implementations/energy_oil_forecasting/) | Daily WTI crude-oil price under regime-breaking news.                           | A capability progression — Prophet → LLM-Process → news-grounded agent → code-executing agent — plus an adaptive agent that learns a strategy from data and is scored before vs after. Continuous trajectories, a binary up-shock task, and interactive scenario analysis.                                  |
+| 4   | [`boc_rate_decisions/`](implementations/boc_rate_decisions/)         | Will the Bank of Canada cut, hold, or hike at its next meeting?                 | Discrete-event forecasting: ordered-categorical outcomes on an irregular calendar, RPS scoring and one-vs-rest calibration (instead of CRPS), a binary (Brier) special case, cutoff-aware document ingestion, and an LLM-as-judge that scores an agent's reasoning against the official rationale.          |
 
 
 **Not sure where to start building?** Each of the four domain implementations above ends with a `99_starter_agent.ipynb` — a fresh, hackable **starter agent** (a `starter_agent/` module) with toggleable news search and code execution, two lightweight tool-usage skills, an interactive cell, and one scored forecast. It's the consistent "continue from here" entry point for taking any reference use case in an agentic direction, and a quick end-to-end test of that use case's agent stack.
@@ -92,7 +92,7 @@ On Apple Silicon the dylib is typically under `/opt/homebrew/opt/libomp/lib/`; o
 
 ### Verify your environment first
 
-New to the project? Open `[implementations/getting_started/00_environment_check.ipynb](implementations/getting_started/00_environment_check.ipynb)` and run it top to bottom. It's a self-guided preflight that checks every major capability — proxy LLM inference, Langfuse, E2B code execution, StatCan/FRED data access, and a full end-to-end mini backtest — one cell at a time, and tells you exactly what to fix when something isn't set up (most often a missing or placeholder key in your `.env`). It's the fastest way to confirm setup before working through the reference implementations.
+New to the project? Open [`implementations/getting_started/00_environment_check.ipynb`](implementations/getting_started/00_environment_check.ipynb) and run it top to bottom. It's a self-guided preflight that checks every major capability — proxy LLM inference, Langfuse, E2B code execution, StatCan/FRED data access, and a full end-to-end mini backtest — one cell at a time, and tells you exactly what to fix when something isn't set up (most often a missing or placeholder key in your `.env`). It's the fastest way to confirm setup before working through the reference implementations.
 
 ### Populate the data cache
 
@@ -104,7 +104,7 @@ uv run python scripts/fetch_cpi.py
 
 ### Build the E2B sandbox image (agentic implementations only)
 
-Agentic forecasters can run code in an E2B cloud sandbox. Credentials for e2b should be automatically injected into the environment for bootcamp participants, and you can confirm successful setup by running `[00_environment_check.ipynb](implementations/getting_started/00_environment_check.ipynb)`.
+Agentic forecasters can run code in an E2B cloud sandbox. Credentials for e2b should be automatically injected into the environment for bootcamp participants, and you can confirm successful setup by running [`00_environment_check.ipynb`](implementations/getting_started/00_environment_check.ipynb).
 
 If this was unsuccessful, or if you prefer to run with E2B in an alternative environment, do this once before enabling code execution in `build_adk_agent`:
 
@@ -159,8 +159,8 @@ uv run pre-commit run --all-files
 
 ## Documentation
 
-- Per-implementation READMEs under `[implementations/](implementations/)` — the primary user surface.
-- `[aieng-forecasting/README.md](aieng-forecasting/README.md)` and `[aieng-forecasting/aieng/forecasting/methods/README.md](aieng-forecasting/aieng/forecasting/methods/README.md)` — the library and the method catalog.
-- `[planning-docs/roadmap.md](planning-docs/roadmap.md)` — architecture principles and extension ideas.
+- Per-implementation READMEs under [`implementations/`](implementations/) — the primary user surface.
+- [`aieng-forecasting/README.md`](aieng-forecasting/README.md) and [`aieng-forecasting/aieng/forecasting/methods/README.md`](aieng-forecasting/aieng/forecasting/methods/README.md) — the library and the method catalog.
+- [`planning-docs/roadmap.md`](planning-docs/roadmap.md) — architecture principles and extension ideas.
 
 Keep code, notebooks, specs, and these docs in sync when you change behavior, setup, layout, or datasets.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A foundation for building, evaluating, and comparing forecasting systems — con
 
 The repository pairs a small, stable core library with a set of self-contained reference implementations. The library gives you cutoff-safe data handling, a single `Predictor` interface, and a backtest/evaluation harness. Each reference implementation is a worked example of a different forecasting problem and the techniques that suit it. Start from whichever one is closest to what you want to build.
 
-> **👉 First time here? Run the environment check.** After `uv sync` (see [Setup](#setup)), open [`implementations/getting_started/00_environment_check.ipynb`](implementations/getting_started/00_environment_check.ipynb) and run it top to bottom. It's a self-guided preflight that verifies every capability — proxy LLM inference, Langfuse, E2B code execution, StatCan/FRED data access, and an end-to-end mini backtest — and tells you exactly what to fix when something isn't set up. **Do this before anything else.**
+> **👉 First time here? Run the environment check.** After `uv sync` (see [Setup](#setup)), open `[implementations/getting_started/00_environment_check.ipynb](implementations/getting_started/00_environment_check.ipynb)` and run it top to bottom. It's a self-guided preflight that verifies every capability — proxy LLM inference, Langfuse, E2B code execution, StatCan/FRED data access, and an end-to-end mini backtest — and tells you exactly what to fix when something isn't set up. **Do this before anything else.**
 
 ## What's here
 
@@ -25,15 +25,15 @@ Every method can be used in one of two modes, and the distinction runs through t
 
 Each is independent and self-contained — pick the one that matches the problem you care about, and read that directory's `README.md` for the full walkthrough. They are numbered in a recommended order that mirrors the bootcamp progression — conventional numerical methods → LLM Processes → agents → agentic evaluation — but any one stands on its own, so jump straight to the problem you care about.
 
-**Start here → #0 [`getting_started/`](implementations/getting_started/)** — one CPI series, one month ahead. The smallest end-to-end loop: a `Predictor`, a `BacktestSpec` and `EvalSpec`, naive + AutoARIMA baselines, CRPS scoring. The place to learn the evaluation framework before picking a domain below.
+**Start here → #0 `[getting_started/](implementations/getting_started/)`** — one CPI series, one month ahead. The smallest end-to-end loop: a `Predictor`, a `BacktestSpec` and `EvalSpec`, naive + AutoARIMA baselines, CRPS scoring. The place to learn the evaluation framework before picking a domain below.
 
 
 | #   | Implementation                                                       | The problem                                                                     | Concepts & techniques it demonstrates                                                                                                                                                                                                                                                                       |
 | --- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | [`sp500_forecasting/`](implementations/sp500_forecasting/)           | S&P 500 returns under a macro/market covariate panel.                           | A head-to-head of conventional numerical methods (naive, ETS, Kalman, AutoARIMA, linear regression, LightGBM) plus a covariate-aware LLM-Process, all reading the same leak-safe covariate panel. Cumulative-return targets at 1/5/21-business-day horizons, CRPS + direction metrics, config-driven specs. |
-| 2   | [`food_price_forecasting/`](implementations/food_price_forecasting/) | A multivariate food-CPI trajectory, in the style of Canada's Food Price Report. | Nine correlated sub-indices, a 12-step trajectory, a domain metric (avg/avg YoY), baselines vs LLM-Process predictors, leakage-aware backtests, and cached artifacts for fast iteration.                                                                                                                    |
-| 3   | [`energy_oil_forecasting/`](implementations/energy_oil_forecasting/) | Daily WTI crude-oil price under regime-breaking news.                           | A capability progression — Prophet → LLM-Process → news-grounded agent → code-executing agent — plus an adaptive agent that learns a strategy from data and is scored before vs after. Continuous trajectories, a binary up-shock task, and interactive scenario analysis.                                  |
-| 4   | [`boc_rate_decisions/`](implementations/boc_rate_decisions/)         | Will the Bank of Canada cut, hold, or hike at its next meeting?                 | Discrete-event forecasting: ordered-categorical outcomes on an irregular calendar, RPS scoring and one-vs-rest calibration (instead of CRPS), a binary (Brier) special case, cutoff-aware document ingestion, and an LLM-as-judge that scores an agent's reasoning against the official rationale.          |
+| 1   | `[sp500_forecasting/](implementations/sp500_forecasting/)`           | S&P 500 returns under a macro/market covariate panel.                           | A head-to-head of conventional numerical methods (naive, ETS, Kalman, AutoARIMA, linear regression, LightGBM) plus a covariate-aware LLM-Process, all reading the same leak-safe covariate panel. Cumulative-return targets at 1/5/21-business-day horizons, CRPS + direction metrics, config-driven specs. |
+| 2   | `[food_price_forecasting/](implementations/food_price_forecasting/)` | A multivariate food-CPI trajectory, in the style of Canada's Food Price Report. | Nine correlated sub-indices, a 12-step trajectory, a domain metric (avg/avg YoY), baselines vs LLM-Process predictors, leakage-aware backtests, and cached artifacts for fast iteration.                                                                                                                    |
+| 3   | `[energy_oil_forecasting/](implementations/energy_oil_forecasting/)` | Daily WTI crude-oil price under regime-breaking news.                           | A capability progression — Prophet → LLM-Process → news-grounded agent → code-executing agent — plus an adaptive agent that learns a strategy from data and is scored before vs after. Continuous trajectories, a binary up-shock task, and interactive scenario analysis.                                  |
+| 4   | `[boc_rate_decisions/](implementations/boc_rate_decisions/)`         | Will the Bank of Canada cut, hold, or hike at its next meeting?                 | Discrete-event forecasting: ordered-categorical outcomes on an irregular calendar, RPS scoring and one-vs-rest calibration (instead of CRPS), a binary (Brier) special case, cutoff-aware document ingestion, and an LLM-as-judge that scores an agent's reasoning against the official rationale.          |
 
 
 **Not sure where to start building?** Each of the four domain implementations above ends with a `99_starter_agent.ipynb` — a fresh, hackable **starter agent** (a `starter_agent/` module) with toggleable news search and code execution, two lightweight tool-usage skills, an interactive cell, and one scored forecast. It's the consistent "continue from here" entry point for taking any reference use case in an agentic direction, and a quick end-to-end test of that use case's agent stack.
@@ -45,6 +45,22 @@ Each is independent and self-contained — pick the one that matches the problem
 - **yfinance** — equities, indices, and commodity futures.
 
 Historical data is cached locally under `data/` and is not committed. Each implementation's README names the fetch script(s) it needs.
+
+### FRED API key
+
+Several reference implementations (S&P 500, BoC rate decisions) fetch data from the Federal Reserve Economic Data (FRED) API, which requires a free personal API key. **We cannot provide this key for you** — each participant must request their own at:
+
+> [https://fred.stlouisfed.org/docs/api/api_key.html](https://fred.stlouisfed.org/docs/api/api_key.html)
+
+FRED keys are free and approval is typically quick, but it can occasionally take some time, so request yours early. When asked for a use-case description, something extended from the following works well:
+
+> "Requesting an API key to explore the effectiveness of various forecasting techniques on economic data."
+
+Once you have the key, add it to your repo-root `.env`:
+
+```
+FRED_API_KEY=your_fred_api_key
+```
 
 ## Repository layout
 
@@ -76,7 +92,7 @@ On Apple Silicon the dylib is typically under `/opt/homebrew/opt/libomp/lib/`; o
 
 ### Verify your environment first
 
-New to the project? Open [`implementations/getting_started/00_environment_check.ipynb`](implementations/getting_started/00_environment_check.ipynb) and run it top to bottom. It's a self-guided preflight that checks every major capability — proxy LLM inference, Langfuse, E2B code execution, StatCan/FRED data access, and a full end-to-end mini backtest — one cell at a time, and tells you exactly what to fix when something isn't set up (most often a missing or placeholder key in your `.env`). It's the fastest way to confirm setup before working through the reference implementations.
+New to the project? Open `[implementations/getting_started/00_environment_check.ipynb](implementations/getting_started/00_environment_check.ipynb)` and run it top to bottom. It's a self-guided preflight that checks every major capability — proxy LLM inference, Langfuse, E2B code execution, StatCan/FRED data access, and a full end-to-end mini backtest — one cell at a time, and tells you exactly what to fix when something isn't set up (most often a missing or placeholder key in your `.env`). It's the fastest way to confirm setup before working through the reference implementations.
 
 ### Populate the data cache
 
@@ -88,7 +104,7 @@ uv run python scripts/fetch_cpi.py
 
 ### Build the E2B sandbox image (agentic implementations only)
 
-Agentic forecasters can run code in an E2B cloud sandbox. Credentials for e2b should be automatically injected into the environment for bootcamp participants, and you can confirm successful setup by running [`00_environment_check.ipynb`](implementations/getting_started/00_environment_check.ipynb).
+Agentic forecasters can run code in an E2B cloud sandbox. Credentials for e2b should be automatically injected into the environment for bootcamp participants, and you can confirm successful setup by running `[00_environment_check.ipynb](implementations/getting_started/00_environment_check.ipynb)`.
 
 If this was unsuccessful, or if you prefer to run with E2B in an alternative environment, do this once before enabling code execution in `build_adk_agent`:
 
@@ -143,8 +159,8 @@ uv run pre-commit run --all-files
 
 ## Documentation
 
-- Per-implementation READMEs under [`implementations/`](implementations/) — the primary user surface.
-- [`aieng-forecasting/README.md`](aieng-forecasting/README.md) and [`aieng-forecasting/aieng/forecasting/methods/README.md`](aieng-forecasting/aieng/forecasting/methods/README.md) — the library and the method catalog.
-- [`planning-docs/roadmap.md`](planning-docs/roadmap.md) — architecture principles and extension ideas.
+- Per-implementation READMEs under `[implementations/](implementations/)` — the primary user surface.
+- `[aieng-forecasting/README.md](aieng-forecasting/README.md)` and `[aieng-forecasting/aieng/forecasting/methods/README.md](aieng-forecasting/aieng/forecasting/methods/README.md)` — the library and the method catalog.
+- `[planning-docs/roadmap.md](planning-docs/roadmap.md)` — architecture principles and extension ideas.
 
 Keep code, notebooks, specs, and these docs in sync when you change behavior, setup, layout, or datasets.

--- a/implementations/boc_rate_decisions/README.md
+++ b/implementations/boc_rate_decisions/README.md
@@ -90,13 +90,20 @@ validation, but no forecast origin targets them.
 | Unemployment rate | FRED `LRUNTTTTCAM156S` | Labour-market pressure |
 | BoC rate-announcement press releases | Bank of Canada announcement pages (`scripts/fetch_boc_press_releases.py`) | One release per scheduled meeting, cached to `data/reports/boc_press_releases/`; served cutoff-aware by `PressReleaseStore` (only releases published on or before the origin are visible). Currently the published-rationale source for the reasoning-alignment evaluator; available as a context seam for the LLMP/agent predictors |
 
-Populate the cache once (`FRED_API_KEY` in `.env` needed for the
-unemployment covariate; the script degrades gracefully without it):
+Populate the cache once:
 
 ```bash
 uv run python scripts/fetch_boc.py                 # series: rate, 2yr yield, CPI, unemployment
 uv run python scripts/fetch_boc_press_releases.py  # press releases (for the rationale-alignment eval)
 ```
+
+`fetch_boc.py` uses the FRED API for the unemployment covariate (`FRED_API_KEY` in
+your repo-root `.env`); the script degrades gracefully without it, but the unemployment
+feature will be absent. FRED keys are free but must be requested individually —
+**we cannot provide one for you**. Request yours at
+https://fred.stlouisfed.org/docs/api/api_key.html (approval is usually quick, but
+allow some time). A description like "Requesting an API key to explore the
+effectiveness of various forecasting techniques on economic data." works well.
 
 **Cutoff discipline.** Monthly adapters carry *approximate* `released_at`
 stamps that are optimistic by roughly one month (the lag is measured from

--- a/implementations/getting_started/README.md
+++ b/implementations/getting_started/README.md
@@ -56,6 +56,15 @@ exactly what to fix. Most ❌ results are a missing or placeholder API key in th
 repo-root `.env`, so it's the fastest way to confirm your setup is complete
 before opening the notebooks below.
 
+The FRED check is optional for `getting_started` itself, but required by the
+S&P 500 reference implementation and useful for the BoC rate decisions one. FRED
+API keys are free but must be requested individually — **we cannot provide one
+for you**. Request yours early at https://fred.stlouisfed.org/docs/api/api_key.html
+(approval is usually quick but can take some time). A description like "Requesting
+an API key to explore the effectiveness of various forecasting techniques on
+economic data." works well. Once approved, add `FRED_API_KEY=your_key` to your
+`.env`.
+
 ### Populate the local data cache
 
 Populate the local data cache (the stats-can download is gitignored):

--- a/implementations/sp500_forecasting/README.md
+++ b/implementations/sp500_forecasting/README.md
@@ -199,6 +199,12 @@ uv run python scripts/fetch_sp500_market.py --refresh   # ^GSPC / ^VIX / ^IXIC (
 uv run python scripts/fetch_fred.py                     # macro covariates (FRED)
 ```
 
+`fetch_fred.py` requires a **FRED API key** in your repo-root `.env` (`FRED_API_KEY=...`).
+FRED keys are free but must be requested individually — **we cannot provide one for you**.
+Request yours at https://fred.stlouisfed.org/docs/api/api_key.html (approval is usually
+quick, but allow some time). A description like "Requesting an API key to explore the
+effectiveness of various forecasting techniques on economic data." works well.
+
 The `llmp_*` rows call the Vector proxy, so a populated repo-root `.env` (with
 `PROXY_BASE_URL` / `PROXY_API_KEY`) is required when those rows are enabled.
 


### PR DESCRIPTION
## Summary

- Adds a dedicated **FRED API key** subsection to the main README under "Time Series Data sources", explaining that participants must request their own free key, linking to the request page, and suggesting a use-case description
- Adds inline FRED key instructions to the **S&P 500** Prerequisites section (key is required to run `fetch_fred.py`)
- Adds inline FRED key instructions to the **BoC rate decisions** Data section (key is optional but unlocks the unemployment covariate)
- Adds a brief FRED key note to the **getting started** environment-check section (optional there, but needed for the implementations participants will move on to)

## Test plan

- [ ] Review all four changed READMEs render correctly on GitHub
- [ ] Confirm the FRED request URL resolves: https://fred.stlouisfed.org/docs/api/api_key.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)