### PR TITLE
fix: load .env without overriding shell env; trim .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,2 @@
-# In the Coder environment bootcamp keys (OPENAI_*, E2B_*, LANGFUSE_*) are injected
-# into your shell environment — do NOT copy those into .env on Coder workspaces.
-# Optional personal keys (e.g. FRED_API_KEY) still need to be set in .env.
-
-# E2B Code Execution Service
-E2B_API_KEY=your_e2b_api_key
-
-# Vector LLM Proxy Service
-OPENAI_BASE_URL=https://proxy.vectorinstitute.ai/v1
-OPENAI_API_KEY=your_api_key
-
-# Langfuse — required for trace logging in playground/news_search and misalignment_qa
-LANGFUSE_PUBLIC_KEY=pk-lf-...
-LANGFUSE_SECRET_KEY=sk-lf-...
-LANGFUSE_HOST=https://us.cloud.langfuse.com
-
 # Optional keys
 FRED_API_KEY=your_fred_api_key  # You need to request this from FRED if you want to use it

--- a/implementations/boc_rate_decisions/02_boc_rate_direction_experiment.ipynb
+++ b/implementations/boc_rate_decisions/02_boc_rate_direction_experiment.ipynb
@@ -135,7 +135,7 @@
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "ROOT = Path.cwd().resolve().parents[1]\n",
-    "load_dotenv(ROOT / \".env\")\n",
+    "load_dotenv(ROOT / \".env\", override=False)\n",
     "\n",
     "from aieng.forecasting.evaluation import BacktestSpec, cached_backtest, describe_spec\n",
     "from boc_rate_decisions.analysis import (\n",

--- a/implementations/boc_rate_decisions/03_rationale_alignment.ipynb
+++ b/implementations/boc_rate_decisions/03_rationale_alignment.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "warnings.filterwarnings(\"ignore\")\n",
     "ROOT = Path.cwd().resolve().parents[1]\n",
-    "load_dotenv(ROOT / \".env\")\n",
+    "load_dotenv(ROOT / \".env\", override=False)\n",
     "\n",
     "from aieng.forecasting.evaluation import EvalSpec, evaluate\n",
     "from boc_rate_decisions.data import DIRECTION_SERIES_ID, build_boc_service\n",

--- a/implementations/boc_rate_decisions/99_starter_agent.ipynb
+++ b/implementations/boc_rate_decisions/99_starter_agent.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "# Repo root holds the .env with PROXY_* creds the agent needs.\n",
     "ROOT = Path.cwd().resolve().parents[1]\n",
-    "load_dotenv(ROOT / \".env\")\n",
+    "load_dotenv(ROOT / \".env\", override=False)\n",
     "\n",
     "# ── Model selection ───────────────────────────────────\n",
     "# Two project models: \"gemini-3.1-flash-lite-preview\" (lite/default) and\n",

--- a/implementations/energy_oil_forecasting/99_starter_agent.ipynb
+++ b/implementations/energy_oil_forecasting/99_starter_agent.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "# Repo root holds the .env with PROXY_* creds the agent needs.\n",
     "ROOT = Path.cwd().resolve().parents[1]\n",
-    "load_dotenv(ROOT / \".env\")\n",
+    "load_dotenv(ROOT / \".env\", override=False)\n",
     "\n",
     "# ── Model selection ───────────────────────────────────\n",
     "# Two project models: \"gemini-3.1-flash-lite-preview\" (lite/default) and\n",

--- a/implementations/food_price_forecasting/02_food_cpi_experiment.ipynb
+++ b/implementations/food_price_forecasting/02_food_cpi_experiment.ipynb
@@ -99,7 +99,7 @@
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "ROOT = Path.cwd().resolve().parents[1]\n",
-    "load_dotenv(ROOT / \".env\")\n",
+    "load_dotenv(ROOT / \".env\", override=False)\n",
     "\n",
     "import importlib\n",
     "\n",

--- a/implementations/food_price_forecasting/99_starter_agent.ipynb
+++ b/implementations/food_price_forecasting/99_starter_agent.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "# Repo root holds the .env with PROXY_* creds the agent needs.\n",
     "ROOT = Path.cwd().resolve().parents[1]\n",
-    "load_dotenv(ROOT / \".env\")\n",
+    "load_dotenv(ROOT / \".env\", override=False)\n",
     "\n",
     "# ── Model selection ───────────────────────────────────\n",
     "# Two project models: \"gemini-3.1-flash-lite-preview\" (lite/default) and\n",

--- a/implementations/sp500_forecasting/01_sp500_multivariate_backtest.ipynb
+++ b/implementations/sp500_forecasting/01_sp500_multivariate_backtest.ipynb
@@ -159,7 +159,7 @@
     "\n",
     "\n",
     "ROOT = _repo_root()\n",
-    "load_dotenv(ROOT / \".env\")  # LLMP rows call the Vector proxy — need PROXY_* set\n",
+    "load_dotenv(ROOT / \".env\", override=False)  # LLMP rows call the Vector proxy — need PROXY_* set\n",
     "\n",
     "from aieng.forecasting.evaluation import (\n",
     "    MultiTargetBacktestSpec,\n",

--- a/implementations/sp500_forecasting/99_starter_agent.ipynb
+++ b/implementations/sp500_forecasting/99_starter_agent.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "# Repo root holds the .env with PROXY_* creds the agent needs.\n",
     "ROOT = Path.cwd().resolve().parents[1]\n",
-    "load_dotenv(ROOT / \".env\")\n",
+    "load_dotenv(ROOT / \".env\", override=False)\n",
     "\n",
     "# ── Model selection ───────────────────────────────────\n",
     "# Two project models: \"gemini-3.1-flash-lite-preview\" (lite/default) and\n",

--- a/implementations/sp500_forecasting/data.py
+++ b/implementations/sp500_forecasting/data.py
@@ -78,7 +78,7 @@ def _load_fred_dotenv() -> None:
     root = _repo_root()
     if root is None:
         return
-    _load_dotenv(root / ".env")
+    _load_dotenv(root / ".env", override=False)
 
 
 def _as_absolute_cache(path: Path | None) -> Path | None:

--- a/playground/energy_case_study/notebooks/02_energy_agentic_forecasting.ipynb
+++ b/playground/energy_case_study/notebooks/02_energy_agentic_forecasting.ipynb
@@ -68,7 +68,7 @@
     "    if p not in sys.path:\n",
     "        sys.path.insert(0, p)\n",
     "\n",
-    "load_dotenv(REPO_ROOT / \".env\")\n",
+    "load_dotenv(REPO_ROOT / \".env\", override=False)\n",
     "\n",
     "# ── Colour palette ────────────────────────────────────────────────────────\n",
     "CLR_ACTUAL = \"#2171b5\"  # blue  — truth\n",

--- a/playground/news_search/run.py
+++ b/playground/news_search/run.py
@@ -75,7 +75,7 @@ def main() -> None:
 
     # Load .env from repo root (two levels up from this file).
     repo_root_env = Path(__file__).resolve().parents[2] / ".env"
-    load_dotenv(repo_root_env, verbose=False)
+    load_dotenv(repo_root_env, override=False, verbose=False)
 
     config = _load_config(args.config, args.max_dates, args.stride)
 

--- a/playground/proxy_tests/run_matrix.py
+++ b/playground/proxy_tests/run_matrix.py
@@ -70,7 +70,7 @@ sys.path.insert(0, str(REPO_ROOT / "aieng-forecasting"))
 from dotenv import load_dotenv  # noqa: E402
 
 
-load_dotenv(REPO_ROOT / ".env")
+load_dotenv(REPO_ROOT / ".env", override=False)
 
 OPENAI_BASE_URL = os.environ.get("OPENAI_BASE_URL", "https://proxy.vectorinstitute.ai/v1")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")

--- a/playground/proxy_tests/run_tests.py
+++ b/playground/proxy_tests/run_tests.py
@@ -42,7 +42,7 @@ sys.path.insert(0, str(REPO_ROOT / "aieng-forecasting"))
 from dotenv import load_dotenv  # noqa: E402
 
 
-load_dotenv(REPO_ROOT / ".env")
+load_dotenv(REPO_ROOT / ".env", override=False)
 
 OPENAI_BASE_URL = "https://proxy.vectorinstitute.ai/v1"
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")

--- a/playground/proxy_tests/test_pdf_file_format.py
+++ b/playground/proxy_tests/test_pdf_file_format.py
@@ -31,7 +31,7 @@ sys.path.insert(0, str(REPO_ROOT / "aieng-forecasting"))
 from dotenv import load_dotenv
 
 
-load_dotenv(REPO_ROOT / ".env")
+load_dotenv(REPO_ROOT / ".env", override=False)
 
 from aieng.forecasting.models import ADVANCED_MODEL, LITE_MODEL
 

--- a/playground/proxy_tests/test_pdf_native_blocks.py
+++ b/playground/proxy_tests/test_pdf_native_blocks.py
@@ -22,7 +22,7 @@ from dotenv import load_dotenv
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-load_dotenv(REPO_ROOT / ".env")
+load_dotenv(REPO_ROOT / ".env", override=False)
 
 BASE = os.environ.get("OPENAI_BASE_URL", "https://proxy.vectorinstitute.ai/v1")
 KEY = os.environ.get("OPENAI_API_KEY", "")

--- a/playground/proxy_tests/test_pdf_raw_http.py
+++ b/playground/proxy_tests/test_pdf_raw_http.py
@@ -22,7 +22,7 @@ from dotenv import load_dotenv
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-load_dotenv(REPO_ROOT / ".env")
+load_dotenv(REPO_ROOT / ".env", override=False)
 
 BASE = os.environ.get("OPENAI_BASE_URL", "https://proxy.vectorinstitute.ai/v1")
 KEY = os.environ.get("OPENAI_API_KEY", "")

--- a/playground/proxy_tests/test_pdf_routing.py
+++ b/playground/proxy_tests/test_pdf_routing.py
@@ -25,7 +25,7 @@ from dotenv import load_dotenv
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-load_dotenv(REPO_ROOT / ".env")
+load_dotenv(REPO_ROOT / ".env", override=False)
 
 BASE = os.environ.get("OPENAI_BASE_URL", "https://proxy.vectorinstitute.ai/v1")
 KEY = os.environ.get("OPENAI_API_KEY", "")

--- a/playground/proxy_tests/test_pdf_upload.py
+++ b/playground/proxy_tests/test_pdf_upload.py
@@ -37,7 +37,7 @@ from aieng.forecasting.models import ADVANCED_MODEL, LITE_MODEL
 from dotenv import load_dotenv
 
 
-load_dotenv(REPO_ROOT / ".env")
+load_dotenv(REPO_ROOT / ".env", override=False)
 
 # Bootstrap LiteLLM + Langfuse callbacks so each proxy call gets a span in the UI.
 bootstrap_litellm()

--- a/scripts/build_e2b_template.py
+++ b/scripts/build_e2b_template.py
@@ -60,7 +60,7 @@ template = _builder.set_workdir("/home/user/workspace").set_start_cmd(
 
 async def main() -> None:
     # load E2B_API_KEY
-    dotenv.load_dotenv()
+    dotenv.load_dotenv(override=False)
     # Fail hard if E2B_API_KEY is not set
     if not dotenv.get_key(".env", "E2B_API_KEY"):
         raise ValueError("E2B_API_KEY is not set")

--- a/scripts/cache_wti_curriculum_news.py
+++ b/scripts/cache_wti_curriculum_news.py
@@ -53,7 +53,7 @@ sys.path.insert(0, str(_REPO_ROOT / "aieng-forecasting"))
 try:
     from dotenv import load_dotenv
 
-    load_dotenv(_REPO_ROOT / ".env")
+    load_dotenv(_REPO_ROOT / ".env", override=False)
 except ImportError:
     pass
 

--- a/scripts/fetch_boc.py
+++ b/scripts/fetch_boc.py
@@ -39,7 +39,7 @@ sys.path.insert(0, str(REPO_ROOT / "implementations"))
 from dotenv import load_dotenv
 
 
-load_dotenv(REPO_ROOT / ".env")
+load_dotenv(REPO_ROOT / ".env", override=False)
 
 from datetime import datetime, timezone
 

--- a/scripts/fetch_fred.py
+++ b/scripts/fetch_fred.py
@@ -33,7 +33,7 @@ sys.path.insert(0, str(REPO_ROOT))
 from dotenv import load_dotenv
 
 
-load_dotenv(REPO_ROOT / ".env")
+load_dotenv(REPO_ROOT / ".env", override=False)
 
 from aieng.forecasting.data import DataService, SeriesMetadata
 from aieng.forecasting.data.adapters import FREDAdapter


### PR DESCRIPTION
Set override=False on every load_dotenv call so injected workspace credentials win over repo-root .env, and limit .env.example to optional personal keys (FRED) now that bootcamp secrets live in the shell.
