### PR TITLE
fix: enforce search_web's cutoff date from the harness, not the LLM

### DIFF
--- a/aieng-forecasting/aieng/forecasting/methods/agentic/adk_runner.py
+++ b/aieng-forecasting/aieng/forecasting/methods/agentic/adk_runner.py
@@ -182,7 +182,13 @@ class AdkTextRunner:
         """Underlying ADK runner (session, artifact, memory services)."""
         return self._runner
 
-    async def _resolve_session_id(self, user_id: str | None, session_id: str | None) -> str:
+    async def _resolve_session_id(
+        self,
+        user_id: str | None,
+        session_id: str | None,
+        *,
+        initial_state: dict[str, Any] | None = None,
+    ) -> str:
         """Return the ADK session id to use for a single turn.
 
         Parameters
@@ -192,6 +198,11 @@ class AdkTextRunner:
         session_id : str or None
             Explicit session id from the caller.  ``None`` triggers sticky-session
             lookup or new-session creation depending on ``fresh_session_per_message``.
+        initial_state : dict[str, Any] or None
+            Seeded into a newly-created session's state. Only takes effect when
+            this call actually creates a session — has no effect when an
+            existing sticky session (``fresh_session_per_message=False``) is
+            reused, since session state can only be seeded at creation.
 
         Returns
         -------
@@ -205,6 +216,7 @@ class AdkTextRunner:
             new_session = await self._runner.session_service.create_session(
                 app_name=self.config.app_name,
                 user_id=user_id,
+                state=initial_state,
             )
             sid = new_session.id
         elif session_id is not None:
@@ -216,6 +228,7 @@ class AdkTextRunner:
             new_session = await self._runner.session_service.create_session(
                 app_name=self.config.app_name,
                 user_id=user_id,
+                state=initial_state,
             )
             sid = new_session.id
             self._conversation_session_by_user[user_id] = sid
@@ -229,6 +242,7 @@ class AdkTextRunner:
         user_id: str | None = None,
         session_id: str | None = None,
         run_config: RunConfig | None = None,
+        initial_state: dict[str, Any] | None = None,
     ) -> str:
         """Run one user turn; return the first final model text or an empty string.
 
@@ -247,6 +261,12 @@ class AdkTextRunner:
         run_config : RunConfig | None, optional
             The run configuration to use for the run. If not provided, the default
             run configuration is used.
+        initial_state : dict[str, Any] | None, optional
+            Seeded into the session's state when this call creates a new
+            session (see :meth:`_resolve_session_id`). Use this to pass
+            harness-controlled values (e.g. a forecast's ``as_of`` date) that
+            tools can read via ``ToolContext.state`` without the LLM being
+            able to see or influence them.
 
         Returns
         -------
@@ -270,7 +290,7 @@ class AdkTextRunner:
 
         user_id = user_id or self.config.default_user_id
 
-        session_id = await self._resolve_session_id(user_id, session_id)
+        session_id = await self._resolve_session_id(user_id, session_id, initial_state=initial_state)
 
         content = genai_types.Content(role="user", parts=[genai_types.Part(text=prompt)])
 

--- a/aieng-forecasting/aieng/forecasting/methods/agentic/agent_factory.py
+++ b/aieng-forecasting/aieng/forecasting/methods/agentic/agent_factory.py
@@ -79,6 +79,13 @@ except ModuleNotFoundError as exc:
 # final text, giving the predictor the structured JSON it expects.
 SMR_STATE_KEY = "__smr_output__"
 
+# Session-state key AgentPredictor seeds with the current prediction's as_of
+# date before each run (see AdkTextRunner.run_text_async's initial_state).
+# search_web reads this via its ADK-injected ToolContext as the authoritative
+# cutoff — unlike the LLM-supplied cutoff_date argument, the model can never
+# see or influence this key, so it can't be silently omitted or spoofed.
+AS_OF_STATE_KEY = "__as_of__"
+
 
 def _build_set_model_response_tool() -> FunctionTool:
     """Return a proxy-compatible ``set_model_response`` shim.
@@ -390,7 +397,7 @@ def _build_search_tool(
         ]
         return content, sources
 
-    async def search_web(query: str, cutoff_date: str | None = None) -> str:
+    async def search_web(query: str, cutoff_date: str | None = None, tool_context: ToolContext | None = None) -> str:
         """Search the web and return a grounded summary with source URLs.
 
         Args:
@@ -404,22 +411,45 @@ def _build_search_tool(
             When cutoff verification is enabled and cannot be satisfied
             within the attempt budget, returns a ``[SEARCH_VERIFICATION_FAILED]``
             sentinel instead of unverified content.
+
+        Notes
+        -----
+        ``tool_context`` is not part of the LLM-visible tool schema — ADK
+        injects it automatically because of its type annotation. When
+        :class:`AgentPredictor` runs this tool, it has already seeded the
+        session with the current prediction's ``as_of`` date under
+        :data:`AS_OF_STATE_KEY`; that harness-controlled value is the
+        authoritative cutoff whenever present, since (unlike ``cutoff_date``)
+        the calling LLM cannot see, omit, or alter it. This closes a bypass
+        where the model simply didn't pass ``cutoff_date`` and both the soft
+        cutoff instruction and the verifier below were silently skipped.
         """
-        needs_verification = bool(cutoff_date and config.enforce_cutoff)
+        harness_as_of = tool_context.state.get(AS_OF_STATE_KEY) if tool_context is not None else None
+        if harness_as_of and cutoff_date and harness_as_of != cutoff_date:
+            logger.warning(
+                "search_web: cutoff_date=%r disagrees with harness as_of=%r; using the harness value.",
+                cutoff_date,
+                harness_as_of,
+            )
+        effective_cutoff = harness_as_of or cutoff_date
+
+        needs_verification = bool(effective_cutoff and config.enforce_cutoff)
         if not needs_verification:
             content, sources = await _do_search(query)
             return _format_result(content, sources)
 
         negative_guidance = ""
         for attempt in range(1, config.verifier_max_attempts + 1):
-            user_content = query + f"\n\nOnly include and cite information published strictly before {cutoff_date}."
+            user_content = (
+                query + f"\n\nOnly include and cite information published strictly before {effective_cutoff}."
+            )
             if negative_guidance:
                 user_content += f"\n\n{negative_guidance}"
             content, sources = await _do_search(user_content)
             verdict = await _verify_no_leakage(
                 text=content,
                 query=query,
-                cutoff_date=cutoff_date,  # type: ignore[arg-type]
+                cutoff_date=effective_cutoff,  # type: ignore[arg-type]
                 verifier_model=config.verifier_model,
                 openai_base_url=openai_base_url,
                 openai_api_key=openai_api_key,
@@ -437,14 +467,14 @@ def _build_search_tool(
             logger.warning("search_web attempt %d flagged %d claim(s); retrying.", attempt, len(verdict.flagged_claims))
             negative_guidance = (
                 f"Your previous search result may have included information published on or after "
-                f"{cutoff_date}. Do not repeat or rely on these claims:\n- "
+                f"{effective_cutoff}. Do not repeat or rely on these claims:\n- "
                 + "\n- ".join(verdict.flagged_claims or ["(unspecified — be more conservative)"])
             )
 
         logger.error("search_web exhausted %d attempts without a verified clean result.", config.verifier_max_attempts)
         return (
             f"[SEARCH_VERIFICATION_FAILED] Could not verify search results as free of information "
-            f"published on or after {cutoff_date} after {config.verifier_max_attempts} attempts. "
+            f"published on or after {effective_cutoff} after {config.verifier_max_attempts} attempts. "
             "Treat this as no verified news context being available for this query."
         )
 

--- a/aieng-forecasting/aieng/forecasting/methods/agentic/predictor.py
+++ b/aieng-forecasting/aieng/forecasting/methods/agentic/predictor.py
@@ -29,7 +29,7 @@ from aieng.forecasting.evaluation.prediction import Prediction
 from aieng.forecasting.evaluation.predictor import Predictor
 from aieng.forecasting.evaluation.task import ForecastingTask
 from aieng.forecasting.methods.agentic.adk_runner import AdkTextRunner, AdkTextRunnerConfig
-from aieng.forecasting.methods.agentic.agent_factory import AgentConfig, build_adk_agent
+from aieng.forecasting.methods.agentic.agent_factory import AS_OF_STATE_KEY, AgentConfig, build_adk_agent
 from aieng.forecasting.methods.agentic.outputs import AgentForecastOutput
 from aieng.forecasting.methods.llm_processes._client import strip_markdown_fence, trace_url_for
 from google.adk.agents.base_agent import BaseAgent
@@ -277,7 +277,11 @@ class AgentPredictor(Predictor):
             validation errors on the agent's JSON are not swallowed.
         """
         prompt = self.prompt_builder(task=task, context=context)
-        output_str = _run_coroutine_sync(self._runner.run_text_async(prompt))
+        # Seed the harness-controlled as_of into the ADK session before the run,
+        # so search_web can enforce it via ToolContext.state regardless of
+        # whether the LLM remembers to pass a matching cutoff_date argument.
+        initial_state = {AS_OF_STATE_KEY: str(context.as_of)[:10]}
+        output_str = _run_coroutine_sync(self._runner.run_text_async(prompt, initial_state=initial_state))
 
         # Normalise: strip markdown fences before validation so any model can
         # be swapped in without breaking the parse layer.

--- a/aieng-forecasting/tests/aieng/forecasting/methods/agentic/test_adk_runner.py
+++ b/aieng-forecasting/tests/aieng/forecasting/methods/agentic/test_adk_runner.py
@@ -147,6 +147,37 @@ class TestFreshSessionMode:
 
         assert patch_runner_cls.run_async.call_args.kwargs["session_id"] == "fresh-sid"
 
+    async def test_initial_state_passed_through_to_create_session(self, patch_runner_cls, mock_agent) -> None:
+        """initial_state reaches session_service.create_session's state kwarg.
+
+        This is what lets AgentPredictor seed a harness-controlled as_of value
+        that search_web can enforce via ToolContext.state, regardless of
+        whether the LLM remembers to pass a matching cutoff_date argument.
+        """
+        patch_runner_cls.session_service.create_session.return_value = _session("s1")
+        patch_runner_cls.run_async.return_value = _stream(_final_event("ok"))
+        runner = AdkTextRunner(
+            mock_agent,
+            config=AdkTextRunnerConfig(app_name="app", fresh_session_per_message=True),
+        )
+
+        await runner.run_text_async("hello", user_id="alice", initial_state={"__as_of__": "2024-01-15"})
+
+        assert patch_runner_cls.session_service.create_session.call_args.kwargs["state"] == {"__as_of__": "2024-01-15"}
+
+    async def test_no_initial_state_passes_none_to_create_session(self, patch_runner_cls, mock_agent) -> None:
+        """Omitting initial_state passes state=None (unchanged default behavior)."""
+        patch_runner_cls.session_service.create_session.return_value = _session("s1")
+        patch_runner_cls.run_async.return_value = _stream(_final_event("ok"))
+        runner = AdkTextRunner(
+            mock_agent,
+            config=AdkTextRunnerConfig(app_name="app", fresh_session_per_message=True),
+        )
+
+        await runner.run_text_async("hello", user_id="alice")
+
+        assert patch_runner_cls.session_service.create_session.call_args.kwargs["state"] is None
+
 
 # ---------------------------------------------------------------------------
 # Session resolution — fresh_session_per_message=False (sticky)

--- a/aieng-forecasting/tests/aieng/forecasting/methods/agentic/test_agent_factory.py
+++ b/aieng-forecasting/tests/aieng/forecasting/methods/agentic/test_agent_factory.py
@@ -2,11 +2,14 @@
 
 import inspect
 import json
+import logging
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aieng.forecasting.methods.agentic.agent_factory import (
+    AS_OF_STATE_KEY,
     AgentConfig,
     CodeExecutionConfig,
     ContextRetrievalConfig,
@@ -264,6 +267,8 @@ class TestBuildSearchTool:
         assert "query" in sig.parameters
         assert "cutoff_date" in sig.parameters
         assert sig.parameters["cutoff_date"].default is None
+        assert "tool_context" in sig.parameters
+        assert sig.parameters["tool_context"].default is None
 
     @pytest.mark.asyncio
     async def test_cutoff_date_appended_when_enforce_cutoff_true(self) -> None:
@@ -559,3 +564,73 @@ class TestSearchToolLeakageVerification:
 
         assert len(calls) == config.verifier_max_attempts * 2
         assert result.startswith("[SEARCH_VERIFICATION_FAILED]")
+
+    @pytest.mark.asyncio
+    async def test_harness_as_of_triggers_verification_even_without_cutoff_date(self) -> None:
+        """Verification runs from harness as_of alone when the LLM omits cutoff_date.
+
+        This is the production bypass this fix closes: 11 of 14 search_web
+        calls in a real trace omitted cutoff_date, silently skipping the guard.
+        """
+        config = ContextRetrievalConfig(enabled=True, instruction="Search assistant.")
+        tool = _build_search_tool(config, openai_base_url="https://proxy.example.com/v1", openai_api_key="test-key")
+        fake_tool_context = SimpleNamespace(state={AS_OF_STATE_KEY: "2024-01-15"})
+        calls: list[dict] = []
+
+        async def _fake_acompletion(**kwargs):  # type: ignore[override]
+            calls.append(kwargs)
+            if kwargs["model"] == f"openai/{config.verifier_model}":
+                return self._verify_response(clean=True, confidence=9, filtered_text="Clean summary.")
+            return self._search_response("Raw summary with a source.")
+
+        with patch("litellm.acompletion", new=AsyncMock(side_effect=_fake_acompletion)):
+            result = await tool(query="WTI price", cutoff_date=None, tool_context=fake_tool_context)
+
+        assert len(calls) == 2
+        assert result == "Clean summary."
+        search_user_msg = next(m for m in calls[0]["messages"] if m["role"] == "user")
+        assert "2024-01-15" in search_user_msg["content"]
+
+    @pytest.mark.asyncio
+    async def test_harness_as_of_overrides_disagreeing_cutoff_date(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The harness as_of wins over a disagreeing cutoff_date, and logs a warning."""
+        config = ContextRetrievalConfig(enabled=True, instruction="Search assistant.")
+        tool = _build_search_tool(config, openai_base_url="https://proxy.example.com/v1", openai_api_key="test-key")
+        fake_tool_context = SimpleNamespace(state={AS_OF_STATE_KEY: "2024-01-15"})
+        calls: list[dict] = []
+
+        async def _fake_acompletion(**kwargs):  # type: ignore[override]
+            calls.append(kwargs)
+            if kwargs["model"] == f"openai/{config.verifier_model}":
+                return self._verify_response(clean=True, confidence=9, filtered_text="Clean summary.")
+            return self._search_response("Raw summary with a source.")
+
+        with (
+            caplog.at_level(logging.WARNING),
+            patch("litellm.acompletion", new=AsyncMock(side_effect=_fake_acompletion)),
+        ):
+            await tool(query="WTI price", cutoff_date="2026-06-01", tool_context=fake_tool_context)
+
+        search_user_msg = next(m for m in calls[0]["messages"] if m["role"] == "user")
+        assert "2024-01-15" in search_user_msg["content"]
+        assert "2026-06-01" not in search_user_msg["content"]
+        assert any("disagrees with harness as_of" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_no_tool_context_falls_back_to_cutoff_date(self) -> None:
+        """With no tool_context (e.g. interactive use), cutoff_date still works."""
+        config = ContextRetrievalConfig(enabled=True, instruction="Search assistant.")
+        tool = _build_search_tool(config, openai_base_url="https://proxy.example.com/v1", openai_api_key="test-key")
+        calls: list[dict] = []
+
+        async def _fake_acompletion(**kwargs):  # type: ignore[override]
+            calls.append(kwargs)
+            if kwargs["model"] == f"openai/{config.verifier_model}":
+                return self._verify_response(clean=True, confidence=9, filtered_text="Clean summary.")
+            return self._search_response("Raw summary with a source.")
+
+        with patch("litellm.acompletion", new=AsyncMock(side_effect=_fake_acompletion)):
+            result = await tool(query="WTI price", cutoff_date="2024-01-15")
+
+        assert len(calls) == 2
+        assert result == "Clean summary."

--- a/aieng-forecasting/tests/aieng/forecasting/methods/agentic/test_predictor.py
+++ b/aieng-forecasting/tests/aieng/forecasting/methods/agentic/test_predictor.py
@@ -26,7 +26,7 @@ import pytest
 from aieng.forecasting.data.context import ForecastContext
 from aieng.forecasting.evaluation.prediction import STANDARD_QUANTILES, Prediction
 from aieng.forecasting.evaluation.task import ForecastingTask
-from aieng.forecasting.methods.agentic.agent_factory import AgentConfig
+from aieng.forecasting.methods.agentic.agent_factory import AS_OF_STATE_KEY, AgentConfig
 from aieng.forecasting.methods.agentic.outputs import AgentForecastOutput, ContinuousAgentForecastOutput
 from aieng.forecasting.methods.agentic.predictor import AgentPredictor
 from pydantic import ValidationError
@@ -57,14 +57,16 @@ class _StubRunner:
         self._agent.model = model
         # No tracing in unit tests, so no trace is captured.
         self.last_trace_id: str | None = None
+        self.run_text_async_calls: list[dict[str, Any]] = []
 
     @property
     def agent(self) -> Any:
         """Return the stub agent so the predictor can read ``name``/``model``."""
         return self._agent
 
-    async def run_text_async(self, prompt: str, **_: Any) -> str:
-        """Return the canned response regardless of prompt."""
+    async def run_text_async(self, prompt: str, **kwargs: Any) -> str:
+        """Record the call and return the canned response regardless of prompt."""
+        self.run_text_async_calls.append({"prompt": prompt, **kwargs})
         return self._response
 
 
@@ -212,6 +214,22 @@ class TestPredictHappyPath:
         predictor.predict(task, context)
 
         builder.assert_called_once_with(task=task, context=context)
+
+    def test_seeds_harness_as_of_into_run_text_async(self) -> None:
+        """predict() seeds the session with context.as_of so search_web can enforce it.
+
+        This is what closes the bypass where an LLM omits cutoff_date on a
+        search_web call: the harness-controlled as_of is injected regardless
+        of what (if anything) the model passes.
+        """
+        predictor, _ = _make_predictor(response=_output_json([1]))
+        context = _context()  # as_of = datetime(2024, 1, 1)
+
+        predictor.predict(_task([1]), context)
+
+        calls = predictor._runner.run_text_async_calls  # type: ignore[attr-defined]
+        assert len(calls) == 1
+        assert calls[0]["initial_state"] == {AS_OF_STATE_KEY: "2024-01-01"}
 
     def test_fenced_json_is_accepted_and_converts_to_predictions(self) -> None:
         """JSON wrapped in a ```json ... ``` fence still produces valid predictions.

--- a/implementations/energy_oil_forecasting/04_systematic_backtest_eval.ipynb
+++ b/implementations/energy_oil_forecasting/04_systematic_backtest_eval.ipynb
@@ -333,7 +333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "deae96a9",
    "metadata": {},
    "outputs": [
@@ -354,405 +354,10 @@
       "  LLMP-Sampled + cov (gemini-3.5-flash) ✓\n",
       "  LLMP-Grid (gemini-3.1-flash-lite-preview) ✓\n",
       "  LLMP-Grid (gemini-3.5-flash) ✓\n",
-      "  News Agent (gemini-3.1-flash-lite-preview) ✓\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Node execution failed with exception\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 930, in acompletion\n",
-      "    headers, response = await self.make_openai_chat_completion_request(\n",
-      "                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/logging_utils.py\", line 297, in async_wrapper\n",
-      "    result = await func(*args, **kwargs)\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 461, in make_openai_chat_completion_request\n",
-      "    raise e\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 438, in make_openai_chat_completion_request\n",
-      "    await openai_aclient.chat.completions.with_raw_response.create(\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/_legacy_response.py\", line 384, in wrapped\n",
-      "    return cast(LegacyAPIResponse[R], await func(*args, **kwargs))\n",
-      "                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/resources/chat/completions/completions.py\", line 2739, in create\n",
-      "    return await self._post(\n",
-      "           ^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/_base_client.py\", line 1931, in post\n",
-      "    return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/_base_client.py\", line 1716, in request\n",
-      "    raise self._make_status_error_from_response(err.response) from None\n",
-      "openai.BadRequestError: Error code: 400 - {'detail': '{\\n  \"error\": {\\n    \"code\": 400,\\n    \"message\": \"* GenerateContentRequest.contents[5].parts[0].function_response.name: Name cannot be empty.\\\\n\",\\n    \"status\": \"INVALID_ARGUMENT\"\\n  }\\n}\\n'}\n",
+      "  News Agent (gemini-3.1-flash-lite-preview) ✓\n",
+      "  News Agent (gemini-3.5-flash) ✓\n",
       "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/main.py\", line 639, in acompletion\n",
-      "    response = await init_response\n",
-      "               ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 990, in acompletion\n",
-      "    raise OpenAIError(\n",
-      "litellm.llms.openai.common_utils.OpenAIError: Error code: 400 - {'detail': '{\\n  \"error\": {\\n    \"code\": 400,\\n    \"message\": \"* GenerateContentRequest.contents[5].parts[0].function_response.name: Name cannot be empty.\\\\n\",\\n    \"status\": \"INVALID_ARGUMENT\"\\n  }\\n}\\n'}\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_node_runner.py\", line 135, in run\n",
-      "    await self._execute_node(ctx, node_input)\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_node_runner.py\", line 255, in _execute_node\n",
-      "    await self._run_node_loop(ctx, node_input)\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_node_runner.py\", line 269, in _run_node_loop\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_base_node.py\", line 217, in run\n",
-      "    async for item in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/agents/llm_agent.py\", line 559, in _run_impl\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_llm_agent_wrapper.py\", line 383, in run_llm_agent_as_node\n",
-      "    async for event in run_iter:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openinference/instrumentation/google_adk/_wrappers.py\", line 188, in __aiter__\n",
-      "    async for event in self.__wrapped__:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/agents/base_agent.py\", line 305, in run_async\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/agents/llm_agent.py\", line 515, in _run_async_impl\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 889, in run_async\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 968, in _run_one_step_async\n",
-      "    async for llm_response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 1362, in _call_llm_async\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 1340, in _call_llm_with_tracing\n",
-      "    async for llm_response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 1423, in _run_and_handle_error\n",
-      "    async for response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 408, in _run_and_handle_error\n",
-      "    raise model_error\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 385, in _run_and_handle_error\n",
-      "    async for llm_response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/models/lite_llm.py\", line 2568, in generate_content_async\n",
-      "    response = await self.llm_client.acompletion(**completion_args)\n",
-      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/models/lite_llm.py\", line 609, in acompletion\n",
-      "    return await acompletion(\n",
-      "           ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/utils.py\", line 2100, in wrapper_async\n",
-      "    raise e\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/utils.py\", line 1899, in wrapper_async\n",
-      "    result = await original_function(*args, **kwargs)\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/main.py\", line 659, in acompletion\n",
-      "    raise exception_type(\n",
-      "          ^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py\", line 2473, in exception_type\n",
-      "    raise e\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py\", line 544, in exception_type\n",
-      "    raise BadRequestError(\n",
-      "litellm.exceptions.BadRequestError: litellm.BadRequestError: OpenAIException - Error code: 400 - {'detail': '{\\n  \"error\": {\\n    \"code\": 400,\\n    \"message\": \"* GenerateContentRequest.contents[5].parts[0].function_response.name: Name cannot be empty.\\\\n\",\\n    \"status\": \"INVALID_ARGUMENT\"\\n  }\\n}\\n'}\n",
-      "Root node wti_analyst_news failed.\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 930, in acompletion\n",
-      "    headers, response = await self.make_openai_chat_completion_request(\n",
-      "                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/logging_utils.py\", line 297, in async_wrapper\n",
-      "    result = await func(*args, **kwargs)\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 461, in make_openai_chat_completion_request\n",
-      "    raise e\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 438, in make_openai_chat_completion_request\n",
-      "    await openai_aclient.chat.completions.with_raw_response.create(\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/_legacy_response.py\", line 384, in wrapped\n",
-      "    return cast(LegacyAPIResponse[R], await func(*args, **kwargs))\n",
-      "                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/resources/chat/completions/completions.py\", line 2739, in create\n",
-      "    return await self._post(\n",
-      "           ^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/_base_client.py\", line 1931, in post\n",
-      "    return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/_base_client.py\", line 1716, in request\n",
-      "    raise self._make_status_error_from_response(err.response) from None\n",
-      "openai.BadRequestError: Error code: 400 - {'detail': '{\\n  \"error\": {\\n    \"code\": 400,\\n    \"message\": \"* GenerateContentRequest.contents[5].parts[0].function_response.name: Name cannot be empty.\\\\n\",\\n    \"status\": \"INVALID_ARGUMENT\"\\n  }\\n}\\n'}\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/main.py\", line 639, in acompletion\n",
-      "    response = await init_response\n",
-      "               ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 990, in acompletion\n",
-      "    raise OpenAIError(\n",
-      "litellm.llms.openai.common_utils.OpenAIError: Error code: 400 - {'detail': '{\\n  \"error\": {\\n    \"code\": 400,\\n    \"message\": \"* GenerateContentRequest.contents[5].parts[0].function_response.name: Name cannot be empty.\\\\n\",\\n    \"status\": \"INVALID_ARGUMENT\"\\n  }\\n}\\n'}\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/runners.py\", line 815, in _cleanup_root_task\n",
-      "    await task\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/runners.py\", line 560, in _drive_root_node\n",
-      "    raise ctx.error\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_node_runner.py\", line 135, in run\n",
-      "    await self._execute_node(ctx, node_input)\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_node_runner.py\", line 255, in _execute_node\n",
-      "    await self._run_node_loop(ctx, node_input)\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_node_runner.py\", line 269, in _run_node_loop\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_base_node.py\", line 217, in run\n",
-      "    async for item in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/agents/llm_agent.py\", line 559, in _run_impl\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_llm_agent_wrapper.py\", line 383, in run_llm_agent_as_node\n",
-      "    async for event in run_iter:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openinference/instrumentation/google_adk/_wrappers.py\", line 188, in __aiter__\n",
-      "    async for event in self.__wrapped__:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/agents/base_agent.py\", line 305, in run_async\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/agents/llm_agent.py\", line 515, in _run_async_impl\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 889, in run_async\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 968, in _run_one_step_async\n",
-      "    async for llm_response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 1362, in _call_llm_async\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 1340, in _call_llm_with_tracing\n",
-      "    async for llm_response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 1423, in _run_and_handle_error\n",
-      "    async for response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 408, in _run_and_handle_error\n",
-      "    raise model_error\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 385, in _run_and_handle_error\n",
-      "    async for llm_response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/models/lite_llm.py\", line 2568, in generate_content_async\n",
-      "    response = await self.llm_client.acompletion(**completion_args)\n",
-      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/models/lite_llm.py\", line 609, in acompletion\n",
-      "    return await acompletion(\n",
-      "           ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/utils.py\", line 2100, in wrapper_async\n",
-      "    raise e\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/utils.py\", line 1899, in wrapper_async\n",
-      "    result = await original_function(*args, **kwargs)\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/main.py\", line 659, in acompletion\n",
-      "    raise exception_type(\n",
-      "          ^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py\", line 2473, in exception_type\n",
-      "    raise e\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py\", line 544, in exception_type\n",
-      "    raise BadRequestError(\n",
-      "litellm.exceptions.BadRequestError: litellm.BadRequestError: OpenAIException - Error code: 400 - {'detail': '{\\n  \"error\": {\\n    \"code\": 400,\\n    \"message\": \"* GenerateContentRequest.contents[5].parts[0].function_response.name: Name cannot be empty.\\\\n\",\\n    \"status\": \"INVALID_ARGUMENT\"\\n  }\\n}\\n'}\n",
-      "predict() failed at origin 2025-01-06 (attempt 1/3): litellm.BadRequestError: OpenAIException - Error code: 400 - {'detail': '{\\n  \"error\": {\\n    \"code\": 400,\\n    \"message\": \"* GenerateContentRequest.contents[5].parts[0].function_response.name: Name cannot be empty.\\\\n\",\\n    \"status\": \"INVALID_ARGUMENT\"\\n  }\\n}\\n'} — retrying in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\u001b[1;31mGive Feedback / Get Help: https://github.com/BerriAI/litellm/issues/new\u001b[0m\n",
-      "LiteLLM.Info: If you need to debug this error, use `litellm._turn_on_debug()'.\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Node execution failed with exception\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 930, in acompletion\n",
-      "    headers, response = await self.make_openai_chat_completion_request(\n",
-      "                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/logging_utils.py\", line 297, in async_wrapper\n",
-      "    result = await func(*args, **kwargs)\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 461, in make_openai_chat_completion_request\n",
-      "    raise e\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 438, in make_openai_chat_completion_request\n",
-      "    await openai_aclient.chat.completions.with_raw_response.create(\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/_legacy_response.py\", line 384, in wrapped\n",
-      "    return cast(LegacyAPIResponse[R], await func(*args, **kwargs))\n",
-      "                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/resources/chat/completions/completions.py\", line 2739, in create\n",
-      "    return await self._post(\n",
-      "           ^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/_base_client.py\", line 1931, in post\n",
-      "    return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/_base_client.py\", line 1716, in request\n",
-      "    raise self._make_status_error_from_response(err.response) from None\n",
-      "openai.BadRequestError: Error code: 400 - {'detail': '{\\n  \"error\": {\\n    \"code\": 400,\\n    \"message\": \"* GenerateContentRequest.contents[5].parts[0].function_response.name: Name cannot be empty.\\\\n\",\\n    \"status\": \"INVALID_ARGUMENT\"\\n  }\\n}\\n'}\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/main.py\", line 639, in acompletion\n",
-      "    response = await init_response\n",
-      "               ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 990, in acompletion\n",
-      "    raise OpenAIError(\n",
-      "litellm.llms.openai.common_utils.OpenAIError: Error code: 400 - {'detail': '{\\n  \"error\": {\\n    \"code\": 400,\\n    \"message\": \"* GenerateContentRequest.contents[5].parts[0].function_response.name: Name cannot be empty.\\\\n\",\\n    \"status\": \"INVALID_ARGUMENT\"\\n  }\\n}\\n'}\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_node_runner.py\", line 135, in run\n",
-      "    await self._execute_node(ctx, node_input)\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_node_runner.py\", line 255, in _execute_node\n",
-      "    await self._run_node_loop(ctx, node_input)\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_node_runner.py\", line 269, in _run_node_loop\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_base_node.py\", line 217, in run\n",
-      "    async for item in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/agents/llm_agent.py\", line 559, in _run_impl\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_llm_agent_wrapper.py\", line 383, in run_llm_agent_as_node\n",
-      "    async for event in run_iter:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openinference/instrumentation/google_adk/_wrappers.py\", line 188, in __aiter__\n",
-      "    async for event in self.__wrapped__:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/agents/base_agent.py\", line 305, in run_async\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/agents/llm_agent.py\", line 515, in _run_async_impl\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 889, in run_async\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 968, in _run_one_step_async\n",
-      "    async for llm_response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 1362, in _call_llm_async\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 1340, in _call_llm_with_tracing\n",
-      "    async for llm_response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 1423, in _run_and_handle_error\n",
-      "    async for response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 408, in _run_and_handle_error\n",
-      "    raise model_error\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 385, in _run_and_handle_error\n",
-      "    async for llm_response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/models/lite_llm.py\", line 2568, in generate_content_async\n",
-      "    response = await self.llm_client.acompletion(**completion_args)\n",
-      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/models/lite_llm.py\", line 609, in acompletion\n",
-      "    return await acompletion(\n",
-      "           ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/utils.py\", line 2100, in wrapper_async\n",
-      "    raise e\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/utils.py\", line 1899, in wrapper_async\n",
-      "    result = await original_function(*args, **kwargs)\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/main.py\", line 659, in acompletion\n",
-      "    raise exception_type(\n",
-      "          ^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py\", line 2473, in exception_type\n",
-      "    raise e\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py\", line 544, in exception_type\n",
-      "    raise BadRequestError(\n",
-      "litellm.exceptions.BadRequestError: litellm.BadRequestError: OpenAIException - Error code: 400 - {'detail': '{\\n  \"error\": {\\n    \"code\": 400,\\n    \"message\": \"* GenerateContentRequest.contents[5].parts[0].function_response.name: Name cannot be empty.\\\\n\",\\n    \"status\": \"INVALID_ARGUMENT\"\\n  }\\n}\\n'}\n",
-      "Root node wti_analyst_news failed.\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 930, in acompletion\n",
-      "    headers, response = await self.make_openai_chat_completion_request(\n",
-      "                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/logging_utils.py\", line 297, in async_wrapper\n",
-      "    result = await func(*args, **kwargs)\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 461, in make_openai_chat_completion_request\n",
-      "    raise e\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 438, in make_openai_chat_completion_request\n",
-      "    await openai_aclient.chat.completions.with_raw_response.create(\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/_legacy_response.py\", line 384, in wrapped\n",
-      "    return cast(LegacyAPIResponse[R], await func(*args, **kwargs))\n",
-      "                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/resources/chat/completions/completions.py\", line 2739, in create\n",
-      "    return await self._post(\n",
-      "           ^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/_base_client.py\", line 1931, in post\n",
-      "    return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)\n",
-      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openai/_base_client.py\", line 1716, in request\n",
-      "    raise self._make_status_error_from_response(err.response) from None\n",
-      "openai.BadRequestError: Error code: 400 - {'detail': '{\\n  \"error\": {\\n    \"code\": 400,\\n    \"message\": \"* GenerateContentRequest.contents[5].parts[0].function_response.name: Name cannot be empty.\\\\n\",\\n    \"status\": \"INVALID_ARGUMENT\"\\n  }\\n}\\n'}\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/main.py\", line 639, in acompletion\n",
-      "    response = await init_response\n",
-      "               ^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/llms/openai/openai.py\", line 990, in acompletion\n",
-      "    raise OpenAIError(\n",
-      "litellm.llms.openai.common_utils.OpenAIError: Error code: 400 - {'detail': '{\\n  \"error\": {\\n    \"code\": 400,\\n    \"message\": \"* GenerateContentRequest.contents[5].parts[0].function_response.name: Name cannot be empty.\\\\n\",\\n    \"status\": \"INVALID_ARGUMENT\"\\n  }\\n}\\n'}\n",
-      "\n",
-      "During handling of the above exception, another exception occurred:\n",
-      "\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/runners.py\", line 815, in _cleanup_root_task\n",
-      "    await task\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/runners.py\", line 560, in _drive_root_node\n",
-      "    raise ctx.error\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_node_runner.py\", line 135, in run\n",
-      "    await self._execute_node(ctx, node_input)\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_node_runner.py\", line 255, in _execute_node\n",
-      "    await self._run_node_loop(ctx, node_input)\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_node_runner.py\", line 269, in _run_node_loop\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_base_node.py\", line 217, in run\n",
-      "    async for item in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/agents/llm_agent.py\", line 559, in _run_impl\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/workflow/_llm_agent_wrapper.py\", line 383, in run_llm_agent_as_node\n",
-      "    async for event in run_iter:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/openinference/instrumentation/google_adk/_wrappers.py\", line 188, in __aiter__\n",
-      "    async for event in self.__wrapped__:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/agents/base_agent.py\", line 305, in run_async\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/agents/llm_agent.py\", line 515, in _run_async_impl\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 889, in run_async\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 968, in _run_one_step_async\n",
-      "    async for llm_response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 1362, in _call_llm_async\n",
-      "    async for event in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 1340, in _call_llm_with_tracing\n",
-      "    async for llm_response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 1423, in _run_and_handle_error\n",
-      "    async for response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 408, in _run_and_handle_error\n",
-      "    raise model_error\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/flows/llm_flows/base_llm_flow.py\", line 385, in _run_and_handle_error\n",
-      "    async for llm_response in agen:\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/models/lite_llm.py\", line 2568, in generate_content_async\n",
-      "    response = await self.llm_client.acompletion(**completion_args)\n",
-      "               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/google/adk/models/lite_llm.py\", line 609, in acompletion\n",
-      "    return await acompletion(\n",
-      "           ^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/utils.py\", line 2100, in wrapper_async\n",
-      "    raise e\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/utils.py\", line 1899, in wrapper_async\n",
-      "    result = await original_function(*args, **kwargs)\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/main.py\", line 659, in acompletion\n",
-      "    raise exception_type(\n",
-      "          ^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py\", line 2473, in exception_type\n",
-      "    raise e\n",
-      "  File \"/Users/ethanjackson/agentic-forecasting/.venv/lib/python3.12/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py\", line 544, in exception_type\n",
-      "    raise BadRequestError(\n",
-      "litellm.exceptions.BadRequestError: litellm.BadRequestError: OpenAIException - Error code: 400 - {'detail': '{\\n  \"error\": {\\n    \"code\": 400,\\n    \"message\": \"* GenerateContentRequest.contents[5].parts[0].function_response.name: Name cannot be empty.\\\\n\",\\n    \"status\": \"INVALID_ARGUMENT\"\\n  }\\n}\\n'}\n",
-      "predict() failed at origin 2025-05-05 (attempt 1/3): litellm.BadRequestError: OpenAIException - Error code: 400 - {'detail': '{\\n  \"error\": {\\n    \"code\": 400,\\n    \"message\": \"* GenerateContentRequest.contents[5].parts[0].function_response.name: Name cannot be empty.\\\\n\",\\n    \"status\": \"INVALID_ARGUMENT\"\\n  }\\n}\\n'} — retrying in 2s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\u001b[1;31mGive Feedback / Get Help: https://github.com/BerriAI/litellm/issues/new\u001b[0m\n",
-      "LiteLLM.Info: If you need to debug this error, use `litellm._turn_on_debug()'.\n",
-      "\n"
+      "All 2025 backtests complete.\n"
      ]
     }
    ],
@@ -789,826 +394,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "e788448d",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133641640>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336574d0>, 754324.387265708)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1345d8d40>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13363c320>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133656d60>, 754334.119015333)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13363ce00>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13363c200>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133656ba0>, 754343.446184291)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13363d850>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13369c590>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336565f0>, 754350.361730375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13369f1a0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13369c680>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133655f60>, 754359.410917208)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13369e960>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13360f140>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336551d0>, 754369.830710291)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13360e930>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13369cb90>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133655710>, 754383.061793833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13360c800>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133666d80>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133655b70>, 754395.657177791)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133665760>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133667200>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133655550>, 754405.914658333)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13369c920>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133673a70>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336544b0>, 754418.959740541)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133673680>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133672630>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133654670>, 754432.19516525)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1336700e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1335e89b0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133654360>, 754440.926241833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1335e8590>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1335eb2f0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336547c0>, 754453.427442416)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133671bb0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133665ac0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a5c50>, 754462.197548375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133673f80>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1336a8920>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a5fd0>, 754473.369202333)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1336ab380>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1336aa6c0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a77e0>, 754486.226948333)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1336abe00>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1335ea870>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a4050>, 754495.272700291)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134448b90>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1335cc8f0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a7e70>, 754508.489042083)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1335ce7b0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1335ce420>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a7460>, 754520.514673583)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1335cc440>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1335a8770>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a7690>, 754532.978669041)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1335a92e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1335cddc0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a7070>, 754545.366618833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1335ccce0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1333a1fd0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a6c10>, 754557.84665875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1333a3b30>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1335cdf70>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a5e10>, 754570.674129)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1335ea8a0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1335abe60>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a6ac0>, 754584.062219041)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13414f440>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13444a780>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a6820>, 754596.349441041)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1335e98b0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1347132f0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a65f0>, 754606.150888083)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134713590>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134713fe0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a5080>, 754617.863233416)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134710560>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133660860>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a4de0>, 754626.753534541)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133660770>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133711f10>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a4360>, 754673.265060375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134712390>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1336aa360>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a4600>, 754686.254156041)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13475d160>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133661c40>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a7af0>, 754699.37927725)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134668ef0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1346d9bb0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a4d70>, 754708.443158416)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1346d9070>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1346da630>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13358f9a0>, 754717.0717905)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1346da690>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134740bf0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13358f230>, 754728.202013708)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13475d2e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134740560>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13358fcb0>, 754738.068636041)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1347408c0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1347a07d0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133b8ca60>, 754750.483801166)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13429f680>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13427b590>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133b8c210>, 754762.524602791)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133bcff80>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133b9bd10>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133b8ce50>, 754774.505520375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133b987d0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133b99610>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133986040>, 754787.077034041)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1347a03e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133bc2090>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133986f90>, 754799.11028375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133bc06b0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133bc1490>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1339842f0>, 754809.635246375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133bc1010>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13392db20>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1339862e0>, 754822.550276875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13456c920>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13392fda0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1339870e0>, 754834.856184625)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13392c4d0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1339a3da0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133986f20>, 754846.894833666)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13475c920>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1339a2c30>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1339869e0>, 754858.658008333)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1339a39e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1338e4470>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133985e80>, 754871.495422416)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1338e48f0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1338e6ff0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133986970>, 754884.215299166)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1338e4830>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1339d5460>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133985780>, 754894.531603083)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1339d5d30>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1339d52e0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133984130>, 754912.460733833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1339d4440>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1339a1d00>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133986200>, 754929.466105375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1339a38f0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1339b6e10>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133985550>, 754945.013893916)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1339b71a0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1339b6660>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133984bb0>, 754963.466358291)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1339d4920>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13394bd40>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133985860>, 754981.194848666)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133949280>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13394af60>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133985390>, 754999.21988075)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13394af90>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133ad25a0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133984520>, 755018.289252125)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133ad3890>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133ad27e0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133984440>, 755030.468649958)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133b994f0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133a6d610>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13383fc40>, 755039.034020708)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134287e90>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133948710>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1337cec80>, 755036.217192083)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133a6f920>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133a71d90>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1337cd550>, 755047.225529916)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133a72210>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133a034a0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1337cdf60>, 755043.670787125)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133a018b0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133a6f170>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1337ce4a0>, 755055.696424625)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133a448f0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133a197c0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1337cd240>, 755052.388368708)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133a19760>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133a18b00>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1337cde10>, 755064.711890625)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133a185c0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133a19400>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1337cf310>, 755061.537283541)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133a186b0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133a03050>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13373fa80>, 755073.229580708)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133a02cc0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1339b0290>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13373fcb0>, 755069.549556583)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1339b2a50>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133a03cb0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13373fd20>, 755080.963450166)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133a00410>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133857ce0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336a56a0>, 755077.976036208)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1338556d0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1339b3230>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13478f1c0>, 755089.109073666)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1339b1070>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1338677d0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13478f070>, 755085.587909041)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133865610>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1338669f0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13478f460>, 755098.0820245)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1338665d0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133866f00>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13478fee0>, 755094.246406125)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133867a40>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1339b2930>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1338684b0>, 755107.51830825)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1339b1220>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1338bbe00>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133868b40>, 755102.932913625), (<aiohttp.client_proto.ResponseHandler object at 0x1338695c0>, 755103.423771875), (<aiohttp.client_proto.ResponseHandler object at 0x133869550>, 755103.476048416)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1338b9880>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1338ba750>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133869e10>, 755115.531129375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133865400>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1338bac90>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13386a580>, 755112.473941)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1338b9670>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1338648c0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13386a6d0>, 755125.2552355)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133865130>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133822f00>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13386b930>, 755120.9483405), (<aiohttp.client_proto.ResponseHandler object at 0x13386b310>, 755120.966736791), (<aiohttp.client_proto.ResponseHandler object at 0x13386bbd0>, 755121.808529)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133821250>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1338179b0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13386b150>, 755133.343423875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133817a40>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1339b1be0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133a7c2f0>, 755130.074934333)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1333a3e00>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1337e98e0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133a7c3d0>, 755141.682826916)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1337e9ac0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1337e8e30>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133a7cb40>, 755138.35194425)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1337e91f0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13381f290>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133a7d240>, 755150.463337208)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13381eba0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13381df10>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133a7da20>, 755146.606748666)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13381e0f0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13378cc80>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133a7def0>, 755158.850378333)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13378f170>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13378c410>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133a7e510>, 755155.620784833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13378e8a0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1337e85f0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133a7e430>, 755171.241582958)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1337e9010>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133731220>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133a7f070>, 755167.487325041)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1337327e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13381e270>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133a7e040>, 755179.833826875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13381ce00>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13378dc10>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133a7f8c0>, 755176.360336708)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133732c00>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1337b43e0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13492c360>, 755189.424744125)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1337b4ad0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1337b7b00>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13492cbb0>, 755185.594588666)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1337b5ca0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1337312b0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13492d240>, 755198.944557125)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13362bb30>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1335aaea0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13492da90>, 755195.093150583)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1335a8290>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1335a84d0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13492d5c0>, 755207.173657)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1335aa810>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1335aae10>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13492e200>, 755203.954365416), (<aiohttp.client_proto.ResponseHandler object at 0x13492e7b0>, 755204.052748291)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13378d3d0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1337b4440>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13492d2b0>, 755216.221725791)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1337b61e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13378e000>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13492f1c0>, 755212.391164166)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13381c5f0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133820770>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13492f4d0>, 755224.809711916)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13371fef0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1335eb4d0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13492fcb0>, 755221.51196425)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1335e8d70>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1335cfb30>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1348f0360>, 755232.980222041)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1335eaea0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1337951f0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1348f0a60>, 755229.704498)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133794c50>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133713ad0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1348f0050>, 755242.33632925)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1335ea8d0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133641910>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1348f16a0>, 755238.314530458)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13371e5a0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1336655b0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1348f06e0>, 755250.640831708)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1336662a0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133728620>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1348f2190>, 755247.624429083)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13371e690>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13381e630>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1348f2510>, 755255.900870083)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133795d30>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133710440>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1348f2350>, 755259.618451208)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13371eb10>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1336413d0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1348f3070>, 755267.610403583)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1337b6ae0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1336732c0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1348f38c0>, 755264.35016925)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133673710>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133794a40>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1348f3d20>, 755276.172093041)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133603170>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1346dbbf0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134a3c520>, 755272.837893)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1346d8230>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133667530>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134a3c3d0>, 755284.794512708)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133671c10>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134751520>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134a3db00>, 755281.119773291), (<aiohttp.client_proto.ResponseHandler object at 0x134a3c9f0>, 755281.189214291), (<aiohttp.client_proto.ResponseHandler object at 0x134a3da90>, 755281.474146083)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134752000>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133a11e20>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134a3c980>, 755292.719791375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1347428a0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133a126f0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134a3e350>, 755289.34847425)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133a10710>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13414f1d0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133868de0>, 755302.339780875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1335ea6c0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13414ec30>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1337cd4e0>, 755298.955321958)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1338b9490>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134338f20>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1337ceba0>, 755311.658458666)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13417e690>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13410be00>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1339863c0>, 755307.679656458), (<aiohttp.client_proto.ResponseHandler object at 0x133987e70>, 755307.989812041), (<aiohttp.client_proto.ResponseHandler object at 0x13434cad0>, 755308.044621375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13410a0c0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13417e5d0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1337cf0e0>, 755319.75462975)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13417e0c0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13414fef0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134132eb0>, 755316.128285166)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13414c3e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1346da390>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134133c40>, 755324.807240166)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134108b90>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134195e50>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134133310>, 755328.066143375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134194350>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13410bad0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134132890>, 755336.929740708)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13410b410>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13419d490>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1341302f0>, 755333.44028575)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13419ce00>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13419c200>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134133070>, 755345.907983375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134198e00>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1341cb020>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134131940>, 755341.741723375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1341cac30>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13419ffe0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1341304b0>, 755355.105594833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1341964e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13416f770>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13406bee0>, 755351.311153166), (<aiohttp.client_proto.ResponseHandler object at 0x13406baf0>, 755351.318857166), (<aiohttp.client_proto.ResponseHandler object at 0x13406aeb0>, 755351.766424291)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13416ce60>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1340250a0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13406b620>, 755365.447629833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134025160>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13419f4a0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13406a040>, 755362.28137575)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13419f1a0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134027c20>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13406ad60>, 755374.52989075)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1340275c0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134047ce0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134068d00>, 755371.118530583)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1341ca630>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13416c200>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13406b770>, 755383.109723791)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134046870>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134045340>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134068670>, 755379.767988583)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134046d50>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134044200>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1340684b0>, 755391.129254291)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13416e600>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134086ed0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134068c90>, 755387.7677065)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134085c70>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13416eae0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133dd1f60>, 755400.083700125)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13416f950>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1340430e0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133dd3230>, 755396.08778425)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134042360>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134085730>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134068a60>, 755404.968038333)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134043800>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134085040>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133dd3a80>, 755408.428903458)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134087dd0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134043cb0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133dd1cc0>, 755416.922344083)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134087020>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1340b0110>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133dd0b40>, 755413.74670325)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13416d9d0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1340b1070>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133dd1470>, 755425.086389875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1340b0a10>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1340b03b0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133dd3770>, 755421.733993833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1340b3a70>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d72f90>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133ed97f0>, 755434.180735041)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d72ae0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d71880>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133edb2a0>, 755429.881031583), (<aiohttp.client_proto.ResponseHandler object at 0x133edaba0>, 755430.012271416), (<aiohttp.client_proto.ResponseHandler object at 0x133eda7b0>, 755430.666883625)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d73dd0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133e225d0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133ed9b00>, 755442.374095375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133e21580>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1340b0170>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133ed8750>, 755438.807296166)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1340b3380>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d73590>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d72b70>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133ed99b0>, 755447.613136833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d717c0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133ed9da0>, 755450.994027166)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d704d0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133dd6d20>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133ed8600>, 755459.785814583)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133dd48c0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133dcbaa0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133e68bb0>, 755456.134121875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133dc9d30>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133dd4cb0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133e6ad60>, 755468.258494)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133dd61b0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133e08770>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133e6b5b0>, 755465.057881583)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133e0b830>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133e0bfb0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133e68670>, 755476.352605)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133e0a450>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133e08500>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133e69f60>, 755472.704591791)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133e0a270>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133dfa6c0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133e69b00>, 755528.514611291)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133dfa7e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d96990>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133e68de0>, 755499.907514625)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d970e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133df8560>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133e687c0>, 755587.249088791)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133df89b0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133dc96d0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133e69c50>, 755546.843783416)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133dc9dc0>\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1618,9 +407,9 @@
       "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n",
       "                                                    Mean CRPS  MAE h=21d\n",
       "Predictor                                                               \n",
-      "News Agent (gemini-3.5-flash)                        1.798545   2.291586\n",
+      "News Agent (gemini-3.5-flash)                        2.006962   2.673931\n",
       "LightGBM + cov                                       2.093759   2.825932\n",
-      "News Agent (gemini-3.1-flash-lite-preview)           2.135118   2.836897\n",
+      "News Agent (gemini-3.1-flash-lite-preview)           2.221806   2.995311\n",
       "LLMP-Grid (gemini-3.5-flash)                         2.228059   2.927517\n",
       "LightGBM                                             2.312416   3.280632\n",
       "AutoARIMA                                            2.472053   2.992343\n",
@@ -1674,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "496dc416",
    "metadata": {},
    "outputs": [
@@ -1725,7 +514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "e73f27fb",
    "metadata": {},
    "outputs": [
@@ -1738,524 +527,11 @@
       "  AutoARIMA ✓\n",
       "  LightGBM ✓\n",
       "  LightGBM + cov ✓\n",
-      "  LLMP-Sampled (gemini-3.1-flash-lite-preview) ✓\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133dfbb30>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133cc3c40>, 755620.245202583)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133dfaa20>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d6d310>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133cc2e40>, 755651.22417125)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d6ec90>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d6e9c0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133cc0360>, 755690.38719775)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d6f7d0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133e9c800>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133cc1400>, 755717.256602333)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133e9da60>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133e91370>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133cc0fa0>, 755775.39739575)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133e0aae0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133e93800>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133cc3620>, 755741.466064416)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133e91970>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13381f4d0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133b8fbd0>, 755804.440875166)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133e0b680>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13381ec60>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133cc06e0>, 755829.981523625)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133e0b260>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133f3cf20>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133b8dbe0>, 755878.899424166)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133f3e5d0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133f3e750>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133b8d6a0>, 755846.612076916)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133f3d760>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133f4b980>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133b8da90>, 755930.839139666)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133f4a1b0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133f49760>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1348f1080>, 755904.023050291)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133f4b1a0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133f4f260>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133a7faf0>, 756012.910297333)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133f4d940>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133f4d6a0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134a3e7b0>, 755985.022474541)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133f4e390>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133f57bf0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134a3cc20>, 756036.62356675)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133f4d0d0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133f57b30>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134a3dd30>, 756058.540382375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133f569f0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13381c200>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134a3dda0>, 756109.327299833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133cafb30>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133cad730>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134a3f620>, 756085.278553375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133caf2c0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133ca0a70>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134960590>, 756171.890338291)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133ca04d0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133ca3ec0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134960d00>, 756140.969835208)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133ca06e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133c9e8d0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134961550>, 756223.60839875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133c9c890>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133c9fb00>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134962c80>, 756189.3573185)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133c9e3f0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133cd0290>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134962d60>, 756323.862988833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133cd0230>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133cd2e70>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b20590>, 756292.66088875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133cd35c0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133cb7380>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b20a60>, 756386.449756083)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133cb4680>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133cb4260>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b21080>, 756355.9808185)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133cb6600>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d13320>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b21550>, 756485.650788291)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d101a0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d11a30>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b22e40>, 756461.151742)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d11160>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d11cd0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d205f0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b232a0>, 756511.397686708)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133cb5700>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b209f0>, 756544.698469833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d21c10>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d10380>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b20ec0>, 756589.234015416)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d12090>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d45850>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b230e0>, 756564.603384291)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d479e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1337b7ce0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b395c0>, 756612.016655833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133a19f10>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d473b0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b38910>, 756642.933382083)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133a6d0a0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d45070>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b38360>, 756694.648885041)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d46780>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133a19a90>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b383d0>, 756662.610936125)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d113a0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133a1ab10>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b397f0>, 756740.084893833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133c7c1a0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133beaab0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134ad0ad0>, 756714.008325875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133bebc20>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133c7d9d0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134963150>, 756764.318810791)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133c9cc80>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133f57170>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133b8d860>, 756909.277067875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133f54170>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133713b60>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134962ac0>, 756871.700313958)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133713ce0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133711b50>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336566d0>, 756953.032629125)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133ca3c20>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133f4f590>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13406b5b0>, 756988.637815541)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133f4f6b0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133f55850>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133654750>, 757087.044101791)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1346688c0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133ca1640>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1336546e0>, 757109.983070916)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13466b6e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13475ef60>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13478dbe0>, 757145.13540375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13475fa70>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134786cc0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13478f8c0>, 757172.449491625)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134784560>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1347dcb00>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13478def0>, 757233.155694083)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1347dc8c0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1347dd3a0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13478cf30>, 757207.341618125)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1347ddd90>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1347deff0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13478e660>, 757250.066238708)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1347dd100>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1347e99a0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133654050>, 757280.191754083)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1347eb800>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1347a1520>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134a3fa80>, 757322.422917125)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1347a13a0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1347a3650>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13373c4b0>, 757298.620782208)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1347a24e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1347dc200>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1345c8600>, 757387.643560166)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1347834d0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13476c710>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1345c9a90>, 757360.234712958)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13476d4f0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13476f770>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1345c94e0>, 757406.614846958)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13476ebd0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1344fec00>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1345ca040>, 757491.73890475)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1347a2f00>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1347a1730>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1345c81a0>, 757518.121002541)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1344fdaf0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134782d50>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1345c99b0>, 757543.962416166)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134780230>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134783c50>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1345c90f0>, 757567.351853666)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134502ae0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13476f4a0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1345cbb60>, 757609.184678958)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13476cbf0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1345acb90>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1342afa80>, 757584.803116416)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1345afb90>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134500cb0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1342aecf0>, 757664.517156541)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134501c70>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1345ae6f0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1342aeac0>, 757643.311525583)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1345af3e0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1345afe00>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1342ae820>, 757798.634146583)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1345af770>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134578080>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1342acad0>, 757761.254253875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134578f80>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1345aee70>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1345d9250>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1342aee40>, 758151.275844958)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1345d9c70>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1345db140>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x133cc3d20>, 758187.851536625)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1345d9010>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1345d9580>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134ad10f0>, 758165.526458583)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1345d8440>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1345bc560>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134ad3230>, 758213.452022291)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1345bdb50>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1345bcfe0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134ad3c40>, 758245.589115958)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1345bc3b0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1345bf9e0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1342ad9b0>, 758317.183962916)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1345beff0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13436a330>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13434e6d0>, 758275.402499)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134369e80>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1345bdaf0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13434ed60>, 758416.223334416)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1343ae4b0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13436a660>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13434cec0>, 758435.350487041)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1345bf050>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13476d760>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1337979b0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x1345c9080>, 757434.533197166)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13476e930>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134b39710>, 756793.141535875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133a46ed0>\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  LLMP-Sampled (gemini-3.1-flash-lite-preview) ✓\n",
       "  LLMP-Sampled (gemini-3.5-flash) ✓\n",
-      "  LLMP-Sampled + cov (gemini-3.1-flash-lite-preview) ✓\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133f3ee40>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13434ce50>, 758494.557762375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134369a30>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134448f20>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13434f700>, 758473.944237083)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134449a60>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1344491f0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13434f3f0>, 758539.090262)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134431430>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13444cbf0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x13434f4d0>, 758562.82817425)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13444ccb0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13444dc40>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134bc16a0>, 758592.947229833)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13444fc50>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134433440>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134bc35b0>, 758624.630967666)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133e9e060>\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  LLMP-Sampled + cov (gemini-3.1-flash-lite-preview) ✓\n",
       "  LLMP-Sampled + cov (gemini-3.5-flash) ✓\n",
-      "  LLMP-Grid (gemini-3.1-flash-lite-preview) ✓\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1343a1ca0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134bc03d0>, 758688.800393083)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x1343a1070>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13429e8d0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134bc3620>, 758651.313733041)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13429c740>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13429f410>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134bc1550>, 758829.184893416)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13429c770>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13429efc0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134bc0d70>, 758802.285962375)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13444a480>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13444cef0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134ccad60>, 758904.973871)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13444da60>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134278230>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134ccbc40>, 758875.640216625)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13427b440>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134279a00>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134cc84b0>, 758942.917746958)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134279d30>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134280590>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134bc2820>, 758911.53359175), (<aiohttp.client_proto.ResponseHandler object at 0x134bc1c50>, 758912.026008583), (<aiohttp.client_proto.ResponseHandler object at 0x134bc1780>, 758913.052293166)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134281dc0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133d94530>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134d08de0>, 759010.84582525)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13416dbe0>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1342811c0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134d0be70>, 758981.003194875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133d94410>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133dc9280>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134d095c0>, 759066.214550125)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133dc9880>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x133e91a90>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134d0a510>, 759036.486189458)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x133e90920>\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  LLMP-Grid (gemini-3.1-flash-lite-preview) ✓\n",
       "  LLMP-Grid (gemini-3.5-flash) ✓\n",
       "  News Agent (gemini-3.1-flash-lite-preview) ✓\n"
      ]
@@ -2264,27 +540,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Failed to export span batch code: None, reason: HTTPSConnectionPool(host='us.cloud.langfuse.com', port=443): Read timed out. (read timeout=4.999989986419678)\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x134313ad0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134d087c0>, 759134.339808875)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134313890>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1343132f0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134d0b150>, 759106.142334666)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134312a20>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x13444b770>\n",
-      "Unclosed client session\n",
-      "client_session: <aiohttp.client.ClientSession object at 0x1342808f0>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134e50ad0>, 759165.89067625)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x13419d430>\n",
-      "Unclosed connector\n",
-      "connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0x134e501a0>, 759190.995199958)])']\n",
-      "connector: <aiohttp.connector.TCPConnector object at 0x134280530>\n"
+      "search_web: cutoff_date='2026-03-03' disagrees with harness as_of='2026-03-02'; using the harness value.\n",
+      "search_web: cutoff_date='2026-03-03' disagrees with harness as_of='2026-03-02'; using the harness value.\n",
+      "search_web: cutoff_date='2026-03-03' disagrees with harness as_of='2026-03-02'; using the harness value.\n",
+      "search_web: cutoff_date='2026-03-03' disagrees with harness as_of='2026-03-02'; using the harness value.\n",
+      "search_web: cutoff_date='2026-03-03' disagrees with harness as_of='2026-03-02'; using the harness value.\n",
+      "search_web: cutoff_date='2026-03-17' disagrees with harness as_of='2026-03-16'; using the harness value.\n",
+      "search_web: cutoff_date='2026-04-07' disagrees with harness as_of='2026-04-06'; using the harness value.\n",
+      "search_web: cutoff_date='2026-04-07' disagrees with harness as_of='2026-04-06'; using the harness value.\n",
+      "search_web: cutoff_date='2026-04-10' disagrees with harness as_of='2026-04-06'; using the harness value.\n",
+      "search_web: cutoff_date='2026-04-10' disagrees with harness as_of='2026-04-06'; using the harness value.\n",
+      "search_web: cutoff_date='2026-04-10' disagrees with harness as_of='2026-04-06'; using the harness value.\n",
+      "search_web: cutoff_date='2026-04-10' disagrees with harness as_of='2026-04-06'; using the harness value.\n"
      ]
     },
     {
@@ -2309,7 +576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "a49c24d5",
    "metadata": {},
    "outputs": [
@@ -2348,7 +615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "31907f29",
    "metadata": {},
    "outputs": [
@@ -2361,17 +628,17 @@
       "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n",
       "                                                    Mean CRPS (2026)  MAE h=21d (2026)  80% CI Coverage\n",
       "Predictor                                                                                              \n",
-      "News Agent (gemini-3.5-flash)                               5.636426          7.084400        66.000000\n",
-      "LLMP-Grid (gemini-3.5-flash)                                9.154656         12.079400        40.000000\n",
-      "LightGBM                                                    9.389894         11.224602        34.000000\n",
-      "News Agent (gemini-3.1-flash-lite-preview)                  9.647239         12.133200        30.000000\n",
-      "LightGBM + cov                                              9.812166         11.595190        24.000000\n",
-      "LLMP-Grid (gemini-3.1-flash-lite-preview)                   9.935248         11.970600        24.000000\n",
-      "LLMP-Sampled (gemini-3.1-flash-lite-preview)               10.812086         12.098200         6.000000\n",
+      "News Agent (gemini-3.5-flash)                               8.027949         10.794600        46.000000\n",
+      "News Agent (gemini-3.1-flash-lite-preview)                  8.207824         11.012800        24.000000\n",
+      "LLMP-Grid (gemini-3.5-flash)                                9.154656         12.087400        40.000000\n",
+      "LightGBM                                                    9.389894         11.232602        34.000000\n",
+      "LightGBM + cov                                              9.812166         11.603190        24.000000\n",
+      "LLMP-Grid (gemini-3.1-flash-lite-preview)                   9.935248         11.978600        24.000000\n",
+      "LLMP-Sampled (gemini-3.1-flash-lite-preview)               10.812086         12.106200         6.000000\n",
       "AutoARIMA                                                  10.998416         13.804798        31.818182\n",
-      "LLMP-Sampled + cov (gemini-3.1-flash-lite-preview)         11.511221         12.739600         6.000000\n",
-      "LLMP-Sampled + cov (gemini-3.5-flash)                      11.963690         13.087000        14.000000\n",
-      "LLMP-Sampled (gemini-3.5-flash)                            12.617009         13.567600         6.000000\n",
+      "LLMP-Sampled + cov (gemini-3.1-flash-lite-preview)         11.511221         12.747600         6.000000\n",
+      "LLMP-Sampled + cov (gemini-3.5-flash)                      11.963690         13.095000        14.000000\n",
+      "LLMP-Sampled (gemini-3.5-flash)                            12.617009         13.575600         6.000000\n",
       "Naive (Last Value)                                         13.643182         13.643182         0.000000\n"
      ]
     }
@@ -2429,7 +696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "9970844b",
    "metadata": {},
    "outputs": [
@@ -2442,10 +709,10 @@
       "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n",
       "                                                    h=5d  h=10d  h=21d    All\n",
       "predictor                                                                    \n",
-      "News Agent (gemini-3.5-flash)                       5.55   5.58   5.76   5.64\n",
+      "News Agent (gemini-3.5-flash)                       5.57   7.78  10.44   8.03\n",
+      "News Agent (gemini-3.1-flash-lite-preview)          5.06   7.64  11.51   8.21\n",
       "LLMP-Grid (gemini-3.5-flash)                        6.18   8.50  12.38   9.15\n",
       "LightGBM                                            6.43   8.19  13.08   9.39\n",
-      "News Agent (gemini-3.1-flash-lite-preview)          6.46   8.83  13.21   9.65\n",
       "LightGBM + cov                                      6.53   8.79  13.64   9.81\n",
       "LLMP-Grid (gemini-3.1-flash-lite-preview)           6.89   9.23  13.27   9.94\n",
       "LLMP-Sampled (gemini-3.1-flash-lite-preview)        8.11  10.12  13.83  10.81\n",
@@ -2487,7 +754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "099a188a",
    "metadata": {},
    "outputs": [
@@ -2601,12 +868,6 @@
            "9.81"
           ],
           [
-           "6.46",
-           "8.83",
-           "13.21",
-           "9.65"
-          ],
-          [
            "6.43",
            "8.19",
            "13.08",
@@ -2619,10 +880,16 @@
            "9.15"
           ],
           [
-           "5.55",
-           "5.58",
-           "5.76",
-           "5.64"
+           "5.06",
+           "7.64",
+           "11.51",
+           "8.21"
+          ],
+          [
+           "5.57",
+           "7.78",
+           "10.44",
+           "8.03"
           ]
          ],
          "textfont": {
@@ -2645,13 +912,13 @@
           "LLMP-Sampled (gemini-3.1-flash-lite-preview)",
           "LLMP-Grid (gemini-3.1-flash-lite-preview)",
           "LightGBM + cov",
-          "News Agent (gemini-3.1-flash-lite-preview)",
           "LightGBM",
           "LLMP-Grid (gemini-3.5-flash)",
+          "News Agent (gemini-3.1-flash-lite-preview)",
           "News Agent (gemini-3.5-flash)"
          ],
          "z": {
-          "bdata": "JUmSJDMzH0AlSZKkstooQAAAAHjr0TNAL7roIk9JK0Dns0+vEIwhQB4xggSq1SdAD/XWf8WnMECxIhGq6DspQL7I/MWhyR9ARvBcmYNUJ0BwdmsSZpkvQEkIyb1o7SdAKKqP2JlkIEANhd+ih0glQBLZynIQdi5AfWc5t74FJ0DeAduH7R4ZQDo6kqHiZCRATOGG7/anL0CRasJrMP8lQJTOx9c6OSBAteuyYWg9JEBqkGefu6crQADWLbLJnyVAPUYiO8iSG0D8OpfVY3QiQFJh4n1viSpA8w3PwtjeI0DH0XzVih4aQLlTH+25kyFA1wo93YZHK0DmsFIu1J8jQKW3pi5V0hlA5mv1bFqrIUDJqLKI1WkqQDJoJPViSyNANImzMze8GUDNERP6bGEgQNtYYxfuKipAzJdGI6DHIkDCTGVjdroYQJRWMUm4/iBA2x7HCBzDKEDv1sMLL08iQJPDqYpiNBZATpx5s4BQFkCntjdT7w0XQOp0zVqzixZA",
+          "bdata": "JUmSJDMzH0AlSZKkstooQAAAAHjr0TNAL7roIk9JK0Dns0+vEIwhQB4xggSq1SdAD/XWf8WnMECxIhGq6DspQL7I/MWhyR9ARvBcmYNUJ0BwdmsSZpkvQEkIyb1o7SdAKKqP2JlkIEANhd+ih0glQBLZynIQdi5AfWc5t74FJ0DeAduH7R4ZQDo6kqHiZCRATOGG7/anL0CRasJrMP8lQJTOx9c6OSBAteuyYWg9JEBqkGefu6crQADWLbLJnyVAPUYiO8iSG0D8OpfVY3QiQFJh4n1viSpA8w3PwtjeI0DH0XzVih4aQLlTH+25kyFA1wo93YZHK0DmsFIu1J8jQDSJszM3vBlAzRET+mxhIEDbWGMX7ioqQMyXRiOgxyJAwkxlY3a6GECUVjFJuP4gQNsexwgcwyhA79bDCy9PIkAyEtnLo0EUQNa+Ya2xix5AC0OWtDMFJ0BDgT/4Z2ogQMYnCshbRBZAbiFlxdwfH0AEjMYNw94kQI97jERPDiBA",
           "dtype": "f8",
           "shape": "12, 4"
          }
@@ -3490,7 +1757,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "c0f3f7b1",
    "metadata": {},
    "outputs": [
@@ -3504,7 +1771,7 @@
         {
          "error_x": {
           "array": {
-           "bdata": "24VyKdVJA0ApQSBys7b1Py4UaSz27fU/TCswAXxV9T8z7GGgJUgBQKqv9FbdCfU/e6zyCQk58z+Ngc/khQ72P9T0WLOh+PI/CqXyBbrC9D9I9U9MH1DyPzHydTwofeI/",
+           "bdata": "24VyKdVJA0ApQSBys7b1Py4UaSz27fU/TCswAXxV9T8z7GGgJUgBQKqv9FbdCfU/e6zyCQk58z+Ngc/khQ72Pwql8gW6wvQ/SPVPTB9Q8j8LGFeRv+nwP0gfWkBtpus/",
            "dtype": "f8"
           },
           "color": "#888888",
@@ -3523,8 +1790,8 @@
            "#2ca02c",
            "#2ca02c",
            "#1f77b4",
-           "#2ca02c",
            "#1f77b4",
+           "#2ca02c",
            "#2ca02c",
            "#2ca02c"
           ],
@@ -3534,7 +1801,7 @@
          "showlegend": false,
          "type": "scatter",
          "x": {
-          "bdata": "L7roIk9JK0CxIhGq6DspQEkIyb1o7SdAfWc5t74FJ0CRasJrMP8lQADWLbLJnyVA8w3PwtjeI0DmsFIu1J8jQDJoJPViSyNAzJdGI6DHIkDv1sMLL08iQOp0zVqzixZA",
+          "bdata": "L7roIk9JK0CxIhGq6DspQEkIyb1o7SdAfWc5t74FJ0CRasJrMP8lQADWLbLJnyVA8w3PwtjeI0DmsFIu1J8jQMyXRiOgxyJA79bDCy9PIkBDgT/4Z2ogQI97jERPDiBA",
           "dtype": "f8"
          },
          "y": [
@@ -3546,9 +1813,9 @@
           "LLMP-Sampled (gemini-3.1-flash-lite-preview)",
           "LLMP-Grid (gemini-3.1-flash-lite-preview)",
           "LightGBM + cov",
-          "News Agent (gemini-3.1-flash-lite-preview)",
           "LightGBM",
           "LLMP-Grid (gemini-3.5-flash)",
+          "News Agent (gemini-3.1-flash-lite-preview)",
           "News Agent (gemini-3.5-flash)"
          ]
         }
@@ -3562,7 +1829,7 @@
           },
           "showarrow": false,
           "text": " best",
-          "x": 5.636426371374208,
+          "x": 8.027948515080224,
           "xanchor": "center",
           "xref": "x",
           "y": 1,
@@ -3585,8 +1852,8 @@
            "width": 1.5
           },
           "type": "line",
-          "x0": 5.636426371374208,
-          "x1": 5.636426371374208,
+          "x0": 8.027948515080224,
+          "x1": 8.027948515080224,
           "xref": "x",
           "y0": 0,
           "y1": 1,
@@ -4419,7 +2686,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "ba384e79",
    "metadata": {},
    "outputs": [
@@ -4427,7 +2694,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Showing: News Agent (gemini-3.5-flash), LLMP-Grid (gemini-3.5-flash), LightGBM\n"
+      "Showing: News Agent (gemini-3.5-flash), News Agent (gemini-3.1-flash-lite-preview), LLMP-Grid (gemini-3.5-flash)\n"
      ]
     },
     {
@@ -4567,12 +2834,12 @@
         {
          "error_y": {
           "array": [
-           2,
-           4
+           2.5,
+           5.799999999999997
           ],
           "arrayminus": [
-           1.7999999999999972,
-           3.5
+           2.299999999999997,
+           4.799999999999997
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -4600,8 +2867,49 @@
          ],
          "xaxis": "x",
          "y": [
-          64,
-          61.5
+          61.8,
+          60
+         ],
+         "yaxis": "y"
+        },
+        {
+         "error_y": {
+          "array": [
+           1.4000000000000057,
+           3
+          ],
+          "arrayminus": [
+           1.2000000000000028,
+           2.5
+          ],
+          "color": "#ff7f0e",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
+         "line": {
+          "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": true,
+         "type": "scatter",
+         "x": [
+          "2026-02-09T00:00:00",
+          "2026-03-03T00:00:00"
+         ],
+         "xaxis": "x",
+         "y": [
+          65.8,
+          65.5
          ],
          "yaxis": "y"
         },
@@ -4615,7 +2923,7 @@
            3.3499999999999943,
            6.039999999999999
           ],
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "symmetric": false,
           "thickness": 1.4,
           "type": "data",
@@ -4623,7 +2931,7 @@
          },
          "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
          "line": {
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -4643,47 +2951,6 @@
          "y": [
           65.88,
           66.41
-         ],
-         "yaxis": "y"
-        },
-        {
-         "error_y": {
-          "array": [
-           2.408147967633269,
-           3.548615365718092
-          ],
-          "arrayminus": [
-           1.1985169741866173,
-           4.652506604793558
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": true,
-         "type": "scatter",
-         "x": [
-          "2026-02-09T00:00:00",
-          "2026-03-03T00:00:00"
-         ],
-         "xaxis": "x",
-         "y": [
-          64.31607893595701,
-          63.40795619254804
          ],
          "yaxis": "y"
         },
@@ -4817,12 +3084,12 @@
         {
          "error_y": {
           "array": [
-           5,
-           7.799999999999997
+           3.950000000000003,
+           5.799999999999997
           ],
           "arrayminus": [
-           3.6000000000000014,
-           5
+           3.200000000000003,
+           4.399999999999999
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -4850,20 +3117,20 @@
          ],
          "xaxis": "x2",
          "y": [
-          63,
-          62
+          63.25,
+          63
          ],
          "yaxis": "y2"
         },
         {
          "error_y": {
           "array": [
-           3.359999999999999,
-           4.990000000000009
+           3,
+           4.700000000000003
           ],
           "arrayminus": [
-           2.740000000000002,
-           4.009999999999998
+           2.299999999999997,
+           3.700000000000003
           ],
           "color": "#ff7f0e",
           "symmetric": false,
@@ -4871,9 +3138,50 @@
           "type": "data",
           "width": 4
          },
-         "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
          "line": {
           "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-23T00:00:00",
+          "2026-03-10T00:00:00"
+         ],
+         "xaxis": "x2",
+         "y": [
+          64.8,
+          65.5
+         ],
+         "yaxis": "y2"
+        },
+        {
+         "error_y": {
+          "array": [
+           3.3599999999999994,
+           4.990000000000009
+          ],
+          "arrayminus": [
+           2.740000000000002,
+           4.009999999999998
+          ],
+          "color": "#2ca02c",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
+         "line": {
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -4893,47 +3201,6 @@
          "y": [
           62.64,
           61.16
-         ],
-         "yaxis": "y2"
-        },
-        {
-         "error_y": {
-          "array": [
-           2.175075791777516,
-           2.7741393845874427
-          ],
-          "arrayminus": [
-           1.4453925029217132,
-           6.343198258657928
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-02-23T00:00:00",
-          "2026-03-10T00:00:00"
-         ],
-         "xaxis": "x2",
-         "y": [
-          64.50781263457384,
-          64.68245364485004
          ],
          "yaxis": "y2"
         },
@@ -5069,14 +3336,14 @@
         {
          "error_y": {
           "array": [
-           3.5799999999999983,
-           11.269999999999996,
-           19.290000000000006
+           2.0999999999999943,
+           2.9000000000000057,
+           4.400000000000006
           ],
           "arrayminus": [
-           2.519999999999996,
-           7.730000000000004,
-           30.709999999999994
+           2,
+           2.700000000000003,
+           4
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -5105,9 +3372,54 @@
          ],
          "xaxis": "x3",
          "y": [
-          65.72,
-          71.23,
-          95.71
+          63.2,
+          63.5,
+          63.8
+         ],
+         "yaxis": "y3"
+        },
+        {
+         "error_y": {
+          "array": [
+           1.1999999999999957,
+           1.8999999999999915,
+           2.799999999999997
+          ],
+          "arrayminus": [
+           1.1000000000000014,
+           1.8000000000000043,
+           2.700000000000003
+          ],
+          "color": "#ff7f0e",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
+         "line": {
+          "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-02-23T00:00:00",
+          "2026-03-02T00:00:00",
+          "2026-03-17T00:00:00"
+         ],
+         "xaxis": "x3",
+         "y": [
+          62.9,
+          63.2,
+          63.5
          ],
          "yaxis": "y3"
         },
@@ -5120,10 +3432,10 @@
           ],
           "arrayminus": [
            3,
-           3.800000000000004,
+           3.8000000000000043,
            5.099999999999994
           ],
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "symmetric": false,
           "thickness": 1.4,
           "type": "data",
@@ -5131,7 +3443,7 @@
          },
          "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
          "line": {
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -5153,51 +3465,6 @@
           62.4,
           61.7,
           60.3
-         ],
-         "yaxis": "y3"
-        },
-        {
-         "error_y": {
-          "array": [
-           1.5661620542482524,
-           1.1976983694151642,
-           3.677945734416326
-          ],
-          "arrayminus": [
-           3.5777603905807283,
-           5.2121990345644775,
-           8.340490924000427
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-02-23T00:00:00",
-          "2026-03-02T00:00:00",
-          "2026-03-17T00:00:00"
-         ],
-         "xaxis": "x3",
-         "y": [
-          63.82274492839041,
-          65.26944502232584,
-          63.72796242178093
          ],
          "yaxis": "y3"
         },
@@ -5333,14 +3600,14 @@
         {
          "error_y": {
           "array": [
-           6.5,
-           23,
-           21.5
+           2.5,
+           3.4000000000000057,
+           5.5
           ],
           "arrayminus": [
-           6.5,
-           18,
-           15.5
+           2.299999999999997,
+           3.299999999999997,
+           5
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -5369,9 +3636,54 @@
          ],
          "xaxis": "x4",
          "y": [
-          74.5,
-          88,
-          85.5
+          66.5,
+          66.8,
+          67
+         ],
+         "yaxis": "y4"
+        },
+        {
+         "error_y": {
+          "array": [
+           1.7000000000000028,
+           2.700000000000003,
+           4
+          ],
+          "arrayminus": [
+           1.5,
+           2.299999999999997,
+           2.5
+          ],
+          "color": "#ff7f0e",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
+         "line": {
+          "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-03-02T00:00:00",
+          "2026-03-09T00:00:00",
+          "2026-03-24T00:00:00"
+         ],
+         "xaxis": "x4",
+         "y": [
+          66.5,
+          66.8,
+          65.5
          ],
          "yaxis": "y4"
         },
@@ -5387,7 +3699,7 @@
            2.749999999999993,
            3.8999999999999986
           ],
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "symmetric": false,
           "thickness": 1.4,
           "type": "data",
@@ -5395,7 +3707,7 @@
          },
          "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
          "line": {
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -5417,51 +3729,6 @@
           66.05,
           65.6,
           64.55
-         ],
-         "yaxis": "y4"
-        },
-        {
-         "error_y": {
-          "array": [
-           1.1597652314365234,
-           2.34436378940417,
-           4.593402725442601
-          ],
-          "arrayminus": [
-           2.333259478436858,
-           3.5685101606554426,
-           3.8115495606647016
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-03-02T00:00:00",
-          "2026-03-09T00:00:00",
-          "2026-03-24T00:00:00"
-         ],
-         "xaxis": "x4",
-         "y": [
-          66.92888696659587,
-          65.62766121627956,
-          66.06219012602452
          ],
          "yaxis": "y4"
         },
@@ -5589,22 +3856,22 @@
           90.31999969482422,
           94.4800033569336,
           99.63999938964844,
-          102.87999725341795,
-          101.37999725341795
+          102.87999725341797,
+          101.37999725341797
          ],
          "yaxis": "y5"
         },
         {
          "error_y": {
           "array": [
-           10.5,
-           14,
-           15
+           7,
+           9,
+           10.5
           ],
           "arrayminus": [
-           8,
-           12,
-           18
+           4.5,
+           5.5,
+           7
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -5633,9 +3900,54 @@
          ],
          "xaxis": "x5",
          "y": [
-          84,
-          95,
-          110
+          75.5,
+          74.5,
+          73.5
+         ],
+         "yaxis": "y5"
+        },
+        {
+         "error_y": {
+          "array": [
+           5,
+           8,
+           13
+          ],
+          "arrayminus": [
+           3,
+           4,
+           5
+          ],
+          "color": "#ff7f0e",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
+         "line": {
+          "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-03-09T00:00:00",
+          "2026-03-16T00:00:00",
+          "2026-03-31T00:00:00"
+         ],
+         "xaxis": "x5",
+         "y": [
+          82,
+          88,
+          95
          ],
          "yaxis": "y5"
         },
@@ -5651,7 +3963,7 @@
            3.500000000000007,
            4.999999999999993
           ],
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "symmetric": false,
           "thickness": 1.4,
           "type": "data",
@@ -5659,7 +3971,7 @@
          },
          "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
          "line": {
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -5681,51 +3993,6 @@
           66.9,
           66.65,
           66.1
-         ],
-         "yaxis": "y5"
-        },
-        {
-         "error_y": {
-          "array": [
-           0.8243555501988453,
-           0.819539076298156,
-           5.588605465823164
-          ],
-          "arrayminus": [
-           1.3457711357753652,
-           4.891892132291034,
-           4.411155252119485
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-03-09T00:00:00",
-          "2026-03-16T00:00:00",
-          "2026-03-31T00:00:00"
-         ],
-         "xaxis": "x5",
-         "y": [
-          66.88783720085925,
-          67.4880350032759,
-          66.75206441696794
          ],
          "yaxis": "y5"
         },
@@ -5847,26 +4114,26 @@
           90.31999969482422,
           94.4800033569336,
           99.63999938964844,
-          102.87999725341795,
-          101.37999725341795,
-          100.12000274658205,
+          102.87999725341797,
+          101.37999725341797,
+          100.12000274658203,
           111.54000091552734,
           112.41000366210938,
-          112.9499969482422
+          112.94999694824219
          ],
          "yaxis": "y6"
         },
         {
          "error_y": {
           "array": [
-           11,
            13,
-           15
+           17,
+           18
           ],
           "arrayminus": [
-           10,
-           10,
-           9
+           8.5,
+           12,
+           13
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -5895,9 +4162,54 @@
          ],
          "xaxis": "x6",
          "y": [
+          106.5,
           108,
-          104,
-          94
+          105.5
+         ],
+         "yaxis": "y6"
+        },
+        {
+         "error_y": {
+          "array": [
+           11,
+           12,
+           15
+          ],
+          "arrayminus": [
+           10,
+           10,
+           12
+          ],
+          "color": "#ff7f0e",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
+         "line": {
+          "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-03-16T00:00:00",
+          "2026-03-23T00:00:00",
+          "2026-04-07T00:00:00"
+         ],
+         "xaxis": "x6",
+         "y": [
+          105,
+          110,
+          118
          ],
          "yaxis": "y6"
         },
@@ -5906,14 +4218,14 @@
           "array": [
            7.799999999999997,
            9.900000000000006,
-           12.299999999999995
+           12.299999999999997
           ],
           "arrayminus": [
            8,
            9.5,
            11.099999999999994
           ],
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "symmetric": false,
           "thickness": 1.4,
           "type": "data",
@@ -5921,7 +4233,7 @@
          },
          "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
          "line": {
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -5943,51 +4255,6 @@
           88,
           85.8,
           82.3
-         ],
-         "yaxis": "y6"
-        },
-        {
-         "error_y": {
-          "array": [
-           3.05287920369706,
-           3.724124145839653,
-           8.264940353309782
-          ],
-          "arrayminus": [
-           2.708428265640336,
-           5.413549513750425,
-           3.2807530426153164
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-03-16T00:00:00",
-          "2026-03-23T00:00:00",
-          "2026-04-07T00:00:00"
-         ],
-         "xaxis": "x6",
-         "y": [
-          85.20471203310971,
-          86.46963346680023,
-          85.71500652029715
          ],
          "yaxis": "y6"
         },
@@ -6104,16 +4371,16 @@
           90.31999969482422,
           94.4800033569336,
           99.63999938964844,
-          102.87999725341795,
-          101.37999725341795,
-          100.12000274658205,
+          102.87999725341797,
+          101.37999725341797,
+          100.12000274658203,
           111.54000091552734,
           112.41000366210938,
-          112.9499969482422,
+          112.94999694824219,
           94.41000366210938,
-          97.87000274658205,
+          97.87000274658203,
           96.56999969482422,
-          99.08000183105467,
+          99.08000183105469,
           91.27999877929688
          ],
          "yaxis": "y7"
@@ -6121,14 +4388,14 @@
         {
          "error_y": {
           "array": [
-           5.88000000000001,
-           8.120000000000005,
-           9.819999999999991
+           6,
+           8,
+           11
           ],
           "arrayminus": [
-           4.819999999999993,
-           6.079999999999998,
-           7.180000000000007
+           7,
+           7.5,
+           10
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -6157,9 +4424,54 @@
          ],
          "xaxis": "x7",
          "y": [
-          98.32,
-          102.88,
-          95.18
+          98,
+          95.5,
+          93
+         ],
+         "yaxis": "y7"
+        },
+        {
+         "error_y": {
+          "array": [
+           2.5,
+           4,
+           6.5
+          ],
+          "arrayminus": [
+           2.5,
+           3.5,
+           5
+          ],
+          "color": "#ff7f0e",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
+         "line": {
+          "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-03-23T00:00:00",
+          "2026-03-30T00:00:00",
+          "2026-04-14T00:00:00"
+         ],
+         "xaxis": "x7",
+         "y": [
+          96.5,
+          94,
+          90
          ],
          "yaxis": "y7"
         },
@@ -6168,14 +4480,14 @@
           "array": [
            7.5,
            9.099999999999994,
-           10.700000000000005
+           10.700000000000003
           ],
           "arrayminus": [
            7.300000000000011,
            8.5,
            9.5
           ],
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "symmetric": false,
           "thickness": 1.4,
           "type": "data",
@@ -6183,7 +4495,7 @@
          },
          "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
          "line": {
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -6205,51 +4517,6 @@
           92.9,
           88,
           78.2
-         ],
-         "yaxis": "y7"
-        },
-        {
-         "error_y": {
-          "array": [
-           2.065800830941626,
-           1.1442963064246785,
-           2.1294013498790463
-          ],
-          "arrayminus": [
-           3.0850032535107914,
-           4.036076980567515,
-           7.803309660346613
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-03-23T00:00:00",
-          "2026-03-30T00:00:00",
-          "2026-04-14T00:00:00"
-         ],
-         "xaxis": "x7",
-         "y": [
-          97.0192936445251,
-          96.69314101927972,
-          98.15667266072978
          ],
          "yaxis": "y7"
         },
@@ -6361,36 +4628,36 @@
           90.31999969482422,
           94.4800033569336,
           99.63999938964844,
-          102.87999725341795,
-          101.37999725341795,
-          100.12000274658205,
+          102.87999725341797,
+          101.37999725341797,
+          100.12000274658203,
           111.54000091552734,
           112.41000366210938,
-          112.9499969482422,
+          112.94999694824219,
           94.41000366210938,
-          97.87000274658205,
+          97.87000274658203,
           96.56999969482422,
-          99.08000183105467,
+          99.08000183105469,
           91.27999877929688,
           91.29000091552734,
-          94.69000244140624,
+          94.69000244140625,
           83.8499984741211,
           89.61000061035156,
-          92.12999725341795
+          92.12999725341797
          ],
          "yaxis": "y8"
         },
         {
          "error_y": {
           "array": [
-           9,
-           10.5,
-           12
+           6,
+           9.5,
+           15
           ],
           "arrayminus": [
-           6.5,
-           8.5,
-           9
+           5,
+           9,
+           15
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -6419,9 +4686,54 @@
          ],
          "xaxis": "x8",
          "y": [
-          86.5,
-          84.5,
-          81
+          99,
+          101,
+          103
+         ],
+         "yaxis": "y8"
+        },
+        {
+         "error_y": {
+          "array": [
+           4.5,
+           6.5,
+           11
+          ],
+          "arrayminus": [
+           3.5,
+           6,
+           10
+          ],
+          "color": "#ff7f0e",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
+         "line": {
+          "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-03-30T00:00:00",
+          "2026-04-06T00:00:00",
+          "2026-04-21T00:00:00"
+         ],
+         "xaxis": "x8",
+         "y": [
+          100.5,
+          102.5,
+          105
          ],
          "yaxis": "y8"
         },
@@ -6435,9 +4747,9 @@
           "arrayminus": [
            8.049999999999997,
            9.599999999999994,
-           12.049999999999995
+           12.049999999999997
           ],
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "symmetric": false,
           "thickness": 1.4,
           "type": "data",
@@ -6445,7 +4757,7 @@
          },
          "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
          "line": {
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -6467,51 +4779,6 @@
           96.5,
           94.85,
           91.5
-         ],
-         "yaxis": "y8"
-        },
-        {
-         "error_y": {
-          "array": [
-           0.8615922921248256,
-           0.5040056095808723,
-           1.5615465371502495
-          ],
-          "arrayminus": [
-           2.8106503989552465,
-           2.751205445541146,
-           9.491381849253358
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-03-30T00:00:00",
-          "2026-04-06T00:00:00",
-          "2026-04-21T00:00:00"
-         ],
-         "xaxis": "x8",
-         "y": [
-          97.08841601412756,
-          97.8736538480731,
-          99.11819105936225
          ],
          "yaxis": "y8"
         },
@@ -6578,7 +4845,7 @@
           90.31999969482422,
           94.4800033569336,
           99.63999938964844,
-          102.87999725341795
+          102.87999725341797
          ],
          "yaxis": "y9"
         },
@@ -6619,25 +4886,25 @@
          ],
          "xaxis": "x9",
          "y": [
-          101.37999725341795,
-          100.12000274658205,
+          101.37999725341797,
+          100.12000274658203,
           111.54000091552734,
           112.41000366210938,
-          112.9499969482422,
+          112.94999694824219,
           94.41000366210938,
-          97.87000274658205,
+          97.87000274658203,
           96.56999969482422,
-          99.08000183105467,
+          99.08000183105469,
           91.27999877929688,
           91.29000091552734,
-          94.69000244140624,
+          94.69000244140625,
           83.8499984741211,
           89.61000061035156,
-          92.12999725341795,
+          92.12999725341797,
           92.95999908447266,
           95.8499984741211,
           94.4000015258789,
-          96.37000274658205,
+          96.37000274658203,
           99.93000030517578
          ],
          "yaxis": "y9"
@@ -6645,14 +4912,14 @@
         {
          "error_y": {
           "array": [
-           7.5,
-           9.5,
-           12.5
+           10.5,
+           15,
+           17
           ],
           "arrayminus": [
-           6,
-           7,
-           9.5
+           11.5,
+           15,
+           16
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -6681,23 +4948,23 @@
          ],
          "xaxis": "x9",
          "y": [
-          100,
-          98,
-          94.5
+          101.5,
+          103,
+          98
          ],
          "yaxis": "y9"
         },
         {
          "error_y": {
           "array": [
-           7.699999999999989,
-           9.799999999999995,
-           12.400000000000006
+           5,
+           8,
+           14
           ],
           "arrayminus": [
+           4,
            7,
-           8.5,
-           9.599999999999994
+           12
           ],
           "color": "#ff7f0e",
           "symmetric": false,
@@ -6705,9 +4972,54 @@
           "type": "data",
           "width": 4
          },
-         "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
          "line": {
           "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-04-06T00:00:00",
+          "2026-04-13T00:00:00",
+          "2026-04-28T00:00:00"
+         ],
+         "xaxis": "x9",
+         "y": [
+          102.5,
+          105,
+          108
+         ],
+         "yaxis": "y9"
+        },
+        {
+         "error_y": {
+          "array": [
+           7.699999999999989,
+           9.799999999999997,
+           12.400000000000006
+          ],
+          "arrayminus": [
+           7,
+           8.5,
+           9.599999999999994
+          ],
+          "color": "#2ca02c",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
+         "line": {
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -6729,51 +5041,6 @@
           97.4,
           94.8,
           89.8
-         ],
-         "yaxis": "y9"
-        },
-        {
-         "error_y": {
-          "array": [
-           3.092529948520422,
-           2.307391698257163,
-           7.203953632021168
-          ],
-          "arrayminus": [
-           1.8037780421456944,
-           4.012917297705144,
-           4.23123655621032
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-04-06T00:00:00",
-          "2026-04-13T00:00:00",
-          "2026-04-28T00:00:00"
-         ],
-         "xaxis": "x9",
-         "y": [
-          99.43463410690524,
-          97.7857460074704,
-          97.9353699186534
          ],
          "yaxis": "y9"
         },
@@ -6836,9 +5103,9 @@
           90.31999969482422,
           94.4800033569336,
           99.63999938964844,
-          102.87999725341795,
-          101.37999725341795,
-          100.12000274658205,
+          102.87999725341797,
+          101.37999725341797,
+          100.12000274658203,
           111.54000091552734,
           112.41000366210938
          ],
@@ -6882,26 +5149,26 @@
          ],
          "xaxis": "x10",
          "y": [
-          112.9499969482422,
+          112.94999694824219,
           94.41000366210938,
-          97.87000274658205,
+          97.87000274658203,
           96.56999969482422,
-          99.08000183105467,
+          99.08000183105469,
           91.27999877929688,
           91.29000091552734,
-          94.69000244140624,
+          94.69000244140625,
           83.8499984741211,
           89.61000061035156,
-          92.12999725341795,
+          92.12999725341797,
           92.95999908447266,
           95.8499984741211,
           94.4000015258789,
-          96.37000274658205,
+          96.37000274658203,
           99.93000030517578,
-          106.87999725341795,
+          106.87999725341797,
           105.06999969482422,
-          101.94000244140624,
-          106.41999816894533,
+          101.94000244140625,
+          106.41999816894531,
           102.2699966430664
          ],
          "yaxis": "y10"
@@ -6910,13 +5177,13 @@
          "error_y": {
           "array": [
            8,
-           10,
-           12
+           11,
+           17
           ],
           "arrayminus": [
            8,
-           9,
-           11
+           10,
+           12
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -6945,23 +5212,23 @@
          ],
          "xaxis": "x10",
          "y": [
-          111,
-          107,
-          101
+          112,
+          110,
+          105
          ],
          "yaxis": "y10"
         },
         {
          "error_y": {
           "array": [
-           11.5,
-           14.700000000000005,
-           19.200000000000003
+           5.5,
+           7,
+           7.5
           ],
           "arrayminus": [
-           11,
-           13.400000000000006,
-           16.099999999999994
+           4.5,
+           6,
+           6
           ],
           "color": "#ff7f0e",
           "symmetric": false,
@@ -6969,9 +5236,54 @@
           "type": "data",
           "width": 4
          },
-         "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
          "line": {
           "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-04-13T00:00:00",
+          "2026-04-20T00:00:00",
+          "2026-05-05T00:00:00"
+         ],
+         "xaxis": "x10",
+         "y": [
+          108,
+          105,
+          100
+         ],
+         "yaxis": "y10"
+        },
+        {
+         "error_y": {
+          "array": [
+           11.5,
+           14.700000000000003,
+           19.200000000000003
+          ],
+          "arrayminus": [
+           11,
+           13.400000000000006,
+           16.099999999999994
+          ],
+          "color": "#2ca02c",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
+         "line": {
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -6993,51 +5305,6 @@
           110.2,
           108.5,
           105.1
-         ],
-         "yaxis": "y10"
-        },
-        {
-         "error_y": {
-          "array": [
-           3.3871081869549755,
-           4.391068945117084,
-           3.2897759065050565
-          ],
-          "arrayminus": [
-           5.362135745165503,
-           3.568112441676547,
-           1.624172994848024
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-04-13T00:00:00",
-          "2026-04-20T00:00:00",
-          "2026-05-05T00:00:00"
-         ],
-         "xaxis": "x10",
-         "y": [
-          104.11581088946544,
-          102.30227566156763,
-          104.39134584257752
          ],
          "yaxis": "y10"
         },
@@ -7095,16 +5362,16 @@
           90.31999969482422,
           94.4800033569336,
           99.63999938964844,
-          102.87999725341795,
-          101.37999725341795,
-          100.12000274658205,
+          102.87999725341797,
+          101.37999725341797,
+          100.12000274658203,
           111.54000091552734,
           112.41000366210938,
-          112.9499969482422,
+          112.94999694824219,
           94.41000366210938,
-          97.87000274658205,
+          97.87000274658203,
           96.56999969482422,
-          99.08000183105467
+          99.08000183105469
          ],
          "yaxis": "y11"
         },
@@ -7148,23 +5415,23 @@
          "y": [
           91.27999877929688,
           91.29000091552734,
-          94.69000244140624,
+          94.69000244140625,
           83.8499984741211,
           89.61000061035156,
-          92.12999725341795,
+          92.12999725341797,
           92.95999908447266,
           95.8499984741211,
           94.4000015258789,
-          96.37000274658205,
+          96.37000274658203,
           99.93000030517578,
-          106.87999725341795,
+          106.87999725341797,
           105.06999969482422,
-          101.94000244140624,
-          106.41999816894533,
+          101.94000244140625,
+          106.41999816894531,
           102.2699966430664,
-          95.08000183105467,
-          94.80999755859376,
-          95.41999816894533,
+          95.08000183105469,
+          94.80999755859375,
+          95.41999816894531,
           98.06999969482422,
           102.18000030517578
          ],
@@ -7173,14 +5440,14 @@
         {
          "error_y": {
           "array": [
-           4.5,
-           5.5,
-           6.5
+           12,
+           17,
+           21
           ],
           "arrayminus": [
-           4,
-           5,
-           8
+           12,
+           16,
+           21
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -7209,9 +5476,54 @@
          ],
          "xaxis": "x11",
          "y": [
-          106.5,
-          110,
-          112
+          103,
+          101,
+          97
+         ],
+         "yaxis": "y11"
+        },
+        {
+         "error_y": {
+          "array": [
+           4.5,
+           7,
+           10
+          ],
+          "arrayminus": [
+           3.5,
+           5,
+           7
+          ],
+          "color": "#ff7f0e",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
+         "line": {
+          "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-04-20T00:00:00",
+          "2026-04-27T00:00:00",
+          "2026-05-12T00:00:00"
+         ],
+         "xaxis": "x11",
+         "y": [
+          98.5,
+          102,
+          108
          ],
          "yaxis": "y11"
         },
@@ -7227,7 +5539,7 @@
            5.299999999999997,
            8.100000000000009
           ],
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "symmetric": false,
           "thickness": 1.4,
           "type": "data",
@@ -7235,7 +5547,7 @@
          },
          "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
          "line": {
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -7257,51 +5569,6 @@
           96.3,
           95.1,
           92.4
-         ],
-         "yaxis": "y11"
-        },
-        {
-         "error_y": {
-          "array": [
-           3.749364122974896,
-           4.642627756168125,
-           6.169125151194791
-          ],
-          "arrayminus": [
-           2.8324605796252484,
-           3.691161011952815,
-           9.28729190826772
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-04-20T00:00:00",
-          "2026-04-27T00:00:00",
-          "2026-05-12T00:00:00"
-         ],
-         "xaxis": "x11",
-         "y": [
-          96.88783936856557,
-          97.46989403776756,
-          96.9156635826384
          ],
          "yaxis": "y11"
         },
@@ -7354,19 +5621,19 @@
           90.31999969482422,
           94.4800033569336,
           99.63999938964844,
-          102.87999725341795,
-          101.37999725341795,
-          100.12000274658205,
+          102.87999725341797,
+          101.37999725341797,
+          100.12000274658203,
           111.54000091552734,
           112.41000366210938,
-          112.9499969482422,
+          112.94999694824219,
           94.41000366210938,
-          97.87000274658205,
+          97.87000274658203,
           96.56999969482422,
-          99.08000183105467,
+          99.08000183105469,
           91.27999877929688,
           91.29000091552734,
-          94.69000244140624,
+          94.69000244140625,
           83.8499984741211,
           89.61000061035156
          ],
@@ -7410,25 +5677,25 @@
          ],
          "xaxis": "x12",
          "y": [
-          92.12999725341795,
+          92.12999725341797,
           92.95999908447266,
           95.8499984741211,
           94.4000015258789,
-          96.37000274658205,
+          96.37000274658203,
           99.93000030517578,
-          106.87999725341795,
+          106.87999725341797,
           105.06999969482422,
-          101.94000244140624,
-          106.41999816894533,
+          101.94000244140625,
+          106.41999816894531,
           102.2699966430664,
-          95.08000183105467,
-          94.80999755859376,
-          95.41999816894533,
+          95.08000183105469,
+          94.80999755859375,
+          95.41999816894531,
           98.06999969482422,
           102.18000030517578,
           101.0199966430664,
-          101.16999816894533,
-          105.41999816894533,
+          101.16999816894531,
+          105.41999816894531,
           108.66000366210938,
           107.7699966430664
          ],
@@ -7437,14 +5704,14 @@
         {
          "error_y": {
           "array": [
-           5,
            6.5,
-           8
+           10,
+           13.5
           ],
           "arrayminus": [
-           5,
            6.5,
-           9
+           10,
+           14.5
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -7473,9 +5740,54 @@
          ],
          "xaxis": "x12",
          "y": [
-          96,
-          105.5,
-          102
+          91.5,
+          93,
+          94.5
+         ],
+         "yaxis": "y12"
+        },
+        {
+         "error_y": {
+          "array": [
+           5,
+           7,
+           9
+          ],
+          "arrayminus": [
+           4,
+           5,
+           5
+          ],
+          "color": "#ff7f0e",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
+         "line": {
+          "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-04-27T00:00:00",
+          "2026-05-04T00:00:00",
+          "2026-05-19T00:00:00"
+         ],
+         "xaxis": "x12",
+         "y": [
+          88,
+          92,
+          95
          ],
          "yaxis": "y12"
         },
@@ -7491,7 +5803,7 @@
            7.299999999999997,
            10.599999999999994
           ],
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "symmetric": false,
           "thickness": 1.4,
           "type": "data",
@@ -7499,7 +5811,7 @@
          },
          "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
          "line": {
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -7521,51 +5833,6 @@
           84.1,
           83.6,
           82.5
-         ],
-         "yaxis": "y12"
-        },
-        {
-         "error_y": {
-          "array": [
-           6.976697409267828,
-           6.593622209280426,
-           6.117087295263502
-          ],
-          "arrayminus": [
-           3.8378465149603898,
-           6.565672308332978,
-           15.522320422304231
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-04-27T00:00:00",
-          "2026-05-04T00:00:00",
-          "2026-05-19T00:00:00"
-         ],
-         "xaxis": "x12",
-         "y": [
-          85.32536976209812,
-          85.20522134010547,
-          89.2270323998424
          ],
          "yaxis": "y12"
         },
@@ -7613,26 +5880,26 @@
           90.31999969482422,
           94.4800033569336,
           99.63999938964844,
-          102.87999725341795,
-          101.37999725341795,
-          100.12000274658205,
+          102.87999725341797,
+          101.37999725341797,
+          100.12000274658203,
           111.54000091552734,
           112.41000366210938,
-          112.9499969482422,
+          112.94999694824219,
           94.41000366210938,
-          97.87000274658205,
+          97.87000274658203,
           96.56999969482422,
-          99.08000183105467,
+          99.08000183105469,
           91.27999877929688,
           91.29000091552734,
-          94.69000244140624,
+          94.69000244140625,
           83.8499984741211,
           89.61000061035156,
-          92.12999725341795,
+          92.12999725341797,
           92.95999908447266,
           95.8499984741211,
           94.4000015258789,
-          96.37000274658205
+          96.37000274658203
          ],
          "yaxis": "y13"
         },
@@ -7674,22 +5941,22 @@
          "xaxis": "x13",
          "y": [
           99.93000030517578,
-          106.87999725341795,
+          106.87999725341797,
           105.06999969482422,
-          101.94000244140624,
-          106.41999816894533,
+          101.94000244140625,
+          106.41999816894531,
           102.2699966430664,
-          95.08000183105467,
-          94.80999755859376,
-          95.41999816894533,
+          95.08000183105469,
+          94.80999755859375,
+          95.41999816894531,
           98.06999969482422,
           102.18000030517578,
           101.0199966430664,
-          101.16999816894533,
-          105.41999816894533,
+          101.16999816894531,
+          105.41999816894531,
           108.66000366210938,
           107.7699966430664,
-          98.26000213623048,
+          98.26000213623047,
           96.3499984741211,
           96.5999984741211,
           93.88999938964844
@@ -7699,14 +5966,14 @@
         {
          "error_y": {
           "array": [
-           6,
            9,
-           11.5
+           11.5,
+           13.5
           ],
           "arrayminus": [
-           6,
            8,
-           10
+           9.5,
+           11.5
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -7735,9 +6002,54 @@
          ],
          "xaxis": "x13",
          "y": [
-          98,
-          99,
-          97
+          93,
+          91.5,
+          88.5
+         ],
+         "yaxis": "y13"
+        },
+        {
+         "error_y": {
+          "array": [
+           4.5,
+           5,
+           6.5
+          ],
+          "arrayminus": [
+           4,
+           4,
+           5.5
+          ],
+          "color": "#ff7f0e",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
+         "line": {
+          "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-05-04T00:00:00",
+          "2026-05-11T00:00:00",
+          "2026-05-26T00:00:00"
+         ],
+         "xaxis": "x13",
+         "y": [
+          93.5,
+          92,
+          89.5
          ],
          "yaxis": "y13"
         },
@@ -7751,9 +6063,9 @@
           "arrayminus": [
            8.5,
            10.5,
-           13.299999999999995
+           13.299999999999997
           ],
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "symmetric": false,
           "thickness": 1.4,
           "type": "data",
@@ -7761,7 +6073,7 @@
          },
          "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
          "line": {
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -7783,51 +6095,6 @@
           93.5,
           91,
           85.5
-         ],
-         "yaxis": "y13"
-        },
-        {
-         "error_y": {
-          "array": [
-           3.3093267857251902,
-           1.983145150854952,
-           3.9607494296932377
-          ],
-          "arrayminus": [
-           2.0394141199098783,
-           4.464146113750573,
-           5.885875178920244
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-05-04T00:00:00",
-          "2026-05-11T00:00:00",
-          "2026-05-26T00:00:00"
-         ],
-         "xaxis": "x13",
-         "y": [
-          93.9837992111415,
-          95.4061986072814,
-          94.70375505178318
          ],
          "yaxis": "y13"
         },
@@ -7870,31 +6137,31 @@
          ],
          "xaxis": "x14",
          "y": [
-          102.87999725341795,
-          101.37999725341795,
-          100.12000274658205,
+          102.87999725341797,
+          101.37999725341797,
+          100.12000274658203,
           111.54000091552734,
           112.41000366210938,
-          112.9499969482422,
+          112.94999694824219,
           94.41000366210938,
-          97.87000274658205,
+          97.87000274658203,
           96.56999969482422,
-          99.08000183105467,
+          99.08000183105469,
           91.27999877929688,
           91.29000091552734,
-          94.69000244140624,
+          94.69000244140625,
           83.8499984741211,
           89.61000061035156,
-          92.12999725341795,
+          92.12999725341797,
           92.95999908447266,
           95.8499984741211,
           94.4000015258789,
-          96.37000274658205,
+          96.37000274658203,
           99.93000030517578,
-          106.87999725341795,
+          106.87999725341797,
           105.06999969482422,
-          101.94000244140624,
-          106.41999816894533
+          101.94000244140625,
+          106.41999816894531
          ],
          "yaxis": "y14"
         },
@@ -7936,17 +6203,17 @@
          "xaxis": "x14",
          "y": [
           102.2699966430664,
-          95.08000183105467,
-          94.80999755859376,
-          95.41999816894533,
+          95.08000183105469,
+          94.80999755859375,
+          95.41999816894531,
           98.06999969482422,
           102.18000030517578,
           101.0199966430664,
-          101.16999816894533,
-          105.41999816894533,
+          101.16999816894531,
+          105.41999816894531,
           108.66000366210938,
           107.7699966430664,
-          98.26000213623048,
+          98.26000213623047,
           96.3499984741211,
           96.5999984741211,
           93.88999938964844,
@@ -7954,21 +6221,21 @@
           88.9000015258789,
           87.36000061035156,
           92.16000366210938,
-          93.76000213623048
+          93.76000213623047
          ],
          "yaxis": "y14"
         },
         {
          "error_y": {
           "array": [
+           7.5,
            9.5,
-           12,
-           14
+           11.5
           ],
           "arrayminus": [
-           15,
-           18,
-           20.5
+           8.5,
+           9.5,
+           11
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -7997,9 +6264,54 @@
          ],
          "xaxis": "x14",
          "y": [
-          105,
+          101.5,
+          100.5,
+          98
+         ],
+         "yaxis": "y14"
+        },
+        {
+         "error_y": {
+          "array": [
+           3.5,
+           5.5,
+           9.5
+          ],
+          "arrayminus": [
+           3,
+           5,
+           8
+          ],
+          "color": "#ff7f0e",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
+         "line": {
+          "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-05-11T00:00:00",
+          "2026-05-18T00:00:00",
+          "2026-06-02T00:00:00"
+         ],
+         "xaxis": "x14",
+         "y": [
+          102.5,
           104,
-          102.5
+          106.5
          ],
          "yaxis": "y14"
         },
@@ -8015,7 +6327,7 @@
            8.849999999999994,
            12.579999999999998
           ],
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "symmetric": false,
           "thickness": 1.4,
           "type": "data",
@@ -8023,7 +6335,7 @@
          },
          "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
          "line": {
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -8045,51 +6357,6 @@
           101.88,
           101.78,
           100.42
-         ],
-         "yaxis": "y14"
-        },
-        {
-         "error_y": {
-          "array": [
-           2.669484917331033,
-           1.5515135529144146,
-           11.746813459719988
-          ],
-          "arrayminus": [
-           2.9053198532255635,
-           6.34995019572402,
-           6.847106853898595
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-05-11T00:00:00",
-          "2026-05-18T00:00:00",
-          "2026-06-02T00:00:00"
-         ],
-         "xaxis": "x14",
-         "y": [
-          98.88870250830657,
-          100.82378413494186,
-          96.49592587645714
          ],
          "yaxis": "y14"
         },
@@ -8132,30 +6399,30 @@
          ],
          "xaxis": "x15",
          "y": [
-          112.9499969482422,
+          112.94999694824219,
           94.41000366210938,
-          97.87000274658205,
+          97.87000274658203,
           96.56999969482422,
-          99.08000183105467,
+          99.08000183105469,
           91.27999877929688,
           91.29000091552734,
-          94.69000244140624,
+          94.69000244140625,
           83.8499984741211,
           89.61000061035156,
-          92.12999725341795,
+          92.12999725341797,
           92.95999908447266,
           95.8499984741211,
           94.4000015258789,
-          96.37000274658205,
+          96.37000274658203,
           99.93000030517578,
-          106.87999725341795,
+          106.87999725341797,
           105.06999969482422,
-          101.94000244140624,
-          106.41999816894533,
+          101.94000244140625,
+          106.41999816894531,
           102.2699966430664,
-          95.08000183105467,
-          94.80999755859376,
-          95.41999816894533,
+          95.08000183105469,
+          94.80999755859375,
+          95.41999816894531,
           98.06999969482422
          ],
          "yaxis": "y15"
@@ -8199,11 +6466,11 @@
          "y": [
           102.18000030517578,
           101.0199966430664,
-          101.16999816894533,
-          105.41999816894533,
+          101.16999816894531,
+          105.41999816894531,
           108.66000366210938,
           107.7699966430664,
-          98.26000213623048,
+          98.26000213623047,
           96.3499984741211,
           96.5999984741211,
           93.88999938964844,
@@ -8211,11 +6478,11 @@
           88.9000015258789,
           87.36000061035156,
           92.16000366210938,
-          93.76000213623048,
+          93.76000213623047,
           96.0199966430664,
           93.04000091552734,
           90.54000091552734,
-          91.3000030517578,
+          91.30000305175781,
           88.19999694824219
          ],
          "yaxis": "y15"
@@ -8223,12 +6490,12 @@
         {
          "error_y": {
           "array": [
-           6,
-           13
+           7.5,
+           15
           ],
           "arrayminus": [
-           3.5,
-           9
+           7,
+           13
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -8256,8 +6523,49 @@
          ],
          "xaxis": "x15",
          "y": [
-          95,
-          90
+          94.5,
+          91.5
+         ],
+         "yaxis": "y15"
+        },
+        {
+         "error_y": {
+          "array": [
+           5.5,
+           9
+          ],
+          "arrayminus": [
+           3,
+           4.5
+          ],
+          "color": "#ff7f0e",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
+         "line": {
+          "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-05-18T00:00:00",
+          "2026-06-09T00:00:00"
+         ],
+         "xaxis": "x15",
+         "y": [
+          98.5,
+          105
          ],
          "yaxis": "y15"
         },
@@ -8269,9 +6577,9 @@
           ],
           "arrayminus": [
            5,
-           10.799999999999995
+           10.799999999999997
           ],
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "symmetric": false,
           "thickness": 1.4,
           "type": "data",
@@ -8279,7 +6587,7 @@
          },
          "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
          "line": {
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -8299,47 +6607,6 @@
          "y": [
           94.5,
           89.6
-         ],
-         "yaxis": "y15"
-        },
-        {
-         "error_y": {
-          "array": [
-           4.310629068666728,
-           3.7793670453956025
-          ],
-          "arrayminus": [
-           3.516989857570451,
-           11.49199493198948
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-05-18T00:00:00",
-          "2026-06-09T00:00:00"
-         ],
-         "xaxis": "x15",
-         "y": [
-          95.80925267864224,
-          99.12568942543513
          ],
          "yaxis": "y15"
         },
@@ -8384,28 +6651,28 @@
          "y": [
           91.27999877929688,
           91.29000091552734,
-          94.69000244140624,
+          94.69000244140625,
           83.8499984741211,
           89.61000061035156,
-          92.12999725341795,
+          92.12999725341797,
           92.95999908447266,
           95.8499984741211,
           94.4000015258789,
-          96.37000274658205,
+          96.37000274658203,
           99.93000030517578,
-          106.87999725341795,
+          106.87999725341797,
           105.06999969482422,
-          101.94000244140624,
-          106.41999816894533,
+          101.94000244140625,
+          106.41999816894531,
           102.2699966430664,
-          95.08000183105467,
-          94.80999755859376,
-          95.41999816894533,
+          95.08000183105469,
+          94.80999755859375,
+          95.41999816894531,
           98.06999969482422,
           102.18000030517578,
           101.0199966430664,
-          101.16999816894533,
-          105.41999816894533,
+          101.16999816894531,
+          105.41999816894531,
           108.66000366210938
          ],
          "yaxis": "y16"
@@ -8448,7 +6715,7 @@
          "xaxis": "x16",
          "y": [
           107.7699966430664,
-          98.26000213623048,
+          98.26000213623047,
           96.3499984741211,
           96.5999984741211,
           93.88999938964844,
@@ -8456,11 +6723,11 @@
           88.9000015258789,
           87.36000061035156,
           92.16000366210938,
-          93.76000213623048,
+          93.76000213623047,
           96.0199966430664,
           93.04000091552734,
           90.54000091552734,
-          91.3000030517578,
+          91.30000305175781,
           88.19999694824219,
           90.02999877929688,
           87.70999908447266,
@@ -8473,12 +6740,12 @@
         {
          "error_y": {
           "array": [
-           7.340000000000003,
-           7.230000000000004
+           10.5,
+           12.5
           ],
           "arrayminus": [
-           6.659999999999997,
-           6.269999999999996
+           10.5,
+           10.5
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -8506,8 +6773,49 @@
          ],
          "xaxis": "x16",
          "y": [
-          92.16,
-          75.27
+          103.5,
+          101.5
+         ],
+         "yaxis": "y16"
+        },
+        {
+         "error_y": {
+          "array": [
+           10,
+           20
+          ],
+          "arrayminus": [
+           9,
+           16
+          ],
+          "color": "#ff7f0e",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
+         "line": {
+          "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-06-01T00:00:00",
+          "2026-06-16T00:00:00"
+         ],
+         "xaxis": "x16",
+         "y": [
+          112,
+          118
          ],
          "yaxis": "y16"
         },
@@ -8521,7 +6829,7 @@
            6.699999999999989,
            7.900000000000006
           ],
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "symmetric": false,
           "thickness": 1.4,
           "type": "data",
@@ -8529,7 +6837,7 @@
          },
          "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
          "line": {
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -8549,47 +6857,6 @@
          "y": [
           99.6,
           93.5
-         ],
-         "yaxis": "y16"
-        },
-        {
-         "error_y": {
-          "array": [
-           4.375103866136882,
-           2.7907944255048136
-          ],
-          "arrayminus": [
-           6.166391245810999,
-           6.519215687567382
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-06-01T00:00:00",
-          "2026-06-16T00:00:00"
-         ],
-         "xaxis": "x16",
-         "y": [
-          101.04057231783618,
-          107.86742743264006
          ],
          "yaxis": "y16"
         },
@@ -8633,28 +6900,28 @@
          "xaxis": "x17",
          "y": [
           89.61000061035156,
-          92.12999725341795,
+          92.12999725341797,
           92.95999908447266,
           95.8499984741211,
           94.4000015258789,
-          96.37000274658205,
+          96.37000274658203,
           99.93000030517578,
-          106.87999725341795,
+          106.87999725341797,
           105.06999969482422,
-          101.94000244140624,
-          106.41999816894533,
+          101.94000244140625,
+          106.41999816894531,
           102.2699966430664,
-          95.08000183105467,
-          94.80999755859376,
-          95.41999816894533,
+          95.08000183105469,
+          94.80999755859375,
+          95.41999816894531,
           98.06999969482422,
           102.18000030517578,
           101.0199966430664,
-          101.16999816894533,
-          105.41999816894533,
+          101.16999816894531,
+          105.41999816894531,
           108.66000366210938,
           107.7699966430664,
-          98.26000213623048,
+          98.26000213623047,
           96.3499984741211,
           96.5999984741211
          ],
@@ -8702,11 +6969,11 @@
           88.9000015258789,
           87.36000061035156,
           92.16000366210938,
-          93.76000213623048,
+          93.76000213623047,
           96.0199966430664,
           93.04000091552734,
           90.54000091552734,
-          91.3000030517578,
+          91.30000305175781,
           88.19999694824219,
           90.02999877929688,
           87.70999908447266,
@@ -8723,14 +6990,14 @@
         {
          "error_y": {
           "array": [
-           4,
-           5.5,
-           6.5
+           6,
+           8,
+           12
           ],
           "arrayminus": [
-           3.5,
-           4.5,
-           5
+           5,
+           5.5,
+           8
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -8759,9 +7026,54 @@
          ],
          "xaxis": "x17",
          "y": [
-          90,
-          87.5,
-          72.5
+          95,
+          92,
+          88
+         ],
+         "yaxis": "y17"
+        },
+        {
+         "error_y": {
+          "array": [
+           3.5,
+           6,
+           11
+          ],
+          "arrayminus": [
+           2.5,
+           4.5,
+           11
+          ],
+          "color": "#ff7f0e",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
+         "line": {
+          "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-06-01T00:00:00",
+          "2026-06-08T00:00:00",
+          "2026-06-23T00:00:00"
+         ],
+         "xaxis": "x17",
+         "y": [
+          98.5,
+          101,
+          105
          ],
          "yaxis": "y17"
         },
@@ -8777,7 +7089,7 @@
            4.910000000000011,
            6.900000000000006
           ],
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "symmetric": false,
           "thickness": 1.4,
           "type": "data",
@@ -8785,7 +7097,7 @@
          },
          "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
          "line": {
-          "color": "#ff7f0e",
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -8807,51 +7119,6 @@
           94.99,
           92.93,
           88.11
-         ],
-         "yaxis": "y17"
-        },
-        {
-         "error_y": {
-          "array": [
-           4.129085448747404,
-           3.383115837632829,
-           2.058003499218344
-          ],
-          "arrayminus": [
-           3.808728704337142,
-           2.3762822803994226,
-           3.9488512037813166
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-06-01T00:00:00",
-          "2026-06-08T00:00:00",
-          "2026-06-23T00:00:00"
-         ],
-         "xaxis": "x17",
-         "y": [
-          93.9927445788524,
-          95.29043814066736,
-          96.74480316139892
          ],
          "yaxis": "y17"
         },
@@ -8894,24 +7161,24 @@
          ],
          "xaxis": "x18",
          "y": [
-          96.37000274658205,
+          96.37000274658203,
           99.93000030517578,
-          106.87999725341795,
+          106.87999725341797,
           105.06999969482422,
-          101.94000244140624,
-          106.41999816894533,
+          101.94000244140625,
+          106.41999816894531,
           102.2699966430664,
-          95.08000183105467,
-          94.80999755859376,
-          95.41999816894533,
+          95.08000183105469,
+          94.80999755859375,
+          95.41999816894531,
           98.06999969482422,
           102.18000030517578,
           101.0199966430664,
-          101.16999816894533,
-          105.41999816894533,
+          101.16999816894531,
+          105.41999816894531,
           108.66000366210938,
           107.7699966430664,
-          98.26000213623048,
+          98.26000213623047,
           96.3499984741211,
           96.5999984741211,
           93.88999938964844,
@@ -8959,11 +7226,11 @@
          ],
          "xaxis": "x18",
          "y": [
-          93.76000213623048,
+          93.76000213623047,
           96.0199966430664,
           93.04000091552734,
           90.54000091552734,
-          91.3000030517578,
+          91.30000305175781,
           88.19999694824219,
           90.02999877929688,
           87.70999908447266,
@@ -8978,21 +7245,21 @@
           71.91999816894531,
           69.2300033569336,
           70.75,
-          69.9000015258789
+          69.5
          ],
          "yaxis": "y18"
         },
         {
          "error_y": {
           "array": [
-           5.459999999999994,
-           6.1200000000000045,
-           8.25
+           7.5,
+           11.200000000000003,
+           15
           ],
           "arrayminus": [
-           4.540000000000006,
-           5.3799999999999955,
-           5.75
+           6.5,
+           9.799999999999997,
+           12.5
           ],
           "color": "#1f77b4",
           "symmetric": false,
@@ -9021,23 +7288,23 @@
          ],
          "xaxis": "x18",
          "y": [
-          90.54,
-          84.88,
-          70.75
+          86.5,
+          85.8,
+          84.5
          ],
          "yaxis": "y18"
         },
         {
          "error_y": {
           "array": [
-           7.899999999999992,
-           10.129999999999995,
-           14.590000000000003
+           2,
+           2.799999999999997,
+           3.5
           ],
           "arrayminus": [
-           7.989999999999995,
-           10.47,
-           14.100000000000009
+           1.5,
+           2,
+           3
           ],
           "color": "#ff7f0e",
           "symmetric": false,
@@ -9045,9 +7312,54 @@
           "type": "data",
           "width": 4
          },
-         "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
+         "legendgroup": "News Agent (gemini-3.1-flash-lite-preview)",
          "line": {
           "color": "#ff7f0e",
+          "dash": "dot",
+          "width": 1.4
+         },
+         "marker": {
+          "size": 8,
+          "symbol": "diamond"
+         },
+         "mode": "lines+markers",
+         "name": "News Agent (gemini-3.1-flash-lite-preview)",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          "2026-06-08T00:00:00",
+          "2026-06-15T00:00:00",
+          "2026-06-30T00:00:00"
+         ],
+         "xaxis": "x18",
+         "y": [
+          86.5,
+          85,
+          82.5
+         ],
+         "yaxis": "y18"
+        },
+        {
+         "error_y": {
+          "array": [
+           7.8999999999999915,
+           10.129999999999995,
+           14.590000000000003
+          ],
+          "arrayminus": [
+           7.989999999999995,
+           10.469999999999999,
+           14.100000000000009
+          ],
+          "color": "#2ca02c",
+          "symmetric": false,
+          "thickness": 1.4,
+          "type": "data",
+          "width": 4
+         },
+         "legendgroup": "LLMP-Grid (gemini-3.5-flash)",
+         "line": {
+          "color": "#2ca02c",
           "dash": "dot",
           "width": 1.4
          },
@@ -9069,51 +7381,6 @@
           87.42,
           86.48,
           85.45
-         ],
-         "yaxis": "y18"
-        },
-        {
-         "error_y": {
-          "array": [
-           4.28133332196731,
-           5.306094834521161,
-           6.8262832406309
-          ],
-          "arrayminus": [
-           4.693297958729573,
-           10.481102691845493,
-           14.166214893641822
-          ],
-          "color": "#2ca02c",
-          "symmetric": false,
-          "thickness": 1.4,
-          "type": "data",
-          "width": 4
-         },
-         "legendgroup": "LightGBM",
-         "line": {
-          "color": "#2ca02c",
-          "dash": "dot",
-          "width": 1.4
-         },
-         "marker": {
-          "size": 8,
-          "symbol": "diamond"
-         },
-         "mode": "lines+markers",
-         "name": "LightGBM",
-         "showlegend": false,
-         "type": "scatter",
-         "x": [
-          "2026-06-08T00:00:00",
-          "2026-06-15T00:00:00",
-          "2026-06-30T00:00:00"
-         ],
-         "xaxis": "x18",
-         "y": [
-          88.45896674515633,
-          87.0580625405234,
-          92.87741511084948
          ],
          "yaxis": "y18"
         }
@@ -9347,7 +7614,7 @@
           },
           "showarrow": false,
           "text": "Jun 01, 2026  WTI $92",
-          "x": 0.9863888888888888,
+          "x": 0.9863888888888889,
           "xanchor": "center",
           "xref": "paper",
           "y": 1,
@@ -10507,8 +8774,8 @@
         "xaxis17": {
          "anchor": "y17",
          "domain": [
-          0.9155555555555556,
-          0.9427777777777776
+          0.9155555555555555,
+          0.9427777777777777
          ],
          "gridcolor": "#f0f0f0",
          "showgrid": true,
@@ -10519,7 +8786,7 @@
         "xaxis18": {
          "anchor": "y18",
          "domain": [
-          0.9727777777777776,
+          0.9727777777777777,
           1
          ],
          "gridcolor": "#f0f0f0",
@@ -10543,7 +8810,7 @@
         "xaxis3": {
          "anchor": "y3",
          "domain": [
-          0.11444444444444445,
+          0.11444444444444443,
           0.14166666666666666
          ],
          "gridcolor": "#f0f0f0",
@@ -10567,7 +8834,7 @@
         "xaxis5": {
          "anchor": "y5",
          "domain": [
-          0.2288888888888889,
+          0.22888888888888886,
           0.25611111111111107
          ],
          "gridcolor": "#f0f0f0",
@@ -10603,7 +8870,7 @@
         "xaxis8": {
          "anchor": "y8",
          "domain": [
-          0.4005555555555555,
+          0.40055555555555555,
           0.42777777777777776
          ],
          "gridcolor": "#f0f0f0",
@@ -10615,7 +8882,7 @@
         "xaxis9": {
          "anchor": "y9",
          "domain": [
-          0.4577777777777778,
+          0.45777777777777773,
           0.48499999999999993
          ],
          "gridcolor": "#f0f0f0",
@@ -10910,14 +9177,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "f7c42d62",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<div style='max-width:900px'><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-02-02 &nbsp; point $65.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/c212301caf0fdd361f899a706f3dee4a' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The WTI forecast is driven by the confluence of OPEC+ production constraints and the significant geopolitical risk premium from the Strait of Hormuz. The market is currently biased toward the upside as it balances the risk of physical supply shocks against the structural supply capability of the US and other non-OPEC+ producers. Volatility is expected to remain high over the next 21 business days.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term momentum is bullish following a late-January rally toward $65. The market is pricing in significant geopolitical risk from Strait of Hormuz tensions, keeping volatility elevated. A 5-day horizon is expected to consolidate these gains, with strong support at $64.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-02-09 &nbsp; point $63.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/203b570e5969940bce61f1c992433c43' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The overall forecast assumes that the market remains in a delicate equilibrium. Geopolitical risk—centered on U.S.-Iran tensions—provides a persistent price floor (the 'war premium'), while long-term bearish pressures stemming from non-OPEC production growth and stable demand ensure a capped upside. OPEC+ policy is assumed to remain largely supportive but reactive to price volatility, limiting extreme downside movements unless a fundamental supply-demand shift occurs.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Expect a gradual drift toward slightly lower levels as the market tests the sustainability of the current risk premium in the absence of new, concrete escalation signals.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-02-16 &nbsp; point $63.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/c18af3b8ff8985634e1d1613140ea177' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecasts as of 2026-02-16 reflect a market currently dominated by geopolitical risk premiums related to the Strait of Hormuz and the Iran-U.S. tension. OPEC+ remains committed to market stability through production management, and the U.S. continues to signal potential SPR interventions if supply security is compromised. The distributions incorporate a clear upward risk skew, reflecting that negative supply developments in the Persian Gulf could trigger rapid price increases.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term horizon reflects continued geopolitical risk premium from Strait of Hormuz tensions, offset slightly by OPEC+'s continued supply restraint and potential U.S. SPR management.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-02-23 &nbsp; point $67.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/358f37a99b0d1f5c29bf3b67132ec867' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast assumes that the geopolitical risk premium related to U.S.-Iran tensions and the Strait of Hormuz will remain a dominant driver in the near term. OPEC+ remains committed to restricting supply to manage price floors. We note a slightly bullish tilt in the short term, but acknowledge significant downside risk if the geopolitical premium evaporates.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over the next 5 business days, we anticipate continued upward pressure on WTI prices as market participants maintain the geopolitical risk premium due to U.S.-Iran tensions. The price is likely to remain elevated above the $66.40 level seen on Feb 20, with potential for short-term volatility spikes.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-03-02 &nbsp; point $67.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/ff7be1d9ed08b93e66542e8a39f7fb5b' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The WTI forecast is heavily influenced by the elevated geopolitical risk premium stemming from US-Iran tensions in the Persian Gulf. OPEC+ is maintaining production discipline, and the market is cautious. Forecasts assume moderate volatility with skewed upside risk in the short term due to the geopolitical uncertainty, balanced by potential for fundamental cooling if the situation stabilizes.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term momentum is driven by the immediate geopolitical risk premium associated with US-Iran tensions in the Persian Gulf. Prices are expected to remain elevated or slightly drift higher as traders hedge against potential supply disruptions.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-03-09 &nbsp; point $93.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/25adde86593f33b9d5b633a47a0ec178' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast reflects the catastrophic supply-side risk triggered by the closure of the Strait of Hormuz in late February 2026. The market is in an acute shock phase; price volatility is elevated, and the upside risk remains dominant as the duration of the conflict and the effectiveness of IEA emergency inventory releases are highly uncertain. Downside protection in the forecast quantiles accounts for the potential (though currently unlikely) scenario of rapid diplomatic de-escalation.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> The Strait of Hormuz closure creates extreme, immediate risk. The 5-day horizon remains highly volatile as the market adjusts to the initial shock and prices in the potential for prolonged conflict vs. the impact of announced emergency releases.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-03-16 &nbsp; point $100.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2633086a507bed391a68f690fd7dacb4' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast is driven by the extreme geopolitical crisis involving the closure of the Strait of Hormuz. The baseline assumption is that global supply will be significantly hampered for at least the next month. While the emergency release of 400M barrels by the IEA is a significant intervention, it is likely to only act as a partial buffer against the massive structural supply loss. Price volatility remains elevated, with risks skewed to the upside if the conflict persists or deepens, while downside risks are capped by the tightness of global inventory levels prior to the crisis.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Market is in a state of high geopolitical tension due to the U.S.-Iran conflict and the closure of the Strait of Hormuz. Short-term price action (5-day) remains heavily skewed toward volatility as traders digest the impact of the emergency IEA reserve release. A price consolidation near current levels is expected as supply chain adjustments are attempted.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-03-23 &nbsp; point $97.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/8d15659a079c7f89846e7b6d95dc8356' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The WTI crude oil market is currently functioning under a regime of extreme geopolitical shock due to the closure of the Strait of Hormuz. The baseline analysis assumes that the extreme volatility will persist, with prices sensitive to the duration and severity of the regional conflict. SPR releases provide only a temporary buffer. My forecasts utilize a wide distribution to account for the potential for rapid de-escalation versus continued or worsening supply disruption.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term prices are heavily influenced by the extreme geopolitical risk premium stemming from the closure of the Strait of Hormuz. While emergency SPR releases are underway, the market remains highly sensitive to any news regarding the conflict's intensity. I anticipate slight consolidation from recent highs as initial panic subsides, but extreme volatility remains the base case.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-03-30 &nbsp; point $98.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/8e9fc69bea4d2c000c8059fb4539bc75' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast reflects the acute geopolitical crisis following the closure of the Strait of Hormuz in late February 2026. The market is in a supply-constrained environment. While the US and international allies have initiated significant SPR releases, the magnitude of the disruption (approx. 10m b/d) outweighs these temporary measures. Prices are expected to trend higher as the market tests the sustainability of the current price regime under severe geopolitical tension.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term volatility remains elevated due to the Strait of Hormuz closure. While coordinated SPR releases provide some psychological relief, supply constraints are real and immediate. The market is trading at the 52-week high, suggesting strong bullish momentum.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-04-06 &nbsp; point $113.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/0e3a1c4403f21c8a9cf0f98e4dac50a6' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast reflects a severe geopolitical supply shock resulting from the 2026 Iran war and the blockade of the Strait of Hormuz. We assume that the disruption is ongoing, leading to a rapid depletion of global inventories. The risk distribution is skewed to the upside as supply security remains the dominant market concern, with strategic reserves providing only a temporary, partial buffer.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> As of April 6, 2026, the oil market is in extreme turmoil due to the Iran war and the effective closure of the Strait of Hormuz. With 35% of seaborne trade at risk, the immediate term (5 days) is characterized by massive volatility and a significant geopolitical risk premium. Prices are likely to test higher levels as the market prices in a prolonged disruption.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-04-13 &nbsp; point $98.2 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/496d23a918af028349b0da77a8f0bc6c' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The WTI forecast is heavily influenced by the critical geopolitical crisis in the Persian Gulf and the resulting Strait of Hormuz blockade. While U.S. SPR releases are attempting to buffer global supply gaps (approx. 10.1M bpd lost), market sentiment is dominated by extreme risk premiums and physical delivery constraints. The current forecast assumes the blockade remains in place or intensifies, preventing any significant downward correction in price despite demand concerns.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term volatility driven by the Strait of Hormuz blockade and market reaction to recent supply shocks. Expectations of continued geopolitical instability support a modest upward trend as inventory tightness persists.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-04-20 &nbsp; point $86.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/6b304b93fe4104753d455362cbbe3e61' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast is centered on the extreme geopolitical risk currently impacting the WTI market: the blockade of the Strait of Hormuz. As of April 20, 2026, the market is in a highly unstable state, with significant production shut-ins and depleting global inventories. SPR releases are mitigating the immediate shock, but a structural deficit persists, supporting an upward bias in the median forecast as time horizon increases, while acknowledging that any signs of de-escalation would lead to rapid, violent price corrections.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Prices recently retreated from peaks near $113 toward $83.85. The near-term horizon reflects high volatility as the market digests the ongoing disruption in the Strait of Hormuz and the impact of recent SPR releases. A slight recovery is anticipated as the extreme price spike of early April corrects, while uncertainty over shipping security keeps the downside risk substantial.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-04-27 &nbsp; point $95.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/c9daa72aca3a58a097f652b8e1e5597e' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>As of April 27, 2026, the oil market is trapped in a supply crisis initiated by the conflict in Iran and the closure of the Strait of Hormuz in late February. My forecast is centered on the ongoing geopolitical instability. Key factors: (1) Supply Disruption: 20% of global trade is effectively halted. (2) SPR Policy: Strategic releases are occurring but are failing to offset the severity of the supply gap, with logistical hurdles limiting their efficacy. (3) Demand destruction: High prices are impacting consumption, yet physical scarcity supports elevated price levels. The distribution is skewed to the upside due to the risk of further escalation.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over the next 5 days, market volatility will be driven by the continued closure of the Strait of Hormuz. The supply risk premium remains high, and any minor escalation or confirmation of limited SPR impact will sustain prices above $90/bbl. The tight balance suggests a slight upward drift.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-05-04 &nbsp; point $103.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/ca876fd70bf17764a4d081b7a295581b' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast is anchored by the catastrophic supply shock from the Strait of Hormuz closure (circa May 2026). With substantial global inventory drawdowns and limited immediate supply alternatives, the market is structurally bullish. We maintain a risk-tilted outlook that accounts for significant volatility given the potential for further escalations or sudden diplomatic shifts.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term volatility driven by the Strait of Hormuz closure remains elevated. The market is pricing in sustained supply deficits. While SPR releases provide a floor to supply, the primary trend remains upward bias due to geopolitical risk premiums.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-05-11 &nbsp; point $96.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/a3146b6e97bd0981bfef10291def536e' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The WTI crude market as of May 11, 2026, is dominated by the closure of the Strait of Hormuz. With approximately 25% of global seaborne oil flow effectively halted, the market is pricing in a severe supply-side shock. Strategic reserves are being utilized to mitigate, but are at historical lows. Prices are expected to maintain an elevated, volatile regime characterized by a wide uncertainty band reflecting binary risk regarding shipping lane access.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term volatility driven by the Strait of Hormuz closure remains high. With prices around $95.42, the market is range-bound pending further diplomatic news or confirmation of shipping lane access. Probabilities skewed slightly to the upside due to acute supply risks.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-05-18 &nbsp; point $111.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/ef2785f0f5c4c88ddf9d160239a67ae8' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>As of 2026-05-18, the WTI market is dominated by a major geopolitical supply risk: the closure of the Strait of Hormuz. With OECD oil stocks at two-decade lows and U.S. SPR levels significantly depleted, the market lacks the typical inventory cushion to mitigate supply shocks. My forecast assumes that the geopolitical premium will persist or increase in the near term as diplomatic solutions appear distant. Short-term volatility is exceptionally high, and the potential for a runaway upside spike is greater than the potential for a supply-demand-driven correction.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> As the physical disruption in shipping lanes persists, supply-side tightness continues to escalate. With SPR levels at record lows, the market lacks a meaningful buffer against shocks, increasing the risk of sharp upside spikes in the 10-day window.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-05-25 &nbsp; point $95.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/51e3fe22a7818eb3085e019cb000772b' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast is predicated on the persistent geopolitical risk premium caused by the closure of the Strait of Hormuz, countered by the aggressive, albeit diminishing, use of the US SPR. We assume a scenario where the conflict remains contained but unresolved, leading to a slow decay in price as the market prices in gradual demand destruction and long-term supply-demand rebalancing.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over the next 5 business days, the market will likely consolidate around the $96 level as it balances extreme uncertainty regarding the Strait of Hormuz with aggressive US SPR release pressures. A slight consolidation is expected as immediate inventory fears are partially offset by high-frequency demand concerns.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-06-01 &nbsp; point $88.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/b3783ded9ee8ecc70c18b0d483345d94' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The WTI forecast is driven primarily by the acute geopolitical risk premium in the Persian Gulf, where the effective closure of the Strait of Hormuz has created a massive supply bottleneck. Despite modest, incremental increases in OPEC+ production, the market focus remains on record inventory draws and U.S. reliance on the Strategic Petroleum Reserve. The volatility observed throughout May 2026 confirms that prices are sensitive to any signals regarding diplomatic resolution versus long-term conflict, leading to a probabilistic forecast with significant upward bias and fat tails.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over the next 5 days, market volatility will remain high as traders await potential diplomatic de-escalation in the Persian Gulf. The market is currently consolidating after the late-May slide, but the supply risk premium remains elevated due to the ongoing closure of the Strait of Hormuz.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-02-02 &nbsp; point $64.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/01dfb7c10c4dc3867feb7e2a2abebaac' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>As of February 2, 2026, WTI crude oil has recently rallied to $65.21 due to a combination of temporary weather-related US production losses (~250k bpd) and escalating US-Iran tensions in the Strait of Hormuz. OPEC+ has maintained its production increase pause through Q1 2026 to stabilize prices. Over the 5, 10, and 21 business day horizons, we forecast a gradual mean-reversion trend. This is driven by the resolution of weather-related supply disruptions and a return of focus to structural global oversupply. However, wide and skewed confidence intervals are maintained to reflect the high uncertainty surrounding Middle East geopolitical risks.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over a 5-business-day horizon (by February 9, 2026), the recent sharp spike in WTI prices from ~$60.60 to $65.21 (driven by US-Iran geopolitical tensions and transient US freeze-offs of ~250k bpd) is expected to face initial resistance. The point forecast of $64.00 assumes a slight pullback as cold weather impacts begin to ease, though the geopolitical premium remains partially active. The interval from $59.50 to $69.00 reflects high short-term volatility, representing either a rapid deflation of the geopolitical premium or an extension of the rally if tensions worsen.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-02-09 &nbsp; point $63.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/dca1f4b6171f020ac92ed975e8a42491' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>Our outlook as of February 9, 2026, balances two highly divergent forces. Fundamentally, global oil supply is expected to outpace demand, with OPEC+ maintaining voluntary pauses to mitigate oversaturation, and institutions forecasting average prices in the mid-$50s. Geopolitically, the risk of escalation in the Persian Gulf adds a $4-$10 risk premium. This dual-regime dynamic results in a highly skewed and wide probability distribution, where a return to fundamentals triggers a drop to the low $50s, while a major conflict triggers an immediate spike past the 52-week high of $75.14.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> For the 10-day horizon, the point forecast declines slightly to $63.00, anticipating that the structural oversupply projected by the EIA and IEA will exert gradual downward pressure if no immediate geopolitical disruption occurs. However, uncertainty widens considerably. The 0.05 quantile drops to $56.10 on fears of an eventual OPEC+ production unwind, while the 0.95 quantile rises to $73.10 to reflect the growing 'war premium' and the risk of shipping lane disruptions.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-02-16 &nbsp; point $65.7 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/8bedd350fb8cb3da28aa71def546716f' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>This probabilistic forecast reflects a delicate balance between fundamental supply-demand dynamics and a rapidly escalating geopolitical crisis in the Persian Gulf as of mid-February 2026. On the fundamental side, a robust oil surplus driven by the Americas Quintet (U.S., Canada, Brazil, Guyana, and Argentina) and cautious OPEC+ production policies provide a soft supply backdrop. However, the asymmetric risk of military conflict between the United States and Iran and potential closure of the Strait of Hormuz creates a massive right-tail geopolitical risk premium across the 10-day and 21-day horizons.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over the 5-business-day horizon (target date Feb 23, 2026), WTI is projected to trade in a moderate upward trajectory. OPEC+ maintains voluntary supply cuts through March 2026, which provides a strong baseline support. Concurrently, intensifying U.S.-Iran tensions and military maneuvers in the Strait of Hormuz are building up a persistent geopolitical risk premium, pushing prices up from the recent close of $62.89 to a projected median of $65.72. The distribution reflects narrow uncertainty, as actual physical disruptions are not expected to occur immediately within this short window.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-02-23 &nbsp; point $74.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/599bda055deebfc03612a1e93be62f3e' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>Our calibrated forecasts for WTI crude oil as of February 23, 2026, are shaped by the acute tension between soft structural fundamentals (global supply outpacing demand, modest demand growth of ~850kb/d projected by the IEA, and robust non-OPEC+ output) and a rapidly escalating geopolitical crisis in the Persian Gulf. We utilize a highly right-skewed probabilistic model to capture the extreme asymmetric upside risks associated with potential Strait of Hormuz closures, while maintaining a baseline downside scenario reflecting the underlying oversupplied market.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> As of February 23, 2026, WTI is trading near $66.39. Over a 5-business-day horizon (targeting early March 2026), we expect short-term upward price pressure. While underlying physical market fundamentals show a structural supply surplus, the immediate focus is dominated by escalating U.S.-Iran geopolitical tensions and naval maneuvers in the Persian Gulf. This is introducing an acute 'war premium.' WTI is projected to trade in the low-to-mid $74s, with an expanded upper tail representing the risk of immediate military escalations before any policy mitigations can take effect.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-03-02 &nbsp; point $84.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/86913fea1b2914179ac1beda9f773624' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>Overall, the WTI crude oil price outlook for March 2026 is defined by the severe geopolitical supply shock of the Strait of Hormuz closure following US/Iran military clashes on February 28, 2026. This has completely upended the previous outlook of a comfortable supply surplus, transforming the market into one of extreme tightness and panic. The forecasts represent a rapidly escalating price path across horizons 5, 10, and 21, characterized by a substantial upside skew to capture the asymmetric threat of prolonged shipping corridor closures and potential damage to Middle East energy infrastructure, mitigated only partially by emergency SPR releases.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> At Horizon 5 (March 9, 2026), the oil market is driven by severe panic and a massive geopolitical risk premium following the February 28, 2026 outbreak of military conflict between the US/Israel and Iran. The sudden blockade of the Strait of Hormuz—the world's most critical oil transit corridor handling 20% of global seaborne supply—has triggered a dramatic spike in WTI from its recent close of $67.02 on February 27 to over $71.23 on March 2. Over the next five business days, immediate panic, a surge in war-risk insurance premiums, and the lack of physical alternatives will push the median WTI price to $84.00, with an extremely wide upside tail (up to $103.00 at the 0.95 quantile) if …</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-03-09 &nbsp; point $108.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/6400443809b2ba13b6ef2db66fe95571' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>This forecast is constructed in the context of an extreme geopolitical supply shock starting in late February/early March 2026, leading to a de facto closure of the Strait of Hormuz and a sudden rally in WTI close to $117-$119/bbl on March 9. The near-term forecasts reflect a strong risk premium due to physical shipping bottlenecks and production shut-ins in the Gulf, while the medium-term (21 business days) forecast incorporates a cooling effect from a massive, multi-nation coordinated SPR release and subsequent demand destruction.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Forecast for 5 business days ahead (March 16, 2026). The severe geopolitical shock from the Middle East conflict and the effective closure of the Strait of Hormuz are expected to keep prices highly elevated. While the benchmark spiked to near $119/bbl intraday on March 9, a median expectation of $108/bbl reflects the immediate physical supply bottleneck. Upside risk is significant if direct military escalations occur, while downside risk is buffered by the immediate disruption of Gulf crude exports.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-03-16 &nbsp; point $98.3 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/72cf878aa6ce6f9179f933ea038f76a0' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecasts as of March 16, 2026, are heavily shaped by the historic US-Iran conflict and the effective blockade of the Strait of Hormuz. WTI crude oil prices recently spiked from $67 to nearly $99/bbl. While global strategic inventory releases of 400 million barrels are being deployed, the physical disruption remains the largest in history. Our forecasts project high near-term prices ($98.32 at Horizon 5, $102.88 at Horizon 10) followed by a slight moderation to $95.18 at Horizon 21 as diplomatic overtures begin to emerge, though with an extremely wide margin of uncertainty.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> By Horizon 5 (March 23, 2026), WTI crude oil prices are projected to trade near a median of $98.32/bbl. The market remains in a state of high stress following the effective closure of the Strait of Hormuz by the US-Iran conflict. While the coordinated IEA emergency release of 400 million barrels (including the US committing to 172 million barrels from the Strategic Petroleum Reserve) acts as a critical buffer, the loss of physical seaborne supply from Gulf producers maintains a premium of $15-$18/bbl. The downside is limited to ~$84.50 if peace talks are announced, whereas an escalation could trigger a surge toward $112.00.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-03-23 &nbsp; point $86.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/cb668e41caadc5e0838cd684a393517e' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>WTI crude prices surged from ~$65 in late February to nearly $99 by March 20, 2026, due to the outbreak of the US-Iran conflict and the subsequent closure of the Strait of Hormuz. However, on March 23, 2026, prices plummeted to $88.13 as the market reacted to the start of diplomatic talks. This forecast incorporates: 1) the massive 172-million-barrel US SPR release (and 400-million-barrel total global release) which physically caps domestic WTI; 2) the potential for a diplomatic resolution which would return prices to the $65-$75 fundamental range; 3) a widening Brent-WTI spread due to local US supply insulation; and 4) the residual risk of a breakdown in talks leading to a re-escalation.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> For the 5-day horizon (targeting late March 2026), the price forecast takes into account the major shift on March 23 where WTI closed at $88.13, a $10.19 drop from the March 20 close of $98.32. This drop was sparked by the initiation of US-Iran diplomatic talks. The point forecast is set at $86.50, reflecting expectations that diplomatic efforts will continue to defuse the Strait of Hormuz crisis, though high volatility remains. The upper tail ($100-$105) reflects the risk of talks collapsing, while the lower tail ($72-$76) reflects a rapid diplomatic breakthrough and resolution.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-03-30 &nbsp; point $100.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/d2ab77c688897b5ea0270e19e2f03a00' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>This forecast is constructed under the context of the March 2026 US-Iran crisis and the closure of the Strait of Hormuz. We model WTI crude prices beginning at the March 30 close of $101.30 per barrel. The forecast incorporates the stabilizing but delayed physical effect of the historic 400-million-barrel emergency oil release from IEA nations, alongside emerging global demand destruction. Due to extreme geopolitical uncertainty, the probability bands are widened significantly to reflect the potential for rapid de-escalation versus further military escalations.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over a 5-day horizon, the market remains locked in intense geopolitical tension following Iran's de facto closure of the Strait of Hormuz to US and allied vessels. Although coordinated releases from international strategic reserves are scheduled to begin, the physical supply deficit of Middle Eastern crude supports WTI prices near the $100.00 level. High daily volatility (with daily swings of 4-5% observed in late March) is expected to persist, keeping the price distributions wide.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-04-06 &nbsp; point $111.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/b3f54c05814d2efd98982a4272a31718' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>WTI crude oil is experiencing extraordinary volatility and trading near multi-year highs of $111.54/bbl due to the ongoing conflict in the Middle East and the closure of the Strait of Hormuz since late February 2026, which has shut in over 9 million b/d of crude production. However, massive offsetting forces are at play: a historic, coordinated global release of 400 million barrels of strategic reserves (including 172 million from the US SPR), rising OPEC+ output starting in May, and demand destruction from high energy costs. Over the next 5 to 21 business days, these physical supplies and potential diplomatic progress are expected to gradually ease domestic tightness, leading to a downward …</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over the next 5 business days, near-term supply concerns and geopolitical panic will likely keep WTI elevated near its recent peak around $111/bbl. Extreme daily volatility ($5-$10 moves) is expected to persist as shipping lanes remain blocked, with the 95% confidence interval spanning from $95 to $127.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-04-13 &nbsp; point $106.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/9f93e1a65eccc11a6aa77cae8190a4b8' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The global oil market is in the midst of an unprecedented supply crisis. The collapse of peace talks in Pakistan on April 12-13, 2026, prompted the U.S. to implement a naval blockade of Iranian ports, shutting off a critical energy artery. Although emergency SPR drawdowns are providing short-term relief, physical tightness is expected to persist through May. Prices are forecasted to surge and peak in late spring before gradually easing back toward historical fundamentals as ceasefire negotiations resume later in the quarter.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> At 5 business days out (April 20, 2026), the market is fully absorbing the shock of the U.S. naval blockade of Iranian ports ordered on April 13 following the collapse of peace talks in Pakistan. With shipping lanes highly disrupted, panic buying is expected to push WTI higher from its April 10 close of $96.57 to a projected point forecast of $106.50.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-04-20 &nbsp; point $96.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/c55eca4d0030407c6b95218f8b5ac5bf' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The WTI crude oil forecast as of April 20, 2026, is driven by the severe conflict in the Persian Gulf and the status of the Strait of Hormuz. Following a brief ceasefire in early April that temporarily lowered WTI to $83.85, the resumption of hostilities and U.S. vessel seizures have reignited supply disruption concerns. In response, prices are projected to rise significantly in the short-to-medium term (Horizons 5 and 10) to reflect the acute supply squeeze, before experiencing a marginal moderation by Horizon 21 as diplomatic channels start negotiating a resolution.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> As of April 20, 2026, the breakdown of the temporary ceasefire over the weekend (due to the U.S. seizure of an Iranian vessel and the subsequent re-closure of the Strait of Hormuz) is driving WTI crude oil sharply upward. By Horizon 5 (April 27, 2026), WTI is expected to trade around $96.00 as the market reprices the geopolitical risk premium. Uncertainty is high given the rapid shift from the ceasefire drop on April 17 ($83.85) to the renewed hostilities.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-04-27 &nbsp; point $98.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/0d33445f66e67bf410eedc95ad8c38e3' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>This forecast is constructed in light of the significant geopolitical supply shock arising from the US-Iran conflict and the subsequent closure of the Strait of Hormuz. Following a brief ceasefire in mid-April that temporarily cooled prices, the breakdown of diplomatic negotiations on April 27 has reintroduced strong bullish momentum. While aggressive emergency SPR exchanges and looming global demand destruction act as a ceiling, the physical loss of supply maintains a exceptionally high risk premium across all horizons.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Near-term forecast (5 business days) reflects upward pressure on WTI crude following the April 27 cancellation of the second round of peace talks in Pakistan by the US administration. With the Strait of Hormuz remaining closed, a massive physical supply deficit of over 10 million bpd persists. Short-term risk is tilted to the upside, but cushioned by aggressive US and international coordinated SPR releases.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-05-04 &nbsp; point $105.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/458688eaeb97ccf263931dd7ac6c411f' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>Global crude oil markets are facing their most severe supply crisis on record following the closure of the Strait of Hormuz on February 28, 2026. WTI surged past $100 and continues to trade with an immense geopolitical risk premium. Mitigating factors include a coordinated global release of 400 million barrels of strategic reserves and high-price demand destruction, which help cap the upper limit of the forecasts. However, extreme volatility remains the defining characteristic of this period, justifying highly dispersed probability distributions across all horizons.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over the 5-day horizon (targeting mid-May 2026), prices are expected to remain highly elevated, hovering around a median of $105.00/bbl due to the ongoing closure of the Strait of Hormuz since late February 2026. Spot trading as of May 4 has spiked to ~$106.42, showing persistent upward pressure. The distribution is wide: the lower tail (0.05 at $78.00) reflects the potential for sudden breakthrough negotiations or a temporary easing of shipping restrictions, while the upper tail (0.95 at $122.0) accounts for direct military escalation in the Gulf.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-05-11 &nbsp; point $95.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/3d5a199ed074f918c11cb320bbed8ea5' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>WTI oil markets are characterized by extreme volatility and a significant geopolitical 'war premium' following the closure of the Strait of Hormuz in late February 2026. The price fell from its peak of over $112 in April to around $95 on May 8, 2026, on reports of a draft MoU for a 60-day ceasefire between the U.S. and Iran. These forecasts reflect the high-stakes binary paths the market faces, with peace talks potentially sending prices into the $70s and a breakdown of talks threatening to spike prices past $115.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> At the 5-business-day horizon (May 15, 2026), the market is heavily focused on whether President Trump will sign the draft memorandum of understanding (MoU) with Iran for a 60-day ceasefire. The recent drop from $106.42 to $95.08 in early May was triggered by reports of this draft MoU. If the MoU is approved and signed, prices are expected to drop quickly toward $84–$88. However, if the draft is rejected or if there is a renewed confrontation in the Strait of Hormuz, prices will rapidly spike back to $102–$108. If the high-stakes negotiations drag on without a resolution, WTI will likely hover close to the current $95 level.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-05-18 &nbsp; point $92.2 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/6c8e1fd3abac28fc6282227850768985' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>As of May 18, 2026, WTI crude oil is trading in an extremely volatile range near multi-year highs due to the closure of the Strait of Hormuz since February 2026. However, the market is poised for a major downward correction over the next 21 business days. The primary catalyst is the anticipated mid-June US-Iran ceasefire framework, which includes a 60-day truce and the gradual reopening of the critical shipping lane. This de-escalation completely unwinds the 'war premium' at the same time OPEC+ increases production quotas and global demand growth targets are revised lower. We provide a calibrated probabilistic forecast that centers the point forecast (0.50 quantile) on the realized …</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> At Horizon 10 (Monday, June 1, 2026, or T+10 trading days from the last close), the point forecast is set to $92.16/bbl (with potential alternative trading-day definitions close to $93.76). De-escalation momentum has accelerated, with market participants aggressively pricing in the normalization of transit through the Strait of Hormuz. OPEC+ policy signals continue to point toward a gradual unwinding of cuts (an incremental quota increase of 188,000 bpd for June is scheduled), while macroeconomic headwinds and weak global demand growth expectations (downgraded to 1.0-1.1 million bpd by the IEA) are amplifying downward pressure.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-05-25 &nbsp; point $90.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/20d51bde77c32766dd270ec669f565f7' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>This forecast captures the transition of the WTI crude oil market from a highly disrupted, geopolitically risk-driven environment in mid-May 2026 to a fundamentals-led surplus environment by late June 2026. Key drivers include the unwinding of the U.S.-Iran conflict's war premium, the gradual recovery of exports through the Strait of Hormuz, ongoing OPEC+ output quota increases, and macro demand headwinds.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> At Horizon 5 (late May/early June 2026), WTI crude oil prices are expected to gradually ease from the recent high of $96.60 to a median of $90.00. Although the Strait of Hormuz remains heavily disrupted by the U.S.-Iran conflict, diplomatic signals regarding a potential ceasefire are beginning to soften the geopolitical war premium. OPEC+ is continuing its gradual unwinding of voluntary production cuts, adding moderate supply, while the U.S. continues to utilize the Strategic Petroleum Reserve (SPR) to mitigate supply gaps, keeping the market volatile but biased slightly downward.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-06-01 &nbsp; point $90.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/a5d33fccd8c99929c3784f774dda34e6' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>WTI oil prices are transitioning from a geopolitical panic-driven regime (Strait of Hormuz crisis) to a supply-normalization and demand-headwind-driven regime. The resolution of tensions between the US and Iran and progressive ceasefire talks are rapidly deflating the geopolitical risk premium that previously sent WTI above $112. At the same time, OPEC+'s modest supply hikes and slowing global economic demand are establishing a more bearish fundamental outlook, driving a mean-reversion process back toward the low $70s by the end of June 2026.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> At the 5-day horizon (June 5, 2026), WTI crude is projected to rebound slightly from its late-May correction, averaging $90.54. The market remains highly sensitive to geopolitical developments in the Middle East. While a tentative ceasefire framework between the US and Iran has eased immediate blockade fears, ongoing shipping disruptions in the Strait of Hormuz and a massive drop in global crude inventories keep a short-term risk premium active, preventing a total collapse of prices.</div></div></div>"
+       "<div style='max-width:900px'><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-02-02 &nbsp; point $65.8 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e6b4dd41c549771ff127f297427fdd08' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast reflects a market in tension: structurally high global inventory and production growth are balanced against significant geopolitical risk premiums, particularly in the Middle East. OPEC+ compliance and the decision to keep output constant support current price levels, but the outlook anticipates a return to structural fundamentals over the medium term.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term momentum is bullish due to ongoing geopolitical risk premium concerns, but technical resistance near $66 remains significant.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-02-09 &nbsp; point $64.8 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/cc8f6066c4fe542914a54cf8856a037c' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>As of Feb 9, 2026, WTI is trading at $63.55. Markets remain highly sensitive to geopolitical tensions in the Strait of Hormuz, maintaining a risk premium. OPEC+ is committed to production pauses through Q1 2026, providing a price floor. However, long-term projections by the EIA suggest that market surpluses may begin to weigh on prices as 2026 progresses, tempering the upside potential for the 21-day horizon.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> The 10-day horizon incorporates potential for further escalation in regional naval activities. While supply remains tight, the market will continue to weigh this against underlying soft demand indicators.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-02-16 &nbsp; point $62.9 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/8dd25380a3e1ffb6853c8f13facbd57c' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecasts are anchored by the current WTI price of $62.89 as of February 13, 2026. The market remains in a tug-of-war: OPEC+ maintains a disciplined supply policy through March 2026 to manage inventory, while geopolitical instability in the Persian Gulf (specifically the Strait of Hormuz) sustains a risk premium. Global demand growth has been revised downward by major agencies, creating a persistent drag on prices. Consequently, we expect a relatively flat to slightly elevated price trajectory, characterized by a wide probability distribution reflecting the unpredictability of regional geopolitical flare-ups.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term prices are expected to remain range-bound near current levels ($62.90) due to a delicate balance between OPEC+ production discipline and persistent geopolitical risk in the Persian Gulf. While fundamental data points to potential oversupply, the risk premium associated with Strait of Hormuz tensions provides a solid support floor.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-02-23 &nbsp; point $66.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/5b95d73e0b6a49a78ae91369c173dbc9' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast reflects a market currently driven by a tension between bearish medium-term fundamentals (global production outpacing demand) and immediate, intense geopolitical risk premiums tied to the Persian Gulf. As of Feb 23, 2026, OPEC+ is maintaining its production cuts, which acts as a support level. The short-term forecast is skewed to the upside due to risk, while the medium-term forecast reflects a potential mean reversion toward fundamental values if conflict does not escalate into physical supply disruption.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over the next 5 days, market sentiment will be dominated by the geopolitical risk premium linked to Iran and the Strait of Hormuz. While underlying fundamentals (projected global surplus) are bearish, they are currently secondary to short-term fears of supply disruption. Prices are expected to maintain current levels with upside volatility risk.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-03-02 &nbsp; point $82.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/f6229c1eea33ddd282209c0cca84ded4' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast is driven by the severe geopolitical shock of February 28, 2026, which effectively closed the Strait of Hormuz, cutting off a critical oil transit artery. Market dynamics are dominated by extreme risk premiums, expectation of severe inventory draws, and the reactive policy of IEA-coordinated reserve releases. The price outlook is inherently bullish and extremely volatile, contingent on the duration and intensity of the Middle East conflict and the effectiveness of international efforts to manage the resulting supply vacuum.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> As of March 2, 2026, the market is in a state of high alarm due to the February 28 outbreak of conflict in the Middle East and the closure of the Strait of Hormuz. With the market reacting to a sudden ~20% global supply threat, extreme volatility and a major geopolitical risk premium are baked into prices. The short-term horizon (5 days) reflects the panic phase and initial market response to the blockade.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-03-09 &nbsp; point $105.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/62d244e3a64c7df2eedf646a563b3f09' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The market is currently reacting to a major systemic shock in the Persian Gulf (Strait of Hormuz closure). The historical volatility is extreme, and as of March 9, 2026, the price reflects a panicked reaction. The forecast assumes persistent geopolitical risk, an inability to fully replace lost production through reserve releases, and a structural upward shift in the oil price curve to account for the supply shortfall.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Following the closure of the Strait of Hormuz, the market is in extreme backwardation and high volatility. The 5-day outlook accounts for continued supply panic and the initial absorption of the shock. $105 serves as a median expectation, balancing the potential for G7 strategic reserve releases against the acute loss of roughly 20% of global oil flows.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-03-16 &nbsp; point $96.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/9d55d1a90b9f23154212bf2a961fcc74' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>As of March 16, 2026, the WTI market is in a high-volatility environment following the major supply shock in the Persian Gulf. The primary drivers are the massive IEA emergency reserve release (400M bbls) and the ongoing threat to shipping through the Strait of Hormuz. My central forecast assumes a cautious retracement as physical supply measures take effect, though the 'tail-risk' of further military escalation remains substantial, causing the wider quantile spreads at longer horizons.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term stabilization is expected as markets digest the IEA's 400M barrel reserve release. While geopolitical tensions remain high due to Strait of Hormuz disruptions, the market is pricing in a 'cooling off' period following the recent price spike, leading to a slight retracement from $98.71.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-03-23 &nbsp; point $100.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2d2cb4e9ef178fe710fd9a052e0f6674' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast reflects the extreme volatility in the oil market as of 2026-03-23, driven by the ongoing conflict in the Middle East and the effective blockade of the Strait of Hormuz. Despite massive coordinated SPR releases, the market is pricing in significant geopolitical risk. OPEC+ remains cautious, and shipping disruptions continue to inflate freight costs, maintaining a strong upward bias.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Market sentiment remains dominated by the 'war premium' following the Strait of Hormuz blockade. While the US SPR release of 172 million barrels is a significant counter-measure, the immediate supply shortfall of ~10mb/d creates upward price pressure over the next week.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-03-30 &nbsp; point $102.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2ed81c4affd1af34b216024c80ed33a7' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast is driven by the unprecedented supply shock from the closure of the Strait of Hormuz in late February 2026. Global energy security hinges on the restoration of tanker transit. Assumptions include: 1) OPEC+ maintains current cautious production stance; 2) SPR releases are ongoing but do not fully offset the massive supply gap; 3) Shipping insurance premiums remain prohibitive. The outlook is structurally bullish with high volatility due to the geopolitical nature of the conflict.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Prices are currently reacting to the total closure of the Strait of Hormuz. In the short term (5 days), volatility remains extreme as the market prices in the risk of sustained supply disruption and the effectiveness of coordinated IEA SPR releases. The price is expected to hold or modestly appreciate above the $99.64 close as market participants wait for news on tanker traffic resumption or potential further military escalations.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-04-06 &nbsp; point $108.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/5172b966227effef450f9f9b739544c8' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The WTI price forecast is heavily conditioned by the unprecedented geopolitical supply shock in the Persian Gulf. The blockade of the Strait of Hormuz has created a massive risk premium. While the U.S. and IEA are attempting to mitigate this with massive SPR releases and coordinated international efforts, demand destruction and persistent shipping uncertainty continue to drive volatility. We expect the market to consolidate from the extreme highs seen on 2026-04-02 as SPR flows materialize, but volatility is likely to remain elevated, and downside is limited by the ongoing supply disruption.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Prices are elevated due to the Strait of Hormuz blockade and persistent geopolitical risk. A slight pullback is expected as the market reacts to the coordinated SPR release and uncertainty, but the high risk premium keeps the floor elevated.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-04-13 &nbsp; point $98.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/83c5ea47abdd544fcface3faf26161f6' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast is driven by the severe physical supply disruption caused by the closure of the Strait of Hormuz and the high probability of an intensified naval blockade. OPEC+ policy remains symbolic due to the geography of the conflict. The U.S. SPR releases are a key bearish counterforce, but current analysis suggests they are insufficient to prevent upward price pressure in a scenario of prolonged regional instability.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> The market remains in a state of extreme tension due to the closure of the Strait of Hormuz and the announcement of a potential U.S. naval blockade. Short-term price action is highly sensitive to daily news on the conflict. The point forecast reflects an expectation of continued volatility with an upward bias as traders assess the implications of the imminent naval blockade and the limited efficacy of SPR releases.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-04-20 &nbsp; point $88.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/fc14681744ece0be71a93e1afc5c5d33' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The WTI forecast is driven by the structural supply crisis following the effective closure of the Strait of Hormuz in February 2026. Global supply has plummeted, and OPEC+ production increases are largely academic. Coordinated SPR releases are mitigating the worst of the volatility but are insufficient to offset the structural loss of Persian Gulf exports. Geopolitical risk remains the primary driver, with high uncertainty regarding the duration of the conflict and the security of maritime shipping.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term prices remain highly sensitive to the effective closure of the Strait of Hormuz. Despite the recent SPR releases, physical supply constraints dominate the market. The horizon reflects persistent elevated risk as shipping operators await security clarity.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-04-27 &nbsp; point $93.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e2945cb921298343842483d1ab85b220' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast is grounded in the ongoing, unprecedented supply disruption resulting from the closure of the Strait of Hormuz (effective late Feb 2026). Strategic reserves (SPR) are being used for stabilization, but demand growth is hampered by high prices and structural economic headwinds. The primary assumptions include: (1) continued, albeit cautious, management by OPEC+; (2) ongoing SPR release programs; (3) persistent geopolitical risk premiums as the Middle East conflict remains unresolved; and (4) downward revisions in global demand growth.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> As of April 27, 2026, the oil market remains highly sensitive to the geopolitical instability surrounding the Strait of Hormuz. While supply release efforts (SPR and increased transits) are mitigating extreme volatility, the 5-day horizon faces continued downward pressure from demand destruction expectations and high inventory drawdowns. The point forecast reflects a slight consolidation after recent volatility.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-05-04 &nbsp; point $102.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/6e67019fcd30b79a97b3f05ce22501dd' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The WTI forecast is driven by the severe geopolitical supply shock in the Strait of Hormuz and the volatile response of the OPEC+ bloc. While strategic reserve releases provide a check on runaway prices, the withdrawal of the UAE from OPEC+ and the ongoing nature of the shipping disruptions create a sustained upward price pressure and higher-than-normal volatility, reflected in the asymmetric, positive-skewed probability distributions for all horizons.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term volatility remains elevated due to the ongoing Strait of Hormuz blockade and supply shock. While SPR releases mitigate extreme upside, the market remains highly reactive to geopolitical headlines.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-05-11 &nbsp; point $98.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/dc30a356d00f42c95b311ae66c1a5aca' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast is predicated on the persistent, effective closure of the Strait of Hormuz following the outbreak of US-Iran conflict. Global oil production is severely curtailed, and while the US and IEA are aggressively releasing SPR stocks, these volumes are insufficient to fully offset the physical supply shock. The market remains in a high-volatility regime with a sustained upward bias for as long as the maritime security environment in the Persian Gulf remains compromised.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term outlook driven by the ongoing closure of the Strait of Hormuz and extreme geopolitical tension. Prices are expected to maintain an upward bias in the next week as inventory drawdowns continue amidst severe supply disruptions.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-05-18 &nbsp; point $112.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/7522eac570852c6b6f41d977bfa2ad54' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast is driven by a profound and ongoing supply shock. The closure of the Strait of Hormuz has created an unprecedented deficit in global oil transit. While the US is aggressively drawing down the SPR, inventories are reaching critically low levels, offering only a temporary buffer. Market participants are in a state of high alert for any escalations or potential de-escalations. The price distribution is heavily skewed to the upside due to the physical 'hard constraint' on supply, with the 0.05 quantile representing a scenario where a breakthrough in diplomatic or military control occurs, and the 0.95 quantile reflecting a total failure of alternative supply routes and further …</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> By the 10-day horizon, the cumulative impact of reduced refining throughput and the failure of SPR releases to stabilize physical markets likely pushes prices higher. The extreme sensitivity to the Strait of Hormuz status means any news of a diplomatic breakthrough would lead to a sharp downside, but the baseline case remains constrained supply.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-05-25 &nbsp; point $98.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/bf44225916aacf5f7449cce938691af1' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecast is predicated on the ongoing crisis in the Persian Gulf, specifically the closure of the Strait of Hormuz. Key assumptions include: 1) Geopolitical risk remains the dominant factor, with the market maintaining a high war premium; 2) U.S. SPR levels are critically low, reducing the efficacy of further releases; 3) OPEC+ remains cautious, failing to fully offset the massive supply deficit; 4) global demand destruction from high prices is partially offsetting the supply shortfall, but the physical constraint remains the primary upward driver.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> The short-term outlook is dominated by the severe supply disruption resulting from the closure of the Strait of Hormuz. With the market already pricing in an extreme risk premium and the U.S. SPR at critically low levels, upside volatility is likely over the next 5 days as refiners scramble for alternative supply. The point forecast reflects a moderate upward trend due to these continued physical constraints.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.1-flash-lite-preview)</b><span style='color:#888'>2026-06-01 &nbsp; point $86.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/0f82f9e2177c861153ba47950531a8cb' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The outlook as of June 1, 2026, is dominated by the unwinding of the geopolitical risk premium following the Strait of Hormuz conflict. Significant U.S. SPR releases (reducing inventories to historic lows) have mitigated immediate shortages, and the market is now reacting to weaker-than-expected global demand. Forecasts reflect a downward trend as the market moves away from crisis pricing, though significant uncertainties regarding the speed of shipping normalization and OPEC+ policy remain.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Short-term horizon (5 days) reflects immediate post-conflict market adjustment. As geopolitical tensions over the Strait of Hormuz show signs of easing, price discovery is shifting toward fundamentals. Prices are expected to remain volatile but show a slight downward bias as the war risk premium continues to be unwound.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-02-02 &nbsp; point $61.8 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/bd47122c5ed56122982765c879878e09' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>As of February 2, 2026, the crude oil market balances supportive geopolitical risk premiums with structural bearishness from projected 2026 global surpluses. While OPEC+ (eight members) has paused production increases through Q1 2026 and the US has utilized its SPR (reported around 415 million barrels) to mitigate shocks, the market is in a corrective phase following late January's geopolitically-driven price spike. On February 2, WTI retreated sharply by $3.07 to settle at $62.14, which anchors our short-to-medium-term projections as we anticipate a continued, gradual drift towards $60.00.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over a 5-business-day horizon, WTI is entering a corrective phase. Following a sharp run-up to $65.21 in late January due to escalating US-Iran geopolitical friction and fears over Strait of Hormuz safety, prices fell significantly to settle at $62.14 on Feb 2, 2026. The point forecast of $61.80 reflects a slight continued downward drift within a short-term trading channel, where near-term support is identified at $61.50 and resistance is near $64.30.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-02-09 &nbsp; point $63.2 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/f93e2686ff62d2bd299a6eaa159a9606' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>As of February 9, 2026, WTI crude oil is trading near $63.55, supported by a significant geopolitical risk premium ($4–$10/bbl) stemming from U.S.–Iran tensions and potential shipping disruptions in the Strait of Hormuz. OPEC+ has paused voluntary production increases through March 2026, maintaining near-term supply tightness despite soft underlying global demand and rising non-OPEC+ production. Over the 5, 10, and 21 business day horizons, we expect the price to exhibit high volatility, with a slight downward drift in the median forecast as some risk premium is anticipated to deflate. However, the probability distribution is heavily skewed to the upside, reflecting the asymmetric risk of a …</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> At the 10-day horizon, the persistent geopolitical 'wild card' continues to dominate, while OPEC+'s production pause through March provides a solid floor. The median forecast is slightly lower at $63.25, reflecting a slow decay of the geopolitical premium in the absence of direct conflict. Increased uncertainty broadens the 90% confidence interval to $57.00–$72.65, with upside risks significantly more pronounced.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-02-16 &nbsp; point $63.2 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2438bf9fc260e46829e9dbe17b49d5e8' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>This oil price forecast models WTI crude futures over 5, 10, and 21 business days. The short-term price path is dominated by Middle Eastern geopolitical risk (specifically Strait of Hormuz transit concerns) and OPEC+'s extension of supply cuts through March 2026. However, bearish structural demand fundamentals and strong non-OPEC+ supply growth throughout 2026 act as a powerful anchor, preventing sustained breakout rallies and keeping the point forecasts centered between $63.20 and $63.80.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> In the near term (5 business days), WTI is expected to remain supported by heightened geopolitical risk in the Middle East, particularly around U.S.-Iran tensions and warning advisories in the Strait of Hormuz. OPEC+ has reaffirmed its decision to keep its voluntary production cuts in place through March 2026, maintaining tight physical supplies. However, broader macroeconomic headwinds and soft demand forecasts from the IEA limit significant upside, keeping the point forecast near $63.20. Volatility remains elevated due to potential quick changes in tension levels.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-02-23 &nbsp; point $66.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/0c497154e723750de7a4cff60080b383' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>Overall, the forecasts represent a market currently driven by a delicate balance: near-term geopolitical risk premium in the Persian Gulf is supporting WTI prices near $66.39, while longer-term demand uncertainties and projected oversupply by the EIA and IEA limit sustained gains. OPEC+ policy maintaining a production pause through March 2026 acts as a strong buffer, but the market's high sensitivity to potential shipping disruptions in the Strait of Hormuz creates upside tail risk.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over the next 5 business days, WTI crude is expected to trade within a relatively tight range centered near $66.50. The market continues to balance the immediate geopolitical risk premium stemming from US-Iran tensions in the Persian Gulf against a broader outlook of comfortable supply. OPEC+ maintains its pause on production increases through March, which provides short-term price support.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-03-02 &nbsp; point $75.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e91937d682c4a7dc2ae5089359cf1e63' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>Our forecasts combine the immediate geopolitical shock in the Strait of Hormuz with fundamental constraints. While a massive war premium has driven WTI prices into the mid-to-high $70s in the spot market, the medium-term price path is capped by massive U.S. and IEA SPR intervention alongside deteriorating macroeconomic demand, creating a highly volatile and wide distribution of possible outcomes.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> As of March 2, 2026, WTI oil prices have surged sharply from the Friday close of $67.02 to the $73-$78 range following a dramatic military conflict between the US, Israel, and Iran on Feb 28, 2026, which threatens the Strait of Hormuz (representing ~20% of global seaborne trade). The short-term horizon reflects this elevated risk premium, but with significant volatility as the market digests potential escalation against planned emergency SPR releases and OPEC+'s extension of supply cuts.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-03-09 &nbsp; point $106.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/d1e35a0d4345b4f0801c8c2ffdaf4af7' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>This forecast is formulated as of March 9, 2026, incorporating the major geopolitical shock involving the United States, Israel, and Iran, which culminated in the closure of the Strait of Hormuz in early March 2026. This disruption representing roughly 20% of global oil flows has injected an unprecedented risk premium, driving WTI from $90.90 on March 6 to a daily close of $104.50 on March 9. The probabilistic distribution reflects extreme short-term volatility, with the upper quantiles representing severe supply shortfall scenarios and the lower quantiles representing potential de-escalation and emergency SPR release interventions.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> WTI prices surged sharply to around $104.50 on Monday, March 9, 2026, up from $90.90 on Friday, March 6. This massive escalation follows the outbreak of military conflict between the US, Israel, and Iran on February 28, 2026, and Iran's subsequent closure of the Strait of Hormuz—a chokepoint handling about 20% of global oil trade. For the 5-day horizon (approx. March 16), the market is expected to remain in extreme panic. While aggressive SPR releases planned by G7 and IEA nations could mitigate some of the supply shock, the sheer size of the deficit (potentially up to 8-10 mb/d) keeps near-term price risks heavily skewed to the upside. The median is projected at $106.50, with a wide upside …</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-03-16 &nbsp; point $98.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/3c95edb045bc555f19a9b7204958be9c' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>Overall WTI price dynamics as of March 16, 2026, are completely dominated by the conflict in the Middle East and the closure of the Strait of Hormuz since late February. While the IEA/SPR releases of 400M barrels provide a critical supply bridge, physical logistics limit immediate delivery. Consequently, WTI remains elevated in the short term, with a gradual moderation expected over the medium term. High volatility and wider tail-risks are reflected in the broad, skewed quantile distributions.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over the 5-day horizon, the physical closure of the Strait of Hormuz continues to severely restrict 20% of global seaborne crude flows. Although the IEA coordinated release of 400M barrels (including 172M from the US SPR) is announced, the physical logistics of delivery take time, keeping WTI highly elevated. The point forecast is set near recent closes at $98.00, with high volatility and potential upside if military actions escalate.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-03-23 &nbsp; point $99.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/d025cc2d375a06b435a20a8bd41251b5' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>WTI crude oil markets are undergoing a historic geopolitical supply shock due to conflict in the Middle East starting in late February 2026, causing the closure of the Strait of Hormuz and shut-ins of over 10 million b/d of Persian Gulf oil production. The global response via a massive 400-million-barrel IEA emergency reserve release and OPEC+ starting its voluntary cut unwinding in April provides a powerful eventual buffer, but physical constraints keep near-term supply critical. The resulting forecasts combine high near-term price stickiness with a rapidly widening and highly asymmetric probability distribution over the multi-week horizon.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over a 5-day horizon (as of late March 2026), WTI crude oil is highly supported by the physical closure of the Strait of Hormuz, which has shut in approximately 10-12 million b/d of Middle Eastern crude. Although a massive coordinated SPR release of 400 million barrels has been announced by the IEA (including 172 million barrels from the U.S.), physical logistics prevent these barrels from immediately alleviating the deficit. Volatility remains extremely high. The point forecast is set slightly higher at $99.00/bbl, with a tight downside unless sudden diplomatic breakthroughs occur.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-03-30 &nbsp; point $101.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/1f9305bcef6cbad03709a894348c3d29' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The WTI crude oil market is currently experiencing unprecedented geopolitical volatility following the outbreak of conflict between the US, Israel, and Iran on February 28, 2026, which effectively closed the Strait of Hormuz. The loss of up to 10 mb/d of oil transit has pushed WTI to a 52-week high close of $99.64. Coordinated emergency releases of 400 million barrels by the IEA and 172 million barrels by the US SPR provide a short-term buffer, but the market remains highly anxious. Our forecasts reflect high near-term prices due to momentum and physical tightening, but show a significantly wider and bifurcated distribution over the 10-day and 21-day horizons, capturing both the potential …</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over a 5-day horizon (by April 6, 2026), the immediate momentum remains heavily bullish as WTI recently closed at a 52-week high of $99.64 on March 27. The de facto closure of the Strait of Hormuz since late February has removed up to 10 mb/d of Gulf oil supply, creating the largest supply disruption in history. While the coordinated IEA release of 400 million barrels (including 172 million from the US SPR) acts as a temporary buffer, the physical shipping blockade remains unresolved. We expect prices to consolidate or rise slightly further, with a median of $101.50. The downside risk (0.05 quantile at $75.00) represents a sudden ceasefire rumor, while the upside risk (0.95 quantile at …</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-04-06 &nbsp; point $112.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/9b5f34a987671ec989c237ff1d9f8ffb' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>Global oil markets as of early April 2026 are experiencing one of the most severe supply shocks in history due to the closure of the Strait of Hormuz on February 28, 2026, which blocked roughly 20% of seaborne oil trade. These forecasts are calibrated to reflect extreme volatility, combining short-term bullish momentum (war-risk premium) with medium-term risks of demand destruction, physical SPR release lag times, and potential diplomatic breakthroughs.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> In the immediate 5-day horizon, WTI crude oil prices are expected to remain extremely elevated, consolidating around the $111-$114 range. The closure of the Strait of Hormuz since late February 2026 has introduced a massive geopolitical war-risk premium of $25-$30/bbl due to the disruption of ~10 million bpd of Middle Eastern crude exports. Despite a massive coordinated 400-million-barrel SPR release led by the US and allies, physical logistics take time to clear, keeping physical markets extremely tight. Short-term upside risks include direct military escalations in the Gulf, potentially driving WTI toward $120-$128. Conversely, any reports of successful diplomatic ceasefire talks in …</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-04-13 &nbsp; point $103.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/6b2cd661cdd5b384a653a758d6a5d01c' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The WTI crude oil market as of April 13, 2026, is dominated by the unprecedented supply crisis following the closure of the Strait of Hormuz and the subsequent U.S. naval blockade. Global supply is down by 10.1 mb/d, countered by a 400-million-barrel international coordinated emergency stock release (including 172 million barrels from the U.S. SPR). This creates a highly volatile, bimodal risk profile, where any signs of diplomatic breakthrough can cause sharp, double-digit daily price plunges, while further military escalation could easily push prices above $120/bbl.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> As of April 13, 2026, WTI is trading at approximately $104.44, up sharply from the April 10 close of $96.57. This jump is driven by a new wave of escalation, including a scheduled U.S. naval blockade of Iranian ports starting April 13. While a two-week ceasefire was announced on April 7 (which dropped prices from $112.95 to $94.41), the blockade orders have injected a massive geopolitical risk premium back into the market. With the Strait of Hormuz effectively closed, a historic global supply deficit of 10.1 mb/d exists, only partially offset by the coordinated 400-million-barrel strategic reserve release (including 172 million barrels from the US SPR). Over a 5-day horizon (by April 20), …</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-04-20 &nbsp; point $91.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2feca4d279d03d907fbf81c944e2b41d' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The forecasts as of April 20, 2026, model WTI prices under extreme geopolitical strain from the US-Iran conflict and the blockaded Strait of Hormuz. The short-term dip on April 17 ($83.85) has reversed due to the weekend escalation (US seizure of an Iranian vessel). Prices are projected to rebound across all horizons as geopolitical premiums are priced back in, though massive, coordinated SPR releases (172M barrels from the US, 400M internationally) will continue to suppress runaway tail spikes.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Following the sharp pullback on Friday, April 17 to $83.85 due to diplomatic hopes, Monday, April 20 saw Brent rebound to ~$95/bbl on news of a US seizure of an Iranian vessel, which has dampened hopes for an immediate ceasefire. In the 5-day horizon (April 27), WTI is projected to rebound into the low-to-mid 90s, driven by the renewed pricing-in of the Strait of Hormuz blockade and regional escalation risks. However, active SPR releases (including the US DOE exchange contract for 26M barrels announced April 16) and demand destruction in high-price regions will cap the immediate upside, keeping the median at $91.50.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-04-27 &nbsp; point $93.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/ae38a365e95e8740d217e683ce46f968' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The WTI crude oil market as of April 27, 2026, is operating in a historic crisis regime following the blockade of the Strait of Hormuz in late February, which disrupted ~10 million b/d of global supply. While the market peaked near $113 on April 7, significant corrections to the low $80s and bounces back to $94.40 indicate a highly volatile, news-driven market. The forecast models this with a slightly declining median trajectory over the next 21 business days, reflecting massive coordinated SPR releases and brewing demand destruction, while maintaining extraordinarily wide and flat tails to reflect the ongoing geopolitical risks and potential for sharp binary shifts.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over a 5-day horizon (targeting early May 2026), the crude oil market will continue to trade under extreme volatility. Although the peak of the panic has subsided from the $113 high on April 7, the Strait of Hormuz remains effectively blocked. The U.S. and IEA's massive coordinated 400-million-barrel SPR release program (including the DOE's recent 30-million-barrel exchange requests) provides a temporary physical ceiling. However, high-headline sensitivity suggests any escalation or a sudden de-escalation could move the market by $10-$15 in either direction.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-05-04 &nbsp; point $101.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e26328576a2b2628aa2dd7364e35ab1c' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>The WTI crude oil market as of May 4, 2026 is dominated by extreme geopolitical tensions following the February 2026 US-Iran conflict and the closure of the Strait of Hormuz. WTI prices surged above $100, peaking near $113, but remain highly volatile. The US emergency SPR release of 172 million barrels serves as a key bearish buffer, while the UAE's exit from OPEC effective May 1 introduces long-term supply uncertainty. The forecasts incorporate high short-term volatility, with a gradual downward drift in the median as demand destruction and emergency supplies offset the geopolitical premium, and a wide distribution representing the dual possibilities of either conflict escalation or a …</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over a 5-business-day horizon (May 11, 2026), WTI crude oil prices are expected to remain highly elevated, driven by the ongoing deadlock in the US-Iran conflict and the continued effective closure of the Strait of Hormuz. The median forecast is set at $101.50, slightly easing from the last close of $101.94 but supported by extremely tight physical markets. Downside risks (0.05 quantile at $82.00) reflect the potential for sudden diplomatic progress or a temporary ceasefire, which previously caused a drop to $83.85 on April 17. Upside risks (0.95 quantile at $115.50) reflect a potential retest of the April high if conflict intensifies or further naval incidents occur.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-05-11 &nbsp; point $94.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/95c5572883d13d9fd3d842b9422f46c8' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>This probabilistic forecast reflects the supply-demand balance under severe geopolitical duress. WTI oil prices remain highly elevated due to the blockaded Strait of Hormuz, but are capped and drifted lower by a massive, coordinated SPR release from the US/IEA and a weakening global demand outlook. Additionally, structural changes in OPEC+ (UAE's exit) and ongoing macroeconomic headwinds introduce a bearish medium-term trend. This dynamic is modeled with a slightly declining median price accompanied by very wide tails that represent the high likelihood of extreme binary outcomes (peace/reopening vs. escalation/blockade).</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over a short-term 5-day horizon, WTI crude is expected to consolidate near its current level, with a minor downward bias to $94.50. The physical supply shortage due to the Strait of Hormuz blockade is countered by ongoing U.S. emergency SPR releases. Volatility remains exceptionally high given daily headline-driven shifts. The downside tail reflects potential diplomatic breakthrough announcements, while the upside tail accounts for sudden escalation.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-05-18 &nbsp; point $103.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/f0eb8ce0a149c4ecf5cc6938be48a8b7' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>WTI prices as of May 18, 2026, are highly volatile and driven by the Strait of Hormuz closure that began on Feb 28, 2026, which severely restricted global tanker traffic. Offsetting these shortages are coordinated emergency releases from the US SPR and other IEA members, along with demand contraction resulting from sustained high prices. The recent exit of the UAE from OPEC+ on May 1 also points to potential supply competition. The probabilistic forecasts reflect a wide range of outcomes over the next month, with a slight downward drift in the point forecast as demand destruction and strategic reserves releases offset the war premium.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> At a 10 business day horizon, the point forecast decays slightly to $103.50/bbl. While physical tightness keeps prices high, demand-saving measures and high costs are beginning to suppress fuel consumption, as highlighted by the IEA's downgraded demand expectations. The UAE's exit from OPEC+ on May 1 also adds potential medium-term competitive supply pressure, widening the downside tail risk.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-05-25 &nbsp; point $95.0 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/139924069807c85cd9fd5edbe36073ab' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>Our probabilistic forecast reflects the highly binary state of the WTI crude market as of late May 2026. The primary driver is the geopolitical standoff in the Strait of Hormuz, where a potential US-Iran peace MOU has triggered a sharp price drop from the $108 level. If the MOU is finalized and the Strait reopens, the supply shock will resolve, though downside is buffered by historically low OECD stocks and the need for US SPR replenishment. If negotiations collapse, WTI is prone to retesting its 52-week high of $112.95. Meanwhile, macroeconomic demand is weak, with the IEA downgrading 2026 demand, and OPEC+ policy remains reactive after the UAE's exit on May 1.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over a 5-business-day horizon (approx. June 1, 2026), WTI oil prices are projected to consolidate slightly lower around a median of $95.00. High-level negotiations for a 60-day US-Iran MOU to reopen the Strait of Hormuz have injected substantial downward pressure, prompting a sharp drop from above $107. However, public Iranian contradictions regarding control of the Strait introduce a strong upside risk, capped around $109.00 if talks break down. Downside risks down to $83.00 would emerge upon a sudden official signing of the ceasefire.</div></div><div style='border:1px solid #e0e0e0;border-radius:8px;padding:12px 14px;margin:8px 0;background:#fafafa;font-size:13px;line-height:1.5'><div style='display:flex;justify-content:space-between'><b style='color:#1a1a1a'>News Agent (gemini-3.5-flash)</b><span style='color:#888'>2026-06-01 &nbsp; point $86.5 &nbsp; <a href='https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/4459e9d86d52ae3c854714697f8a2188' target='_blank' style='color:#2171b5'>🔗 Langfuse trace</a></span></div><div style='margin-top:6px;color:#333'>This WTI crude oil forecast as of June 1, 2026, incorporates the sharp late-May price correction from $108.66 down to $87.36. This decline was driven by diplomatic optimism regarding a potential 60-day US-Iran ceasefire and the reopening of the Strait of Hormuz. Given the extreme geopolitical volatility, low global and US SPR inventory levels (historically supportive of prices), and OPEC+ compliance adjustments, the forecasting distributions are exceptionally wide. Point forecasts reflect a slight downward bias on hopes of successful diplomatic resolution, balanced by substantial upside risk if ceasefire talks fail.</div><div style='margin-top:6px;color:#444'><b>Horizon note:</b> Over a 5-day horizon (approx. June 8, 2026), WTI crude oil prices are expected to exhibit high volatility as the market digests ongoing negotiations regarding a 60-day US-Iran memorandum of understanding (MoU). A successful announcement could compress the geopolitical risk premium further, pushing prices toward $75-$80. Conversely, a failure in negotiations or an uptick in maritime tension near the Strait of Hormuz could quickly rebound WTI back toward $95-$100+. The point forecast is set slightly below the last close at $86.50 to reflect a marginal downward drift on ceasefire optimism.</div></div></div>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -10951,17 +9218,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "fe4b4d17",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/markdown": [
-       "1. **News Agent (gemini-3.5-flash)** has the best mean CRPS (5.64) on the 2026 evaluation, ahead of **LLMP-Grid (gemini-3.5-flash)** (9.15) by 3.52 — a gap larger than the combined standard error — a real edge over this window.\n",
+       "1. **News Agent (gemini-3.5-flash)** has the best mean CRPS (8.03) on the 2026 evaluation, ahead of **News Agent (gemini-3.1-flash-lite-preview)** (8.21) by 0.18 — **well within the combined standard error**, so the ranking here is not statistically distinguishable from noise.\n",
        "2. The leaderboard is **decided at h=21d**, where CRPS ranges 0.2–36.4 across methods; at the short h=5d horizon the methods are nearly tied (range 0.2–27.8). A handful of long-horizon points drives the whole ranking.\n",
-       "3. **By family** (mean CRPS): Numerical ML 9.85, LLM / Agent 10.16, Baseline 13.64. Best family this window: **Numerical ML**.\n",
-       "4. **Calibration:** News Agent (gemini-3.5-flash)'s 80% interval covered 66% of outcomes (target 80%) over its 50 scored point(s). With this few, coverage this far from target is itself a small-sample artefact, not necessarily mis-calibration.\n",
+       "3. **By family** (mean CRPS): Numerical ML 9.85, LLM / Agent 10.28, Baseline 13.64. Best family this window: **Numerical ML**.\n",
+       "4. **Calibration:** News Agent (gemini-3.5-flash)'s 80% interval covered 46% of outcomes (target 80%) over its 50 scored point(s). With this few, coverage this far from target is itself a small-sample artefact, not necessarily mis-calibration.\n",
        "5. Based on 18 origins / 544 scored points."
       ],
       "text/plain": [

--- a/implementations/energy_oil_forecasting/data/predictions/energy_oil_eval/agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous__wti_oil_price_forecast.yaml
+++ b/implementations/energy_oil_forecasting/data/predictions/energy_oil_eval/agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous__wti_oil_price_forecast.yaml
@@ -1,0 +1,1754 @@
+spec:
+  task:
+    task_id: wti_oil_price_forecast
+    target_series_id: wti_crude_oil_price
+    horizons:
+    - 5
+    - 10
+    - 21
+    frequency: B
+    description: 'WTI Crude Oil continuous front-month futures Close price (yfinance
+      symbol: CL=F), projected 5, 10, and 21 trading days ahead.'
+    payload_type: continuous
+    categories: null
+    resolution_fn: observed_value_at_resolution_timestamp
+  start: '2026-02-02T00:00:00'
+  end: '2026-06-01T00:00:00'
+  stride: 5
+  origin_dates: null
+  warmup: 250
+  description: Prospective/out-of-sample evaluation period in 2026 for daily WTI crude
+    oil. Evaluates selected contender models on 18 weekly origins from the early 2026
+    geopolitical price shock through its aftermath, to measure adaptive real-time
+    forecasting performance.
+predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+predictions:
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:54:32.927249'
+  as_of: '2026-02-02T00:00:00'
+  forecast_date: '2026-02-09T00:00:00'
+  payload:
+    point_forecast: 65.8
+    quantiles:
+      '0.05': 63.5
+      '0.1': 64.1
+      '0.2': 64.6
+      '0.3': 65.1
+      '0.4': 65.5
+      '0.5': 65.8
+      '0.6': 66.2
+      '0.7': 66.6
+      '0.8': 67.2
+      '0.9': 67.9
+      '0.95': 68.5
+  metadata:
+    rationale: 'The forecast reflects a market in tension: structurally high global
+      inventory and production growth are balanced against significant geopolitical
+      risk premiums, particularly in the Middle East. OPEC+ compliance and the decision
+      to keep output constant support current price levels, but the outlook anticipates
+      a return to structural fundamentals over the medium term.'
+    horizon_rationale: Short-term momentum is bullish due to ongoing geopolitical
+      risk premium concerns, but technical resistance near $66 remains significant.
+    langfuse_trace_id: e6b4dd41c549771ff127f297427fdd08
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e6b4dd41c549771ff127f297427fdd08
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:54:32.927249'
+  as_of: '2026-02-02T00:00:00'
+  forecast_date: '2026-03-03T00:00:00'
+  payload:
+    point_forecast: 65.5
+    quantiles:
+      '0.05': 60.5
+      '0.1': 61.8
+      '0.2': 63.0
+      '0.3': 64.0
+      '0.4': 64.8
+      '0.5': 65.5
+      '0.6': 66.3
+      '0.7': 67.2
+      '0.8': 68.5
+      '0.9': 70.1
+      '0.95': 71.5
+  metadata:
+    rationale: 'The forecast reflects a market in tension: structurally high global
+      inventory and production growth are balanced against significant geopolitical
+      risk premiums, particularly in the Middle East. OPEC+ compliance and the decision
+      to keep output constant support current price levels, but the outlook anticipates
+      a return to structural fundamentals over the medium term.'
+    horizon_rationale: Over the monthly horizon, the structural supply-demand balance
+      (bearish) is expected to reassert control, tempering the price gains from shorter-term
+      geopolitical premiums.
+    langfuse_trace_id: e6b4dd41c549771ff127f297427fdd08
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e6b4dd41c549771ff127f297427fdd08
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:54:45.852539'
+  as_of: '2026-02-09T00:00:00'
+  forecast_date: '2026-02-23T00:00:00'
+  payload:
+    point_forecast: 64.8
+    quantiles:
+      '0.05': 61.0
+      '0.1': 61.8
+      '0.2': 62.5
+      '0.3': 63.5
+      '0.4': 64.2
+      '0.5': 64.8
+      '0.6': 65.5
+      '0.7': 66.5
+      '0.8': 67.8
+      '0.9': 69.5
+      '0.95': 71.0
+  metadata:
+    rationale: As of Feb 9, 2026, WTI is trading at $63.55. Markets remain highly
+      sensitive to geopolitical tensions in the Strait of Hormuz, maintaining a risk
+      premium. OPEC+ is committed to production pauses through Q1 2026, providing
+      a price floor. However, long-term projections by the EIA suggest that market
+      surpluses may begin to weigh on prices as 2026 progresses, tempering the upside
+      potential for the 21-day horizon.
+    horizon_rationale: The 10-day horizon incorporates potential for further escalation
+      in regional naval activities. While supply remains tight, the market will continue
+      to weigh this against underlying soft demand indicators.
+    langfuse_trace_id: cc8f6066c4fe542914a54cf8856a037c
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/cc8f6066c4fe542914a54cf8856a037c
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:54:45.852539'
+  as_of: '2026-02-09T00:00:00'
+  forecast_date: '2026-03-10T00:00:00'
+  payload:
+    point_forecast: 65.5
+    quantiles:
+      '0.05': 59.5
+      '0.1': 60.5
+      '0.2': 61.8
+      '0.3': 63.0
+      '0.4': 64.2
+      '0.5': 65.5
+      '0.6': 66.8
+      '0.7': 68.5
+      '0.8': 70.2
+      '0.9': 72.5
+      '0.95': 74.0
+  metadata:
+    rationale: As of Feb 9, 2026, WTI is trading at $63.55. Markets remain highly
+      sensitive to geopolitical tensions in the Strait of Hormuz, maintaining a risk
+      premium. OPEC+ is committed to production pauses through Q1 2026, providing
+      a price floor. However, long-term projections by the EIA suggest that market
+      surpluses may begin to weigh on prices as 2026 progresses, tempering the upside
+      potential for the 21-day horizon.
+    horizon_rationale: By the 21-day mark, the market may begin to differentiate between
+      sustained geopolitical risk and the structural supply/demand surplus predicted
+      by the EIA for later in 2026. Price action will heavily depend on whether diplomatic
+      de-escalation holds or if regional tensions tighten physical supply chains further.
+    langfuse_trace_id: cc8f6066c4fe542914a54cf8856a037c
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/cc8f6066c4fe542914a54cf8856a037c
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:54:58.791272'
+  as_of: '2026-02-16T00:00:00'
+  forecast_date: '2026-02-23T00:00:00'
+  payload:
+    point_forecast: 62.9
+    quantiles:
+      '0.05': 60.5
+      '0.1': 61.2
+      '0.2': 61.8
+      '0.3': 62.3
+      '0.4': 62.6
+      '0.5': 62.9
+      '0.6': 63.2
+      '0.7': 63.6
+      '0.8': 64.1
+      '0.9': 64.8
+      '0.95': 65.5
+  metadata:
+    rationale: 'The forecasts are anchored by the current WTI price of $62.89 as of
+      February 13, 2026. The market remains in a tug-of-war: OPEC+ maintains a disciplined
+      supply policy through March 2026 to manage inventory, while geopolitical instability
+      in the Persian Gulf (specifically the Strait of Hormuz) sustains a risk premium.
+      Global demand growth has been revised downward by major agencies, creating a
+      persistent drag on prices. Consequently, we expect a relatively flat to slightly
+      elevated price trajectory, characterized by a wide probability distribution
+      reflecting the unpredictability of regional geopolitical flare-ups.'
+    horizon_rationale: Short-term prices are expected to remain range-bound near current
+      levels ($62.90) due to a delicate balance between OPEC+ production discipline
+      and persistent geopolitical risk in the Persian Gulf. While fundamental data
+      points to potential oversupply, the risk premium associated with Strait of Hormuz
+      tensions provides a solid support floor.
+    langfuse_trace_id: 8dd25380a3e1ffb6853c8f13facbd57c
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/8dd25380a3e1ffb6853c8f13facbd57c
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:54:58.791272'
+  as_of: '2026-02-16T00:00:00'
+  forecast_date: '2026-03-02T00:00:00'
+  payload:
+    point_forecast: 63.2
+    quantiles:
+      '0.05': 59.8
+      '0.1': 60.5
+      '0.2': 61.4
+      '0.3': 62.1
+      '0.4': 62.7
+      '0.5': 63.2
+      '0.6': 63.8
+      '0.7': 64.4
+      '0.8': 65.1
+      '0.9': 66.0
+      '0.95': 66.8
+  metadata:
+    rationale: 'The forecasts are anchored by the current WTI price of $62.89 as of
+      February 13, 2026. The market remains in a tug-of-war: OPEC+ maintains a disciplined
+      supply policy through March 2026 to manage inventory, while geopolitical instability
+      in the Persian Gulf (specifically the Strait of Hormuz) sustains a risk premium.
+      Global demand growth has been revised downward by major agencies, creating a
+      persistent drag on prices. Consequently, we expect a relatively flat to slightly
+      elevated price trajectory, characterized by a wide probability distribution
+      reflecting the unpredictability of regional geopolitical flare-ups.'
+    horizon_rationale: At the two-week horizon, uncertainty regarding geopolitical
+      developments increases. We anticipate a slight upward drift in the point forecast
+      as the market maintains a precautionary premium, although upside is capped by
+      broader demand-growth revisions and continued US production, which prevent a
+      breakout.
+    langfuse_trace_id: 8dd25380a3e1ffb6853c8f13facbd57c
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/8dd25380a3e1ffb6853c8f13facbd57c
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:54:58.791272'
+  as_of: '2026-02-16T00:00:00'
+  forecast_date: '2026-03-17T00:00:00'
+  payload:
+    point_forecast: 63.5
+    quantiles:
+      '0.05': 58.5
+      '0.1': 59.5
+      '0.2': 60.8
+      '0.3': 61.8
+      '0.4': 62.7
+      '0.5': 63.5
+      '0.6': 64.3
+      '0.7': 65.2
+      '0.8': 66.3
+      '0.9': 67.8
+      '0.95': 68.9
+  metadata:
+    rationale: 'The forecasts are anchored by the current WTI price of $62.89 as of
+      February 13, 2026. The market remains in a tug-of-war: OPEC+ maintains a disciplined
+      supply policy through March 2026 to manage inventory, while geopolitical instability
+      in the Persian Gulf (specifically the Strait of Hormuz) sustains a risk premium.
+      Global demand growth has been revised downward by major agencies, creating a
+      persistent drag on prices. Consequently, we expect a relatively flat to slightly
+      elevated price trajectory, characterized by a wide probability distribution
+      reflecting the unpredictability of regional geopolitical flare-ups.'
+    horizon_rationale: Over the monthly horizon, the interplay between fundamental
+      oversupply and geopolitical risk remains the dominant driver. The forecast reflects
+      a scenario where OPEC+ continues its cautious stance into March, while persistent
+      regional tensions in the Persian Gulf sustain a base level of risk-driven support
+      for WTI, even if fundamental market indicators suggest continued price stagnation.
+    langfuse_trace_id: 8dd25380a3e1ffb6853c8f13facbd57c
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/8dd25380a3e1ffb6853c8f13facbd57c
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:55:12.801880'
+  as_of: '2026-02-23T00:00:00'
+  forecast_date: '2026-03-02T00:00:00'
+  payload:
+    point_forecast: 66.5
+    quantiles:
+      '0.05': 63.5
+      '0.1': 64.2
+      '0.2': 65.0
+      '0.3': 65.6
+      '0.4': 66.1
+      '0.5': 66.5
+      '0.6': 66.9
+      '0.7': 67.4
+      '0.8': 68.2
+      '0.9': 69.5
+      '0.95': 70.5
+  metadata:
+    rationale: The forecast reflects a market currently driven by a tension between
+      bearish medium-term fundamentals (global production outpacing demand) and immediate,
+      intense geopolitical risk premiums tied to the Persian Gulf. As of Feb 23, 2026,
+      OPEC+ is maintaining its production cuts, which acts as a support level. The
+      short-term forecast is skewed to the upside due to risk, while the medium-term
+      forecast reflects a potential mean reversion toward fundamental values if conflict
+      does not escalate into physical supply disruption.
+    horizon_rationale: Over the next 5 days, market sentiment will be dominated by
+      the geopolitical risk premium linked to Iran and the Strait of Hormuz. While
+      underlying fundamentals (projected global surplus) are bearish, they are currently
+      secondary to short-term fears of supply disruption. Prices are expected to maintain
+      current levels with upside volatility risk.
+    langfuse_trace_id: 5b95d73e0b6a49a78ae91369c173dbc9
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/5b95d73e0b6a49a78ae91369c173dbc9
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:55:12.801880'
+  as_of: '2026-02-23T00:00:00'
+  forecast_date: '2026-03-09T00:00:00'
+  payload:
+    point_forecast: 66.8
+    quantiles:
+      '0.05': 62.5
+      '0.1': 63.5
+      '0.2': 64.5
+      '0.3': 65.4
+      '0.4': 66.2
+      '0.5': 66.8
+      '0.6': 67.5
+      '0.7': 68.3
+      '0.8': 69.5
+      '0.9': 71.0
+      '0.95': 72.0
+  metadata:
+    rationale: The forecast reflects a market currently driven by a tension between
+      bearish medium-term fundamentals (global production outpacing demand) and immediate,
+      intense geopolitical risk premiums tied to the Persian Gulf. As of Feb 23, 2026,
+      OPEC+ is maintaining its production cuts, which acts as a support level. The
+      short-term forecast is skewed to the upside due to risk, while the medium-term
+      forecast reflects a potential mean reversion toward fundamental values if conflict
+      does not escalate into physical supply disruption.
+    horizon_rationale: By the 10-day horizon, uncertainty regarding potential military
+      escalation will likely keep the geopolitical premium intact. The OPEC+ decision
+      to maintain production cuts provides a floor, offsetting concerns about slowing
+      demand growth in 2026.
+    langfuse_trace_id: 5b95d73e0b6a49a78ae91369c173dbc9
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/5b95d73e0b6a49a78ae91369c173dbc9
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:55:12.801880'
+  as_of: '2026-02-23T00:00:00'
+  forecast_date: '2026-03-24T00:00:00'
+  payload:
+    point_forecast: 65.5
+    quantiles:
+      '0.05': 60.0
+      '0.1': 61.5
+      '0.2': 63.0
+      '0.3': 64.0
+      '0.4': 64.8
+      '0.5': 65.5
+      '0.6': 66.5
+      '0.7': 67.8
+      '0.8': 69.5
+      '0.9': 72.0
+      '0.95': 74.0
+  metadata:
+    rationale: The forecast reflects a market currently driven by a tension between
+      bearish medium-term fundamentals (global production outpacing demand) and immediate,
+      intense geopolitical risk premiums tied to the Persian Gulf. As of Feb 23, 2026,
+      OPEC+ is maintaining its production cuts, which acts as a support level. The
+      short-term forecast is skewed to the upside due to risk, while the medium-term
+      forecast reflects a potential mean reversion toward fundamental values if conflict
+      does not escalate into physical supply disruption.
+    horizon_rationale: By the 21-day horizon, if no major physical disruption occurs,
+      fundamental pressures may begin to assert more influence. The prospect of global
+      supply increasing and projected easing of price levels throughout 2026 may pull
+      prices lower. However, a wide range is maintained for the higher quantiles due
+      to the continued possibility of tail-risk events in the Middle East.
+    langfuse_trace_id: 5b95d73e0b6a49a78ae91369c173dbc9
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/5b95d73e0b6a49a78ae91369c173dbc9
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:55:25.708522'
+  as_of: '2026-03-02T00:00:00'
+  forecast_date: '2026-03-09T00:00:00'
+  payload:
+    point_forecast: 82.0
+    quantiles:
+      '0.05': 75.0
+      '0.1': 77.0
+      '0.2': 79.0
+      '0.3': 80.5
+      '0.4': 81.5
+      '0.5': 82.0
+      '0.6': 83.5
+      '0.7': 85.0
+      '0.8': 87.0
+      '0.9': 90.0
+      '0.95': 93.0
+  metadata:
+    rationale: The forecast is driven by the severe geopolitical shock of February
+      28, 2026, which effectively closed the Strait of Hormuz, cutting off a critical
+      oil transit artery. Market dynamics are dominated by extreme risk premiums,
+      expectation of severe inventory draws, and the reactive policy of IEA-coordinated
+      reserve releases. The price outlook is inherently bullish and extremely volatile,
+      contingent on the duration and intensity of the Middle East conflict and the
+      effectiveness of international efforts to manage the resulting supply vacuum.
+    horizon_rationale: As of March 2, 2026, the market is in a state of high alarm
+      due to the February 28 outbreak of conflict in the Middle East and the closure
+      of the Strait of Hormuz. With the market reacting to a sudden ~20% global supply
+      threat, extreme volatility and a major geopolitical risk premium are baked into
+      prices. The short-term horizon (5 days) reflects the panic phase and initial
+      market response to the blockade.
+    langfuse_trace_id: f6229c1eea33ddd282209c0cca84ded4
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/f6229c1eea33ddd282209c0cca84ded4
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:55:25.708522'
+  as_of: '2026-03-02T00:00:00'
+  forecast_date: '2026-03-16T00:00:00'
+  payload:
+    point_forecast: 88.0
+    quantiles:
+      '0.05': 80.0
+      '0.1': 82.0
+      '0.2': 84.0
+      '0.3': 86.0
+      '0.4': 87.0
+      '0.5': 88.0
+      '0.6': 90.0
+      '0.7': 93.0
+      '0.8': 96.0
+      '0.9': 100.0
+      '0.95': 105.0
+  metadata:
+    rationale: The forecast is driven by the severe geopolitical shock of February
+      28, 2026, which effectively closed the Strait of Hormuz, cutting off a critical
+      oil transit artery. Market dynamics are dominated by extreme risk premiums,
+      expectation of severe inventory draws, and the reactive policy of IEA-coordinated
+      reserve releases. The price outlook is inherently bullish and extremely volatile,
+      contingent on the duration and intensity of the Middle East conflict and the
+      effectiveness of international efforts to manage the resulting supply vacuum.
+    horizon_rationale: Over 10 days, the market will grapple with the reality of the
+      supply chokehold and wait for clarity on the IEA/US emergency reserve release
+      schedule. The risk is heavily skewed upward as logistical bottlenecks worsen
+      and shipping insurers continue to hike premiums, while global supply inventories
+      draw down rapidly.
+    langfuse_trace_id: f6229c1eea33ddd282209c0cca84ded4
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/f6229c1eea33ddd282209c0cca84ded4
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:55:25.708522'
+  as_of: '2026-03-02T00:00:00'
+  forecast_date: '2026-03-31T00:00:00'
+  payload:
+    point_forecast: 95.0
+    quantiles:
+      '0.05': 85.0
+      '0.1': 87.0
+      '0.2': 90.0
+      '0.3': 92.0
+      '0.4': 93.5
+      '0.5': 95.0
+      '0.6': 98.0
+      '0.7': 102.0
+      '0.8': 108.0
+      '0.9': 115.0
+      '0.95': 120.0
+  metadata:
+    rationale: The forecast is driven by the severe geopolitical shock of February
+      28, 2026, which effectively closed the Strait of Hormuz, cutting off a critical
+      oil transit artery. Market dynamics are dominated by extreme risk premiums,
+      expectation of severe inventory draws, and the reactive policy of IEA-coordinated
+      reserve releases. The price outlook is inherently bullish and extremely volatile,
+      contingent on the duration and intensity of the Middle East conflict and the
+      effectiveness of international efforts to manage the resulting supply vacuum.
+    horizon_rationale: By the 21-day horizon, the impact of the Strait of Hormuz closure
+      on refiner operations and global product availability will be fully realized.
+      While SPR releases are planned, they may prove insufficient to offset a prolonged,
+      severe supply shock. The uncertainty range is wide, reflecting the possibility
+      of either a de-escalation or further military conflict and supply disruption.
+    langfuse_trace_id: f6229c1eea33ddd282209c0cca84ded4
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/f6229c1eea33ddd282209c0cca84ded4
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:55:38.529437'
+  as_of: '2026-03-09T00:00:00'
+  forecast_date: '2026-03-16T00:00:00'
+  payload:
+    point_forecast: 105.0
+    quantiles:
+      '0.05': 85.0
+      '0.1': 90.0
+      '0.2': 95.0
+      '0.3': 98.0
+      '0.4': 102.0
+      '0.5': 105.0
+      '0.6': 108.0
+      '0.7': 112.0
+      '0.8': 116.0
+      '0.9': 120.0
+      '0.95': 125.0
+  metadata:
+    rationale: The market is currently reacting to a major systemic shock in the Persian
+      Gulf (Strait of Hormuz closure). The historical volatility is extreme, and as
+      of March 9, 2026, the price reflects a panicked reaction. The forecast assumes
+      persistent geopolitical risk, an inability to fully replace lost production
+      through reserve releases, and a structural upward shift in the oil price curve
+      to account for the supply shortfall.
+    horizon_rationale: Following the closure of the Strait of Hormuz, the market is
+      in extreme backwardation and high volatility. The 5-day outlook accounts for
+      continued supply panic and the initial absorption of the shock. $105 serves
+      as a median expectation, balancing the potential for G7 strategic reserve releases
+      against the acute loss of roughly 20% of global oil flows.
+    langfuse_trace_id: 62d244e3a64c7df2eedf646a563b3f09
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/62d244e3a64c7df2eedf646a563b3f09
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:55:38.529437'
+  as_of: '2026-03-09T00:00:00'
+  forecast_date: '2026-03-23T00:00:00'
+  payload:
+    point_forecast: 110.0
+    quantiles:
+      '0.05': 90.0
+      '0.1': 95.0
+      '0.2': 100.0
+      '0.3': 104.0
+      '0.4': 107.0
+      '0.5': 110.0
+      '0.6': 113.0
+      '0.7': 117.0
+      '0.8': 122.0
+      '0.9': 128.0
+      '0.95': 135.0
+  metadata:
+    rationale: The market is currently reacting to a major systemic shock in the Persian
+      Gulf (Strait of Hormuz closure). The historical volatility is extreme, and as
+      of March 9, 2026, the price reflects a panicked reaction. The forecast assumes
+      persistent geopolitical risk, an inability to fully replace lost production
+      through reserve releases, and a structural upward shift in the oil price curve
+      to account for the supply shortfall.
+    horizon_rationale: By day 10, market participants will have likely concluded that
+      strategic reserve releases are insufficient to bridge the supply gap. As geopolitical
+      tensions remain high and uncertainty about the duration of the Strait's closure
+      persists, the price floor should elevate as the market prices in a prolonged
+      premium.
+    langfuse_trace_id: 62d244e3a64c7df2eedf646a563b3f09
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/62d244e3a64c7df2eedf646a563b3f09
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:55:38.529437'
+  as_of: '2026-03-09T00:00:00'
+  forecast_date: '2026-04-07T00:00:00'
+  payload:
+    point_forecast: 118.0
+    quantiles:
+      '0.05': 95.0
+      '0.1': 100.0
+      '0.2': 106.0
+      '0.3': 110.0
+      '0.4': 114.0
+      '0.5': 118.0
+      '0.6': 122.0
+      '0.7': 127.0
+      '0.8': 133.0
+      '0.9': 140.0
+      '0.95': 148.0
+  metadata:
+    rationale: The market is currently reacting to a major systemic shock in the Persian
+      Gulf (Strait of Hormuz closure). The historical volatility is extreme, and as
+      of March 9, 2026, the price reflects a panicked reaction. The forecast assumes
+      persistent geopolitical risk, an inability to fully replace lost production
+      through reserve releases, and a structural upward shift in the oil price curve
+      to account for the supply shortfall.
+    horizon_rationale: At a 21-day horizon, the cumulative effect of a sustained blockage
+      in the Strait of Hormuz will reach global refinery supply chains. Without a
+      clear diplomatic resolution or reopening, the price must trade significantly
+      higher to force demand destruction and reallocate flows. Forecast assumes the
+      crisis remains unresolved, creating a persistent and elevated risk premium.
+    langfuse_trace_id: 62d244e3a64c7df2eedf646a563b3f09
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/62d244e3a64c7df2eedf646a563b3f09
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:55:51.075485'
+  as_of: '2026-03-16T00:00:00'
+  forecast_date: '2026-03-23T00:00:00'
+  payload:
+    point_forecast: 96.5
+    quantiles:
+      '0.05': 90.0
+      '0.1': 92.0
+      '0.2': 94.0
+      '0.3': 95.0
+      '0.4': 95.8
+      '0.5': 96.5
+      '0.6': 97.2
+      '0.7': 98.0
+      '0.8': 99.0
+      '0.9': 101.0
+      '0.95': 103.0
+  metadata:
+    rationale: As of March 16, 2026, the WTI market is in a high-volatility environment
+      following the major supply shock in the Persian Gulf. The primary drivers are
+      the massive IEA emergency reserve release (400M bbls) and the ongoing threat
+      to shipping through the Strait of Hormuz. My central forecast assumes a cautious
+      retracement as physical supply measures take effect, though the 'tail-risk'
+      of further military escalation remains substantial, causing the wider quantile
+      spreads at longer horizons.
+    horizon_rationale: Short-term stabilization is expected as markets digest the
+      IEA's 400M barrel reserve release. While geopolitical tensions remain high due
+      to Strait of Hormuz disruptions, the market is pricing in a 'cooling off' period
+      following the recent price spike, leading to a slight retracement from $98.71.
+    langfuse_trace_id: 9d55d1a90b9f23154212bf2a961fcc74
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/9d55d1a90b9f23154212bf2a961fcc74
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:55:51.075485'
+  as_of: '2026-03-16T00:00:00'
+  forecast_date: '2026-03-30T00:00:00'
+  payload:
+    point_forecast: 94.0
+    quantiles:
+      '0.05': 85.0
+      '0.1': 88.0
+      '0.2': 90.5
+      '0.3': 92.0
+      '0.4': 93.0
+      '0.5': 94.0
+      '0.6': 95.2
+      '0.7': 96.5
+      '0.8': 98.0
+      '0.9': 100.0
+      '0.95': 102.5
+  metadata:
+    rationale: As of March 16, 2026, the WTI market is in a high-volatility environment
+      following the major supply shock in the Persian Gulf. The primary drivers are
+      the massive IEA emergency reserve release (400M bbls) and the ongoing threat
+      to shipping through the Strait of Hormuz. My central forecast assumes a cautious
+      retracement as physical supply measures take effect, though the 'tail-risk'
+      of further military escalation remains substantial, causing the wider quantile
+      spreads at longer horizons.
+    horizon_rationale: Over two weeks, the impact of physical supply replenishment
+      and potential diplomatic efforts is expected to continue putting downward pressure
+      on prices. However, uncertainty regarding the duration of the Gulf shipping
+      blockage keeps a significant risk premium baked into the market.
+    langfuse_trace_id: 9d55d1a90b9f23154212bf2a961fcc74
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/9d55d1a90b9f23154212bf2a961fcc74
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:55:51.075485'
+  as_of: '2026-03-16T00:00:00'
+  forecast_date: '2026-04-14T00:00:00'
+  payload:
+    point_forecast: 90.0
+    quantiles:
+      '0.05': 78.0
+      '0.1': 82.0
+      '0.2': 85.0
+      '0.3': 87.5
+      '0.4': 89.0
+      '0.5': 90.0
+      '0.6': 92.0
+      '0.7': 94.0
+      '0.8': 96.5
+      '0.9': 100.0
+      '0.95': 105.0
+  metadata:
+    rationale: As of March 16, 2026, the WTI market is in a high-volatility environment
+      following the major supply shock in the Persian Gulf. The primary drivers are
+      the massive IEA emergency reserve release (400M bbls) and the ongoing threat
+      to shipping through the Strait of Hormuz. My central forecast assumes a cautious
+      retracement as physical supply measures take effect, though the 'tail-risk'
+      of further military escalation remains substantial, causing the wider quantile
+      spreads at longer horizons.
+    horizon_rationale: By the 21-day horizon, the market expectation is for further
+      normalization toward a new 'stressed equilibrium'. While the IEA release helps,
+      the persistent structural disruption to Gulf supply limits the potential for
+      a complete return to pre-conflict levels.
+    langfuse_trace_id: 9d55d1a90b9f23154212bf2a961fcc74
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/9d55d1a90b9f23154212bf2a961fcc74
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:03.392711'
+  as_of: '2026-03-23T00:00:00'
+  forecast_date: '2026-03-30T00:00:00'
+  payload:
+    point_forecast: 100.5
+    quantiles:
+      '0.05': 92.0
+      '0.1': 94.5
+      '0.2': 97.0
+      '0.3': 98.5
+      '0.4': 99.5
+      '0.5': 100.5
+      '0.6': 101.5
+      '0.7': 103.0
+      '0.8': 105.0
+      '0.9': 107.5
+      '0.95': 110.0
+  metadata:
+    rationale: The forecast reflects the extreme volatility in the oil market as of
+      2026-03-23, driven by the ongoing conflict in the Middle East and the effective
+      blockade of the Strait of Hormuz. Despite massive coordinated SPR releases,
+      the market is pricing in significant geopolitical risk. OPEC+ remains cautious,
+      and shipping disruptions continue to inflate freight costs, maintaining a strong
+      upward bias.
+    horizon_rationale: Market sentiment remains dominated by the 'war premium' following
+      the Strait of Hormuz blockade. While the US SPR release of 172 million barrels
+      is a significant counter-measure, the immediate supply shortfall of ~10mb/d
+      creates upward price pressure over the next week.
+    langfuse_trace_id: 2d2cb4e9ef178fe710fd9a052e0f6674
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2d2cb4e9ef178fe710fd9a052e0f6674
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:03.392711'
+  as_of: '2026-03-23T00:00:00'
+  forecast_date: '2026-04-06T00:00:00'
+  payload:
+    point_forecast: 102.5
+    quantiles:
+      '0.05': 90.0
+      '0.1': 93.0
+      '0.2': 96.5
+      '0.3': 99.0
+      '0.4': 101.0
+      '0.5': 102.5
+      '0.6': 104.0
+      '0.7': 106.5
+      '0.8': 109.0
+      '0.9': 113.0
+      '0.95': 116.0
+  metadata:
+    rationale: The forecast reflects the extreme volatility in the oil market as of
+      2026-03-23, driven by the ongoing conflict in the Middle East and the effective
+      blockade of the Strait of Hormuz. Despite massive coordinated SPR releases,
+      the market is pricing in significant geopolitical risk. OPEC+ remains cautious,
+      and shipping disruptions continue to inflate freight costs, maintaining a strong
+      upward bias.
+    horizon_rationale: Over 10 days, the market will assess the effectiveness of the
+      coordinated SPR release and the persistence of the shipping disruption. Elevated
+      war-risk insurance premiums (7.5-10%) continue to support a floor, and the risk
+      of further military escalation remains the primary source of upside volatility.
+    langfuse_trace_id: 2d2cb4e9ef178fe710fd9a052e0f6674
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2d2cb4e9ef178fe710fd9a052e0f6674
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:03.392711'
+  as_of: '2026-03-23T00:00:00'
+  forecast_date: '2026-04-21T00:00:00'
+  payload:
+    point_forecast: 105.0
+    quantiles:
+      '0.05': 85.0
+      '0.1': 90.0
+      '0.2': 95.0
+      '0.3': 99.0
+      '0.4': 102.5
+      '0.5': 105.0
+      '0.6': 108.0
+      '0.7': 112.0
+      '0.8': 116.0
+      '0.9': 121.0
+      '0.95': 125.0
+  metadata:
+    rationale: The forecast reflects the extreme volatility in the oil market as of
+      2026-03-23, driven by the ongoing conflict in the Middle East and the effective
+      blockade of the Strait of Hormuz. Despite massive coordinated SPR releases,
+      the market is pricing in significant geopolitical risk. OPEC+ remains cautious,
+      and shipping disruptions continue to inflate freight costs, maintaining a strong
+      upward bias.
+    horizon_rationale: By 21 days, the market will have adjusted to the SPR supply
+      additions, but the underlying supply disruption in the Persian Gulf remains
+      unresolved. High uncertainty regarding the duration of the conflict and the
+      potential for a wider regional war results in a wider distribution of risks,
+      skewed toward higher prices.
+    langfuse_trace_id: 2d2cb4e9ef178fe710fd9a052e0f6674
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2d2cb4e9ef178fe710fd9a052e0f6674
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:17.249352'
+  as_of: '2026-03-30T00:00:00'
+  forecast_date: '2026-04-06T00:00:00'
+  payload:
+    point_forecast: 102.5
+    quantiles:
+      '0.05': 94.0
+      '0.1': 96.5
+      '0.2': 98.5
+      '0.3': 100.0
+      '0.4': 101.5
+      '0.5': 102.5
+      '0.6': 103.5
+      '0.7': 105.0
+      '0.8': 107.5
+      '0.9': 110.0
+      '0.95': 115.0
+  metadata:
+    rationale: 'The forecast is driven by the unprecedented supply shock from the
+      closure of the Strait of Hormuz in late February 2026. Global energy security
+      hinges on the restoration of tanker transit. Assumptions include: 1) OPEC+ maintains
+      current cautious production stance; 2) SPR releases are ongoing but do not fully
+      offset the massive supply gap; 3) Shipping insurance premiums remain prohibitive.
+      The outlook is structurally bullish with high volatility due to the geopolitical
+      nature of the conflict.'
+    horizon_rationale: Prices are currently reacting to the total closure of the Strait
+      of Hormuz. In the short term (5 days), volatility remains extreme as the market
+      prices in the risk of sustained supply disruption and the effectiveness of coordinated
+      IEA SPR releases. The price is expected to hold or modestly appreciate above
+      the $99.64 close as market participants wait for news on tanker traffic resumption
+      or potential further military escalations.
+    langfuse_trace_id: 2ed81c4affd1af34b216024c80ed33a7
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2ed81c4affd1af34b216024c80ed33a7
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:17.249352'
+  as_of: '2026-03-30T00:00:00'
+  forecast_date: '2026-04-13T00:00:00'
+  payload:
+    point_forecast: 105.0
+    quantiles:
+      '0.05': 92.0
+      '0.1': 95.0
+      '0.2': 98.0
+      '0.3': 101.0
+      '0.4': 103.0
+      '0.5': 105.0
+      '0.6': 107.0
+      '0.7': 109.5
+      '0.8': 113.0
+      '0.9': 117.0
+      '0.95': 122.0
+  metadata:
+    rationale: 'The forecast is driven by the unprecedented supply shock from the
+      closure of the Strait of Hormuz in late February 2026. Global energy security
+      hinges on the restoration of tanker transit. Assumptions include: 1) OPEC+ maintains
+      current cautious production stance; 2) SPR releases are ongoing but do not fully
+      offset the massive supply gap; 3) Shipping insurance premiums remain prohibitive.
+      The outlook is structurally bullish with high volatility due to the geopolitical
+      nature of the conflict.'
+    horizon_rationale: Over 10 days, the focus shifts to the physical supply gap created
+      by the ~10 mb/d export loss. While SPR releases are underway, the logistics
+      of replacing this volume are immense. The market is likely to maintain a significant
+      risk premium until there is a tangible path toward reopening the strait or a
+      credible diplomatic breakthrough, keeping prices biased toward the upside.
+    langfuse_trace_id: 2ed81c4affd1af34b216024c80ed33a7
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2ed81c4affd1af34b216024c80ed33a7
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:17.249352'
+  as_of: '2026-03-30T00:00:00'
+  forecast_date: '2026-04-28T00:00:00'
+  payload:
+    point_forecast: 108.0
+    quantiles:
+      '0.05': 85.0
+      '0.1': 90.0
+      '0.2': 96.0
+      '0.3': 101.0
+      '0.4': 105.0
+      '0.5': 108.0
+      '0.6': 112.0
+      '0.7': 116.0
+      '0.8': 122.0
+      '0.9': 130.0
+      '0.95': 140.0
+  metadata:
+    rationale: 'The forecast is driven by the unprecedented supply shock from the
+      closure of the Strait of Hormuz in late February 2026. Global energy security
+      hinges on the restoration of tanker transit. Assumptions include: 1) OPEC+ maintains
+      current cautious production stance; 2) SPR releases are ongoing but do not fully
+      offset the massive supply gap; 3) Shipping insurance premiums remain prohibitive.
+      The outlook is structurally bullish with high volatility due to the geopolitical
+      nature of the conflict.'
+    horizon_rationale: By the 21-day horizon, the impact of sustained supply tightness
+      and the depletion of regional storage will be more acute. Unless the shipping
+      lanes reopen, physical shortages will force prices higher. However, the probability
+      of price-induced demand destruction and political pressure to end the conflict
+      becomes a significant two-sided tail risk, widening the confidence intervals
+      significantly.
+    langfuse_trace_id: 2ed81c4affd1af34b216024c80ed33a7
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2ed81c4affd1af34b216024c80ed33a7
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:28.882466'
+  as_of: '2026-04-06T00:00:00'
+  forecast_date: '2026-04-13T00:00:00'
+  payload:
+    point_forecast: 108.0
+    quantiles:
+      '0.05': 98.0
+      '0.1': 101.0
+      '0.2': 103.5
+      '0.3': 105.5
+      '0.4': 106.5
+      '0.5': 108.0
+      '0.6': 109.5
+      '0.7': 111.0
+      '0.8': 113.5
+      '0.9': 116.0
+      '0.95': 119.0
+  metadata:
+    rationale: The WTI price forecast is heavily conditioned by the unprecedented
+      geopolitical supply shock in the Persian Gulf. The blockade of the Strait of
+      Hormuz has created a massive risk premium. While the U.S. and IEA are attempting
+      to mitigate this with massive SPR releases and coordinated international efforts,
+      demand destruction and persistent shipping uncertainty continue to drive volatility.
+      We expect the market to consolidate from the extreme highs seen on 2026-04-02
+      as SPR flows materialize, but volatility is likely to remain elevated, and downside
+      is limited by the ongoing supply disruption.
+    horizon_rationale: Prices are elevated due to the Strait of Hormuz blockade and
+      persistent geopolitical risk. A slight pullback is expected as the market reacts
+      to the coordinated SPR release and uncertainty, but the high risk premium keeps
+      the floor elevated.
+    langfuse_trace_id: 5172b966227effef450f9f9b739544c8
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/5172b966227effef450f9f9b739544c8
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:28.882466'
+  as_of: '2026-04-06T00:00:00'
+  forecast_date: '2026-04-20T00:00:00'
+  payload:
+    point_forecast: 105.0
+    quantiles:
+      '0.05': 92.0
+      '0.1': 96.0
+      '0.2': 99.0
+      '0.3': 101.5
+      '0.4': 103.0
+      '0.5': 105.0
+      '0.6': 107.0
+      '0.7': 109.5
+      '0.8': 112.0
+      '0.9': 115.0
+      '0.95': 118.0
+  metadata:
+    rationale: The WTI price forecast is heavily conditioned by the unprecedented
+      geopolitical supply shock in the Persian Gulf. The blockade of the Strait of
+      Hormuz has created a massive risk premium. While the U.S. and IEA are attempting
+      to mitigate this with massive SPR releases and coordinated international efforts,
+      demand destruction and persistent shipping uncertainty continue to drive volatility.
+      We expect the market to consolidate from the extreme highs seen on 2026-04-02
+      as SPR flows materialize, but volatility is likely to remain elevated, and downside
+      is limited by the ongoing supply disruption.
+    horizon_rationale: By 10 days, the impact of SPR releases and global demand destruction
+      (as consumers adapt to higher prices) will likely exert moderate downward pressure
+      on prices, although the fundamental supply constraint of the Strait closure
+      remains the dominant bullish factor.
+    langfuse_trace_id: 5172b966227effef450f9f9b739544c8
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/5172b966227effef450f9f9b739544c8
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:28.882466'
+  as_of: '2026-04-06T00:00:00'
+  forecast_date: '2026-05-05T00:00:00'
+  payload:
+    point_forecast: 100.0
+    quantiles:
+      '0.05': 85.0
+      '0.1': 90.0
+      '0.2': 94.0
+      '0.3': 96.5
+      '0.4': 98.5
+      '0.5': 100.0
+      '0.6': 102.0
+      '0.7': 104.5
+      '0.8': 107.5
+      '0.9': 111.0
+      '0.95': 115.0
+  metadata:
+    rationale: The WTI price forecast is heavily conditioned by the unprecedented
+      geopolitical supply shock in the Persian Gulf. The blockade of the Strait of
+      Hormuz has created a massive risk premium. While the U.S. and IEA are attempting
+      to mitigate this with massive SPR releases and coordinated international efforts,
+      demand destruction and persistent shipping uncertainty continue to drive volatility.
+      We expect the market to consolidate from the extreme highs seen on 2026-04-02
+      as SPR flows materialize, but volatility is likely to remain elevated, and downside
+      is limited by the ongoing supply disruption.
+    horizon_rationale: Over a one-month horizon, the market expectation of potential
+      diplomatic efforts or further strategic reserve interventions is reflected in
+      a lower median price. However, the width of the probability distribution remains
+      high, reflecting extreme uncertainty surrounding the duration of the Middle
+      East conflict and its impact on oil shipping routes.
+    langfuse_trace_id: 5172b966227effef450f9f9b739544c8
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/5172b966227effef450f9f9b739544c8
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:42.747744'
+  as_of: '2026-04-13T00:00:00'
+  forecast_date: '2026-04-20T00:00:00'
+  payload:
+    point_forecast: 98.5
+    quantiles:
+      '0.05': 90.0
+      '0.1': 92.5
+      '0.2': 95.0
+      '0.3': 96.5
+      '0.4': 97.5
+      '0.5': 98.5
+      '0.6': 99.5
+      '0.7': 101.0
+      '0.8': 103.0
+      '0.9': 106.0
+      '0.95': 109.0
+  metadata:
+    rationale: The forecast is driven by the severe physical supply disruption caused
+      by the closure of the Strait of Hormuz and the high probability of an intensified
+      naval blockade. OPEC+ policy remains symbolic due to the geography of the conflict.
+      The U.S. SPR releases are a key bearish counterforce, but current analysis suggests
+      they are insufficient to prevent upward price pressure in a scenario of prolonged
+      regional instability.
+    horizon_rationale: The market remains in a state of extreme tension due to the
+      closure of the Strait of Hormuz and the announcement of a potential U.S. naval
+      blockade. Short-term price action is highly sensitive to daily news on the conflict.
+      The point forecast reflects an expectation of continued volatility with an upward
+      bias as traders assess the implications of the imminent naval blockade and the
+      limited efficacy of SPR releases.
+    langfuse_trace_id: 83c5ea47abdd544fcface3faf26161f6
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/83c5ea47abdd544fcface3faf26161f6
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:42.747744'
+  as_of: '2026-04-13T00:00:00'
+  forecast_date: '2026-04-27T00:00:00'
+  payload:
+    point_forecast: 102.0
+    quantiles:
+      '0.05': 92.0
+      '0.1': 94.5
+      '0.2': 97.0
+      '0.3': 99.0
+      '0.4': 100.5
+      '0.5': 102.0
+      '0.6': 103.5
+      '0.7': 106.0
+      '0.8': 109.0
+      '0.9': 113.0
+      '0.95': 117.0
+  metadata:
+    rationale: The forecast is driven by the severe physical supply disruption caused
+      by the closure of the Strait of Hormuz and the high probability of an intensified
+      naval blockade. OPEC+ policy remains symbolic due to the geography of the conflict.
+      The U.S. SPR releases are a key bearish counterforce, but current analysis suggests
+      they are insufficient to prevent upward price pressure in a scenario of prolonged
+      regional instability.
+    horizon_rationale: Over a two-week horizon, the physical market is likely to remain
+      severely constrained as the rerouting of tankers around Africa continues to
+      lengthen transit times and constrain available supply. With the U.S. naval blockade
+      potentially initiating on April 13, the supply disruption risk is expected to
+      escalate, supporting prices despite SPR-driven mitigation efforts.
+    langfuse_trace_id: 83c5ea47abdd544fcface3faf26161f6
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/83c5ea47abdd544fcface3faf26161f6
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:42.747744'
+  as_of: '2026-04-13T00:00:00'
+  forecast_date: '2026-05-12T00:00:00'
+  payload:
+    point_forecast: 108.0
+    quantiles:
+      '0.05': 95.0
+      '0.1': 98.0
+      '0.2': 101.0
+      '0.3': 104.0
+      '0.4': 106.0
+      '0.5': 108.0
+      '0.6': 110.0
+      '0.7': 113.5
+      '0.8': 118.0
+      '0.9': 124.0
+      '0.95': 129.0
+  metadata:
+    rationale: The forecast is driven by the severe physical supply disruption caused
+      by the closure of the Strait of Hormuz and the high probability of an intensified
+      naval blockade. OPEC+ policy remains symbolic due to the geography of the conflict.
+      The U.S. SPR releases are a key bearish counterforce, but current analysis suggests
+      they are insufficient to prevent upward price pressure in a scenario of prolonged
+      regional instability.
+    horizon_rationale: By the 21-day horizon, the cumulative effect of the supply
+      shortfall will likely be more pronounced. Assuming the naval blockade and conflict
+      persist, physical market premiums are expected to expand significantly. While
+      SPR releases provide a safety valve, they are unlikely to fully offset the massive
+      loss of supply, leading to a higher median price expectation.
+    langfuse_trace_id: 83c5ea47abdd544fcface3faf26161f6
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/83c5ea47abdd544fcface3faf26161f6
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:55.431127'
+  as_of: '2026-04-20T00:00:00'
+  forecast_date: '2026-04-27T00:00:00'
+  payload:
+    point_forecast: 88.0
+    quantiles:
+      '0.05': 78.0
+      '0.1': 81.0
+      '0.2': 84.0
+      '0.3': 86.0
+      '0.4': 87.0
+      '0.5': 88.0
+      '0.6': 89.5
+      '0.7': 91.0
+      '0.8': 93.0
+      '0.9': 96.0
+      '0.95': 99.0
+  metadata:
+    rationale: The WTI forecast is driven by the structural supply crisis following
+      the effective closure of the Strait of Hormuz in February 2026. Global supply
+      has plummeted, and OPEC+ production increases are largely academic. Coordinated
+      SPR releases are mitigating the worst of the volatility but are insufficient
+      to offset the structural loss of Persian Gulf exports. Geopolitical risk remains
+      the primary driver, with high uncertainty regarding the duration of the conflict
+      and the security of maritime shipping.
+    horizon_rationale: Short-term prices remain highly sensitive to the effective
+      closure of the Strait of Hormuz. Despite the recent SPR releases, physical supply
+      constraints dominate the market. The horizon reflects persistent elevated risk
+      as shipping operators await security clarity.
+    langfuse_trace_id: fc14681744ece0be71a93e1afc5c5d33
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/fc14681744ece0be71a93e1afc5c5d33
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:55.431127'
+  as_of: '2026-04-20T00:00:00'
+  forecast_date: '2026-05-04T00:00:00'
+  payload:
+    point_forecast: 92.0
+    quantiles:
+      '0.05': 80.0
+      '0.1': 83.0
+      '0.2': 87.0
+      '0.3': 89.0
+      '0.4': 90.5
+      '0.5': 92.0
+      '0.6': 94.0
+      '0.7': 96.0
+      '0.8': 99.0
+      '0.9': 104.0
+      '0.95': 108.0
+  metadata:
+    rationale: The WTI forecast is driven by the structural supply crisis following
+      the effective closure of the Strait of Hormuz in February 2026. Global supply
+      has plummeted, and OPEC+ production increases are largely academic. Coordinated
+      SPR releases are mitigating the worst of the volatility but are insufficient
+      to offset the structural loss of Persian Gulf exports. Geopolitical risk remains
+      the primary driver, with high uncertainty regarding the duration of the conflict
+      and the security of maritime shipping.
+    horizon_rationale: Over 10 days, the depletion of global inventories and the failure
+      of diplomatic/military efforts to quickly reopen the Strait are expected to
+      exert further upward pressure on prices. Market volatility remains extreme.
+    langfuse_trace_id: fc14681744ece0be71a93e1afc5c5d33
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/fc14681744ece0be71a93e1afc5c5d33
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:56:55.431127'
+  as_of: '2026-04-20T00:00:00'
+  forecast_date: '2026-05-19T00:00:00'
+  payload:
+    point_forecast: 95.0
+    quantiles:
+      '0.05': 82.0
+      '0.1': 86.0
+      '0.2': 90.0
+      '0.3': 92.5
+      '0.4': 94.0
+      '0.5': 95.0
+      '0.6': 97.5
+      '0.7': 100.0
+      '0.8': 104.0
+      '0.9': 110.0
+      '0.95': 115.0
+  metadata:
+    rationale: The WTI forecast is driven by the structural supply crisis following
+      the effective closure of the Strait of Hormuz in February 2026. Global supply
+      has plummeted, and OPEC+ production increases are largely academic. Coordinated
+      SPR releases are mitigating the worst of the volatility but are insufficient
+      to offset the structural loss of Persian Gulf exports. Geopolitical risk remains
+      the primary driver, with high uncertainty regarding the duration of the conflict
+      and the security of maritime shipping.
+    horizon_rationale: In the 21-day horizon, the cumulative impact of the supply
+      shortfall, high freight costs due to rerouting around the Cape of Good Hope,
+      and the limited effectiveness of SPR releases will continue to sustain high
+      price levels, barring a major de-escalation in the conflict.
+    langfuse_trace_id: fc14681744ece0be71a93e1afc5c5d33
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/fc14681744ece0be71a93e1afc5c5d33
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:57:08.036075'
+  as_of: '2026-04-27T00:00:00'
+  forecast_date: '2026-05-04T00:00:00'
+  payload:
+    point_forecast: 93.5
+    quantiles:
+      '0.05': 85.0
+      '0.1': 87.5
+      '0.2': 89.5
+      '0.3': 91.0
+      '0.4': 92.5
+      '0.5': 93.5
+      '0.6': 94.5
+      '0.7': 96.0
+      '0.8': 98.0
+      '0.9': 100.5
+      '0.95': 103.0
+  metadata:
+    rationale: 'The forecast is grounded in the ongoing, unprecedented supply disruption
+      resulting from the closure of the Strait of Hormuz (effective late Feb 2026).
+      Strategic reserves (SPR) are being used for stabilization, but demand growth
+      is hampered by high prices and structural economic headwinds. The primary assumptions
+      include: (1) continued, albeit cautious, management by OPEC+; (2) ongoing SPR
+      release programs; (3) persistent geopolitical risk premiums as the Middle East
+      conflict remains unresolved; and (4) downward revisions in global demand growth.'
+    horizon_rationale: As of April 27, 2026, the oil market remains highly sensitive
+      to the geopolitical instability surrounding the Strait of Hormuz. While supply
+      release efforts (SPR and increased transits) are mitigating extreme volatility,
+      the 5-day horizon faces continued downward pressure from demand destruction
+      expectations and high inventory drawdowns. The point forecast reflects a slight
+      consolidation after recent volatility.
+    langfuse_trace_id: e2945cb921298343842483d1ab85b220
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e2945cb921298343842483d1ab85b220
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:57:08.036075'
+  as_of: '2026-04-27T00:00:00'
+  forecast_date: '2026-05-11T00:00:00'
+  payload:
+    point_forecast: 92.0
+    quantiles:
+      '0.05': 83.0
+      '0.1': 85.5
+      '0.2': 88.0
+      '0.3': 89.5
+      '0.4': 91.0
+      '0.5': 92.0
+      '0.6': 93.0
+      '0.7': 95.0
+      '0.8': 97.0
+      '0.9': 100.0
+      '0.95': 103.5
+  metadata:
+    rationale: 'The forecast is grounded in the ongoing, unprecedented supply disruption
+      resulting from the closure of the Strait of Hormuz (effective late Feb 2026).
+      Strategic reserves (SPR) are being used for stabilization, but demand growth
+      is hampered by high prices and structural economic headwinds. The primary assumptions
+      include: (1) continued, albeit cautious, management by OPEC+; (2) ongoing SPR
+      release programs; (3) persistent geopolitical risk premiums as the Middle East
+      conflict remains unresolved; and (4) downward revisions in global demand growth.'
+    horizon_rationale: Over 10 days, the market is likely to continue pricing in the
+      structural impact of the regional conflict. Despite OPEC+ flexibility, the prevailing
+      market view is one of caution regarding consumption, leading to a modest downward
+      bias in the central tendency as the initial shock-premium tapers slightly.
+    langfuse_trace_id: e2945cb921298343842483d1ab85b220
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e2945cb921298343842483d1ab85b220
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:57:08.036075'
+  as_of: '2026-04-27T00:00:00'
+  forecast_date: '2026-05-26T00:00:00'
+  payload:
+    point_forecast: 89.5
+    quantiles:
+      '0.05': 78.0
+      '0.1': 81.0
+      '0.2': 84.0
+      '0.3': 86.5
+      '0.4': 88.5
+      '0.5': 89.5
+      '0.6': 91.0
+      '0.7': 93.5
+      '0.8': 96.0
+      '0.9': 100.0
+      '0.95': 105.0
+  metadata:
+    rationale: 'The forecast is grounded in the ongoing, unprecedented supply disruption
+      resulting from the closure of the Strait of Hormuz (effective late Feb 2026).
+      Strategic reserves (SPR) are being used for stabilization, but demand growth
+      is hampered by high prices and structural economic headwinds. The primary assumptions
+      include: (1) continued, albeit cautious, management by OPEC+; (2) ongoing SPR
+      release programs; (3) persistent geopolitical risk premiums as the Middle East
+      conflict remains unresolved; and (4) downward revisions in global demand growth.'
+    horizon_rationale: By the 21-day horizon, the impact of coordinated SPR releases
+      and the potential for shifts in OPEC+ production quotas are expected to exert
+      further downward pressure on prices, assuming no major escalation in the Middle
+      East conflict. The wider quantile range at this horizon reflects the high degree
+      of uncertainty regarding geopolitical developments.
+    langfuse_trace_id: e2945cb921298343842483d1ab85b220
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e2945cb921298343842483d1ab85b220
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:57:20.711458'
+  as_of: '2026-05-04T00:00:00'
+  forecast_date: '2026-05-11T00:00:00'
+  payload:
+    point_forecast: 102.5
+    quantiles:
+      '0.05': 96.0
+      '0.1': 98.0
+      '0.2': 99.5
+      '0.3': 100.8
+      '0.4': 101.7
+      '0.5': 102.5
+      '0.6': 103.3
+      '0.7': 104.5
+      '0.8': 106.0
+      '0.9': 108.0
+      '0.95': 110.0
+  metadata:
+    rationale: The WTI forecast is driven by the severe geopolitical supply shock
+      in the Strait of Hormuz and the volatile response of the OPEC+ bloc. While strategic
+      reserve releases provide a check on runaway prices, the withdrawal of the UAE
+      from OPEC+ and the ongoing nature of the shipping disruptions create a sustained
+      upward price pressure and higher-than-normal volatility, reflected in the asymmetric,
+      positive-skewed probability distributions for all horizons.
+    horizon_rationale: Short-term volatility remains elevated due to the ongoing Strait
+      of Hormuz blockade and supply shock. While SPR releases mitigate extreme upside,
+      the market remains highly reactive to geopolitical headlines.
+    langfuse_trace_id: 6e67019fcd30b79a97b3f05ce22501dd
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/6e67019fcd30b79a97b3f05ce22501dd
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:57:20.711458'
+  as_of: '2026-05-04T00:00:00'
+  forecast_date: '2026-05-18T00:00:00'
+  payload:
+    point_forecast: 104.0
+    quantiles:
+      '0.05': 95.0
+      '0.1': 97.0
+      '0.2': 99.0
+      '0.3': 101.0
+      '0.4': 102.5
+      '0.5': 104.0
+      '0.6': 105.5
+      '0.7': 107.5
+      '0.8': 109.5
+      '0.9': 112.0
+      '0.95': 115.0
+  metadata:
+    rationale: The WTI forecast is driven by the severe geopolitical supply shock
+      in the Strait of Hormuz and the volatile response of the OPEC+ bloc. While strategic
+      reserve releases provide a check on runaway prices, the withdrawal of the UAE
+      from OPEC+ and the ongoing nature of the shipping disruptions create a sustained
+      upward price pressure and higher-than-normal volatility, reflected in the asymmetric,
+      positive-skewed probability distributions for all horizons.
+    horizon_rationale: Over 10 days, the risk of a persistent conflict increases.
+      OPEC+'s recent commitment to production adjustments provides a baseline floor,
+      but market uncertainty around the UAE's withdrawal and global supply chain impacts
+      keeps the upward skew.
+    langfuse_trace_id: 6e67019fcd30b79a97b3f05ce22501dd
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/6e67019fcd30b79a97b3f05ce22501dd
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:57:20.711458'
+  as_of: '2026-05-04T00:00:00'
+  forecast_date: '2026-06-02T00:00:00'
+  payload:
+    point_forecast: 106.5
+    quantiles:
+      '0.05': 92.0
+      '0.1': 95.0
+      '0.2': 98.5
+      '0.3': 102.0
+      '0.4': 104.5
+      '0.5': 106.5
+      '0.6': 109.0
+      '0.7': 112.0
+      '0.8': 116.0
+      '0.9': 120.0
+      '0.95': 125.0
+  metadata:
+    rationale: The WTI forecast is driven by the severe geopolitical supply shock
+      in the Strait of Hormuz and the volatile response of the OPEC+ bloc. While strategic
+      reserve releases provide a check on runaway prices, the withdrawal of the UAE
+      from OPEC+ and the ongoing nature of the shipping disruptions create a sustained
+      upward price pressure and higher-than-normal volatility, reflected in the asymmetric,
+      positive-skewed probability distributions for all horizons.
+    horizon_rationale: The 21-day horizon factors in the potential for prolonged disruption.
+      If the Strait of Hormuz remains restricted, supply shortages will likely intensify
+      despite managed OPEC+ outputs and SPR flows. The range widens significantly
+      to reflect deep geopolitical uncertainty.
+    langfuse_trace_id: 6e67019fcd30b79a97b3f05ce22501dd
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/6e67019fcd30b79a97b3f05ce22501dd
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:57:33.937056'
+  as_of: '2026-05-11T00:00:00'
+  forecast_date: '2026-05-18T00:00:00'
+  payload:
+    point_forecast: 98.5
+    quantiles:
+      '0.05': 91.0
+      '0.1': 93.5
+      '0.2': 95.5
+      '0.3': 96.8
+      '0.4': 97.7
+      '0.5': 98.5
+      '0.6': 99.5
+      '0.7': 101.5
+      '0.8': 104.0
+      '0.9': 107.5
+      '0.95': 110.0
+  metadata:
+    rationale: The forecast is predicated on the persistent, effective closure of
+      the Strait of Hormuz following the outbreak of US-Iran conflict. Global oil
+      production is severely curtailed, and while the US and IEA are aggressively
+      releasing SPR stocks, these volumes are insufficient to fully offset the physical
+      supply shock. The market remains in a high-volatility regime with a sustained
+      upward bias for as long as the maritime security environment in the Persian
+      Gulf remains compromised.
+    horizon_rationale: Short-term outlook driven by the ongoing closure of the Strait
+      of Hormuz and extreme geopolitical tension. Prices are expected to maintain
+      an upward bias in the next week as inventory drawdowns continue amidst severe
+      supply disruptions.
+    langfuse_trace_id: dc30a356d00f42c95b311ae66c1a5aca
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/dc30a356d00f42c95b311ae66c1a5aca
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:57:33.937056'
+  as_of: '2026-05-11T00:00:00'
+  forecast_date: '2026-06-09T00:00:00'
+  payload:
+    point_forecast: 105.0
+    quantiles:
+      '0.05': 95.0
+      '0.1': 97.5
+      '0.2': 100.5
+      '0.3': 102.5
+      '0.4': 104.0
+      '0.5': 105.0
+      '0.6': 107.0
+      '0.7': 110.0
+      '0.8': 114.0
+      '0.9': 119.0
+      '0.95': 123.0
+  metadata:
+    rationale: The forecast is predicated on the persistent, effective closure of
+      the Strait of Hormuz following the outbreak of US-Iran conflict. Global oil
+      production is severely curtailed, and while the US and IEA are aggressively
+      releasing SPR stocks, these volumes are insufficient to fully offset the physical
+      supply shock. The market remains in a high-volatility regime with a sustained
+      upward bias for as long as the maritime security environment in the Persian
+      Gulf remains compromised.
+    horizon_rationale: By the 21-day horizon, concerns over sustained inventory depletion
+      and the lack of a clear path to resuming normal shipping through the Strait
+      will likely push prices higher. Macroeconomic demand destruction is present,
+      but supply constraints at this magnitude remain the primary driver of the forward
+      curve.
+    langfuse_trace_id: dc30a356d00f42c95b311ae66c1a5aca
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/dc30a356d00f42c95b311ae66c1a5aca
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:57:48.052802'
+  as_of: '2026-05-18T00:00:00'
+  forecast_date: '2026-06-01T00:00:00'
+  payload:
+    point_forecast: 112.0
+    quantiles:
+      '0.05': 95.0
+      '0.1': 99.0
+      '0.2': 103.0
+      '0.3': 106.0
+      '0.4': 109.0
+      '0.5': 112.0
+      '0.6': 115.0
+      '0.7': 118.0
+      '0.8': 122.0
+      '0.9': 127.0
+      '0.95': 133.0
+  metadata:
+    rationale: The forecast is driven by a profound and ongoing supply shock. The
+      closure of the Strait of Hormuz has created an unprecedented deficit in global
+      oil transit. While the US is aggressively drawing down the SPR, inventories
+      are reaching critically low levels, offering only a temporary buffer. Market
+      participants are in a state of high alert for any escalations or potential de-escalations.
+      The price distribution is heavily skewed to the upside due to the physical 'hard
+      constraint' on supply, with the 0.05 quantile representing a scenario where
+      a breakthrough in diplomatic or military control occurs, and the 0.95 quantile
+      reflecting a total failure of alternative supply routes and further escalation.
+    horizon_rationale: By the 10-day horizon, the cumulative impact of reduced refining
+      throughput and the failure of SPR releases to stabilize physical markets likely
+      pushes prices higher. The extreme sensitivity to the Strait of Hormuz status
+      means any news of a diplomatic breakthrough would lead to a sharp downside,
+      but the baseline case remains constrained supply.
+    langfuse_trace_id: 7522eac570852c6b6f41d977bfa2ad54
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/7522eac570852c6b6f41d977bfa2ad54
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:57:48.052802'
+  as_of: '2026-05-18T00:00:00'
+  forecast_date: '2026-06-16T00:00:00'
+  payload:
+    point_forecast: 118.0
+    quantiles:
+      '0.05': 90.0
+      '0.1': 96.0
+      '0.2': 102.0
+      '0.3': 107.0
+      '0.4': 112.0
+      '0.5': 118.0
+      '0.6': 124.0
+      '0.7': 130.0
+      '0.8': 138.0
+      '0.9': 146.0
+      '0.95': 155.0
+  metadata:
+    rationale: The forecast is driven by a profound and ongoing supply shock. The
+      closure of the Strait of Hormuz has created an unprecedented deficit in global
+      oil transit. While the US is aggressively drawing down the SPR, inventories
+      are reaching critically low levels, offering only a temporary buffer. Market
+      participants are in a state of high alert for any escalations or potential de-escalations.
+      The price distribution is heavily skewed to the upside due to the physical 'hard
+      constraint' on supply, with the 0.05 quantile representing a scenario where
+      a breakthrough in diplomatic or military control occurs, and the 0.95 quantile
+      reflecting a total failure of alternative supply routes and further escalation.
+    horizon_rationale: Over 21 days, the depletion of global stocks and the potential
+      for structural damage to energy infrastructure in the conflict zone increase
+      the upside risk. With demand-side destruction being the primary cooling factor,
+      but supply constraints remaining binding, we expect a higher volatility regime
+      with a skew toward higher prices unless the maritime blockade is lifted.
+    langfuse_trace_id: 7522eac570852c6b6f41d977bfa2ad54
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/7522eac570852c6b6f41d977bfa2ad54
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:58:01.562898'
+  as_of: '2026-05-25T00:00:00'
+  forecast_date: '2026-06-01T00:00:00'
+  payload:
+    point_forecast: 98.5
+    quantiles:
+      '0.05': 93.0
+      '0.1': 94.5
+      '0.2': 96.0
+      '0.3': 97.2
+      '0.4': 97.9
+      '0.5': 98.5
+      '0.6': 99.2
+      '0.7': 100.5
+      '0.8': 102.0
+      '0.9': 104.5
+      '0.95': 106.5
+  metadata:
+    rationale: 'The forecast is predicated on the ongoing crisis in the Persian Gulf,
+      specifically the closure of the Strait of Hormuz. Key assumptions include: 1)
+      Geopolitical risk remains the dominant factor, with the market maintaining a
+      high war premium; 2) U.S. SPR levels are critically low, reducing the efficacy
+      of further releases; 3) OPEC+ remains cautious, failing to fully offset the
+      massive supply deficit; 4) global demand destruction from high prices is partially
+      offsetting the supply shortfall, but the physical constraint remains the primary
+      upward driver.'
+    horizon_rationale: The short-term outlook is dominated by the severe supply disruption
+      resulting from the closure of the Strait of Hormuz. With the market already
+      pricing in an extreme risk premium and the U.S. SPR at critically low levels,
+      upside volatility is likely over the next 5 days as refiners scramble for alternative
+      supply. The point forecast reflects a moderate upward trend due to these continued
+      physical constraints.
+    langfuse_trace_id: bf44225916aacf5f7449cce938691af1
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/bf44225916aacf5f7449cce938691af1
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:58:01.562898'
+  as_of: '2026-05-25T00:00:00'
+  forecast_date: '2026-06-08T00:00:00'
+  payload:
+    point_forecast: 101.0
+    quantiles:
+      '0.05': 91.0
+      '0.1': 93.5
+      '0.2': 96.5
+      '0.3': 98.8
+      '0.4': 100.0
+      '0.5': 101.0
+      '0.6': 102.5
+      '0.7': 104.5
+      '0.8': 107.0
+      '0.9': 110.0
+      '0.95': 113.0
+  metadata:
+    rationale: 'The forecast is predicated on the ongoing crisis in the Persian Gulf,
+      specifically the closure of the Strait of Hormuz. Key assumptions include: 1)
+      Geopolitical risk remains the dominant factor, with the market maintaining a
+      high war premium; 2) U.S. SPR levels are critically low, reducing the efficacy
+      of further releases; 3) OPEC+ remains cautious, failing to fully offset the
+      massive supply deficit; 4) global demand destruction from high prices is partially
+      offsetting the supply shortfall, but the physical constraint remains the primary
+      upward driver.'
+    horizon_rationale: Over 10 days, the potential for further military escalation
+      in the Gulf or a complete exhaustion of alternative, non-Hormuz logistics remains
+      high. The market environment remains structurally tight, and despite demand-side
+      contractions, supply-side scarcity is the primary price driver. The wider quantile
+      range accounts for increased uncertainty regarding the duration of the conflict.
+    langfuse_trace_id: bf44225916aacf5f7449cce938691af1
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/bf44225916aacf5f7449cce938691af1
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:58:01.562898'
+  as_of: '2026-05-25T00:00:00'
+  forecast_date: '2026-06-23T00:00:00'
+  payload:
+    point_forecast: 105.0
+    quantiles:
+      '0.05': 85.0
+      '0.1': 89.0
+      '0.2': 94.0
+      '0.3': 98.5
+      '0.4': 102.0
+      '0.5': 105.0
+      '0.6': 108.5
+      '0.7': 112.0
+      '0.8': 116.0
+      '0.9': 121.0
+      '0.95': 125.0
+  metadata:
+    rationale: 'The forecast is predicated on the ongoing crisis in the Persian Gulf,
+      specifically the closure of the Strait of Hormuz. Key assumptions include: 1)
+      Geopolitical risk remains the dominant factor, with the market maintaining a
+      high war premium; 2) U.S. SPR levels are critically low, reducing the efficacy
+      of further releases; 3) OPEC+ remains cautious, failing to fully offset the
+      massive supply deficit; 4) global demand destruction from high prices is partially
+      offsetting the supply shortfall, but the physical constraint remains the primary
+      upward driver.'
+    horizon_rationale: By 21 days, the cumulative effect of the supply shock on global
+      inventories will be more pronounced. The possibility of prolonged disruption
+      or an expansion of the conflict creates a significant right-skew in the distribution.
+      While demand destruction provides a dampening effect, the persistent geopolitical
+      risk is expected to maintain elevated price levels.
+    langfuse_trace_id: bf44225916aacf5f7449cce938691af1
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/bf44225916aacf5f7449cce938691af1
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:58:13.924749'
+  as_of: '2026-06-01T00:00:00'
+  forecast_date: '2026-06-08T00:00:00'
+  payload:
+    point_forecast: 86.5
+    quantiles:
+      '0.05': 82.0
+      '0.1': 83.5
+      '0.2': 85.0
+      '0.3': 85.8
+      '0.4': 86.2
+      '0.5': 86.5
+      '0.6': 86.8
+      '0.7': 87.5
+      '0.8': 88.5
+      '0.9': 90.0
+      '0.95': 91.5
+  metadata:
+    rationale: The outlook as of June 1, 2026, is dominated by the unwinding of the
+      geopolitical risk premium following the Strait of Hormuz conflict. Significant
+      U.S. SPR releases (reducing inventories to historic lows) have mitigated immediate
+      shortages, and the market is now reacting to weaker-than-expected global demand.
+      Forecasts reflect a downward trend as the market moves away from crisis pricing,
+      though significant uncertainties regarding the speed of shipping normalization
+      and OPEC+ policy remain.
+    horizon_rationale: Short-term horizon (5 days) reflects immediate post-conflict
+      market adjustment. As geopolitical tensions over the Strait of Hormuz show signs
+      of easing, price discovery is shifting toward fundamentals. Prices are expected
+      to remain volatile but show a slight downward bias as the war risk premium continues
+      to be unwound.
+    langfuse_trace_id: 0f82f9e2177c861153ba47950531a8cb
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/0f82f9e2177c861153ba47950531a8cb
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:58:13.924749'
+  as_of: '2026-06-01T00:00:00'
+  forecast_date: '2026-06-15T00:00:00'
+  payload:
+    point_forecast: 85.0
+    quantiles:
+      '0.05': 79.0
+      '0.1': 81.0
+      '0.2': 83.0
+      '0.3': 84.0
+      '0.4': 84.5
+      '0.5': 85.0
+      '0.6': 85.8
+      '0.7': 86.5
+      '0.8': 87.8
+      '0.9': 89.5
+      '0.95': 91.0
+  metadata:
+    rationale: The outlook as of June 1, 2026, is dominated by the unwinding of the
+      geopolitical risk premium following the Strait of Hormuz conflict. Significant
+      U.S. SPR releases (reducing inventories to historic lows) have mitigated immediate
+      shortages, and the market is now reacting to weaker-than-expected global demand.
+      Forecasts reflect a downward trend as the market moves away from crisis pricing,
+      though significant uncertainties regarding the speed of shipping normalization
+      and OPEC+ policy remain.
+    horizon_rationale: At the 10-day horizon, the market continues to price in the
+      potential for normalized shipping through the Persian Gulf. With U.S. SPR releases
+      providing significant supply buffers, we expect a gradual normalization of the
+      price toward pre-crisis fundamental levels, though demand concerns persist.
+    langfuse_trace_id: 0f82f9e2177c861153ba47950531a8cb
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/0f82f9e2177c861153ba47950531a8cb
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.1-flash-lite-preview_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T10:58:13.924749'
+  as_of: '2026-06-01T00:00:00'
+  forecast_date: '2026-06-30T00:00:00'
+  payload:
+    point_forecast: 82.5
+    quantiles:
+      '0.05': 75.0
+      '0.1': 77.5
+      '0.2': 79.5
+      '0.3': 81.0
+      '0.4': 81.8
+      '0.5': 82.5
+      '0.6': 83.5
+      '0.7': 84.5
+      '0.8': 86.0
+      '0.9': 88.0
+      '0.95': 90.0
+  metadata:
+    rationale: The outlook as of June 1, 2026, is dominated by the unwinding of the
+      geopolitical risk premium following the Strait of Hormuz conflict. Significant
+      U.S. SPR releases (reducing inventories to historic lows) have mitigated immediate
+      shortages, and the market is now reacting to weaker-than-expected global demand.
+      Forecasts reflect a downward trend as the market moves away from crisis pricing,
+      though significant uncertainties regarding the speed of shipping normalization
+      and OPEC+ policy remain.
+    horizon_rationale: For the 21-day horizon, the primary driver is the transition
+      from geopolitical shock to fundamental supply/demand weakness. With downgraded
+      global demand forecasts and the potential for a return to shipping, the market
+      is likely to see further downward pressure, moderated only by OPEC+ potential
+      output management.
+    langfuse_trace_id: 0f82f9e2177c861153ba47950531a8cb
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/0f82f9e2177c861153ba47950531a8cb
+scores:
+- 0.8981814297762767
+- 6.9533859883458184
+- 1.0473547060627584
+- 14.771484551547974
+- 2.537270285866479
+- 6.7556231916443386
+- 30.817437101001584
+- 3.396945505693924
+- 26.105533833149053
+- 23.78636211048473
+- 8.798922262901119
+- 3.0041322314049586
+- 3.8350405732462227
+- 6.880165289256197
+- 15.349341589557236
+- 4.773967774446343
+- 6.3303333250944265
+- 6.019666674905574
+- 1.8601651782831863
+- 1.678015779857793
+- 6.008845305639852
+- 7.954464557742283
+- 6.517275723544036
+- 3.8024785065453885
+- 5.759090770374643
+- 5.979998501864346
+- 11.282561373119513
+- 2.305040406786705
+- 6.303222530144305
+- 3.644708995976723
+- 4.029751927399437
+- 5.058927867038193
+- 9.16594891508749
+- 7.266857367901764
+- 9.725783292912258
+- 3.59413203720219
+- 2.7764460035592067
+- 2.7843803594920247
+- 2.779340507570377
+- 8.225287508373416
+- 6.210250930155606
+- 14.142978258369382
+- 14.046607908138558
+- 32.346691163118216
+- 4.707764932931948
+- 6.71322064360311
+- 24.81479430395709
+- 3.2181843150745753
+- 2.863223140495867
+- 10.763636363636362
+metric: crps
+mean_score: 8.207824476005618
+ran_at: '2026-07-02T10:58:14.187675'
+skipped_origins: 0

--- a/implementations/energy_oil_forecasting/data/predictions/energy_oil_eval/agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous__wti_oil_price_forecast.yaml
+++ b/implementations/energy_oil_forecasting/data/predictions/energy_oil_eval/agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous__wti_oil_price_forecast.yaml
@@ -1,0 +1,1987 @@
+spec:
+  task:
+    task_id: wti_oil_price_forecast
+    target_series_id: wti_crude_oil_price
+    horizons:
+    - 5
+    - 10
+    - 21
+    frequency: B
+    description: 'WTI Crude Oil continuous front-month futures Close price (yfinance
+      symbol: CL=F), projected 5, 10, and 21 trading days ahead.'
+    payload_type: continuous
+    categories: null
+    resolution_fn: observed_value_at_resolution_timestamp
+  start: '2026-02-02T00:00:00'
+  end: '2026-06-01T00:00:00'
+  stride: 5
+  origin_dates: null
+  warmup: 250
+  description: Prospective/out-of-sample evaluation period in 2026 for daily WTI crude
+    oil. Evaluates selected contender models on 18 weekly origins from the early 2026
+    geopolitical price shock through its aftermath, to measure adaptive real-time
+    forecasting performance.
+predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+predictions:
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:00:15.566132'
+  as_of: '2026-02-02T00:00:00'
+  forecast_date: '2026-02-09T00:00:00'
+  payload:
+    point_forecast: 61.8
+    quantiles:
+      '0.05': 57.2
+      '0.1': 58.2
+      '0.2': 59.5
+      '0.3': 60.4
+      '0.4': 61.1
+      '0.5': 61.8
+      '0.6': 62.5
+      '0.7': 63.3
+      '0.8': 64.3
+      '0.9': 65.8
+      '0.95': 67.2
+  metadata:
+    rationale: As of February 2, 2026, the crude oil market balances supportive geopolitical
+      risk premiums with structural bearishness from projected 2026 global surpluses.
+      While OPEC+ (eight members) has paused production increases through Q1 2026
+      and the US has utilized its SPR (reported around 415 million barrels) to mitigate
+      shocks, the market is in a corrective phase following late January's geopolitically-driven
+      price spike. On February 2, WTI retreated sharply by $3.07 to settle at $62.14,
+      which anchors our short-to-medium-term projections as we anticipate a continued,
+      gradual drift towards $60.00.
+    horizon_rationale: Over a 5-business-day horizon, WTI is entering a corrective
+      phase. Following a sharp run-up to $65.21 in late January due to escalating
+      US-Iran geopolitical friction and fears over Strait of Hormuz safety, prices
+      fell significantly to settle at $62.14 on Feb 2, 2026. The point forecast of
+      $61.80 reflects a slight continued downward drift within a short-term trading
+      channel, where near-term support is identified at $61.50 and resistance is near
+      $64.30.
+    langfuse_trace_id: bd47122c5ed56122982765c879878e09
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/bd47122c5ed56122982765c879878e09
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:00:15.566132'
+  as_of: '2026-02-02T00:00:00'
+  forecast_date: '2026-03-03T00:00:00'
+  payload:
+    point_forecast: 60.0
+    quantiles:
+      '0.05': 51.5
+      '0.1': 53.0
+      '0.2': 55.2
+      '0.3': 57.0
+      '0.4': 58.5
+      '0.5': 60.0
+      '0.6': 61.6
+      '0.7': 63.5
+      '0.8': 65.8
+      '0.9': 69.2
+      '0.95': 72.0
+  metadata:
+    rationale: As of February 2, 2026, the crude oil market balances supportive geopolitical
+      risk premiums with structural bearishness from projected 2026 global surpluses.
+      While OPEC+ (eight members) has paused production increases through Q1 2026
+      and the US has utilized its SPR (reported around 415 million barrels) to mitigate
+      shocks, the market is in a corrective phase following late January's geopolitically-driven
+      price spike. On February 2, WTI retreated sharply by $3.07 to settle at $62.14,
+      which anchors our short-to-medium-term projections as we anticipate a continued,
+      gradual drift towards $60.00.
+    horizon_rationale: Over a 21-business-day horizon, the baseline projection moves
+      closer to the broader 2026 surplus trend, pulling the point forecast to $60.00.
+      High-dispersion tails reflect both the bearish threat of a structural global
+      surplus override (downside to $51.50) and sudden right-tail escalatory risk
+      in key shipping lanes (upside to $72.00).
+    langfuse_trace_id: bd47122c5ed56122982765c879878e09
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/bd47122c5ed56122982765c879878e09
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:01:24.417956'
+  as_of: '2026-02-09T00:00:00'
+  forecast_date: '2026-02-23T00:00:00'
+  payload:
+    point_forecast: 63.25
+    quantiles:
+      '0.05': 57.0
+      '0.1': 58.4
+      '0.2': 60.05
+      '0.3': 61.25
+      '0.4': 62.3
+      '0.5': 63.25
+      '0.6': 64.3
+      '0.7': 65.55
+      '0.8': 67.2
+      '0.9': 69.9
+      '0.95': 72.65
+  metadata:
+    rationale: "As of February 9, 2026, WTI crude oil is trading near $63.55, supported\
+      \ by a significant geopolitical risk premium ($4\u2013$10/bbl) stemming from\
+      \ U.S.\u2013Iran tensions and potential shipping disruptions in the Strait of\
+      \ Hormuz. OPEC+ has paused voluntary production increases through March 2026,\
+      \ maintaining near-term supply tightness despite soft underlying global demand\
+      \ and rising non-OPEC+ production. Over the 5, 10, and 21 business day horizons,\
+      \ we expect the price to exhibit high volatility, with a slight downward drift\
+      \ in the median forecast as some risk premium is anticipated to deflate. However,\
+      \ the probability distribution is heavily skewed to the upside, reflecting the\
+      \ asymmetric risk of a major supply disruption in key Persian Gulf shipping\
+      \ lanes."
+    horizon_rationale: "At the 10-day horizon, the persistent geopolitical 'wild card'\
+      \ continues to dominate, while OPEC+'s production pause through March provides\
+      \ a solid floor. The median forecast is slightly lower at $63.25, reflecting\
+      \ a slow decay of the geopolitical premium in the absence of direct conflict.\
+      \ Increased uncertainty broadens the 90% confidence interval to $57.00\u2013\
+      $72.65, with upside risks significantly more pronounced."
+    langfuse_trace_id: f93e2686ff62d2bd299a6eaa159a9606
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/f93e2686ff62d2bd299a6eaa159a9606
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:01:24.417956'
+  as_of: '2026-02-09T00:00:00'
+  forecast_date: '2026-03-10T00:00:00'
+  payload:
+    point_forecast: 63.0
+    quantiles:
+      '0.05': 54.45
+      '0.1': 56.35
+      '0.2': 58.6
+      '0.3': 60.3
+      '0.4': 61.7
+      '0.5': 63.0
+      '0.6': 64.5
+      '0.7': 66.35
+      '0.8': 68.8
+      '0.9': 72.85
+      '0.95': 77.0
+  metadata:
+    rationale: "As of February 9, 2026, WTI crude oil is trading near $63.55, supported\
+      \ by a significant geopolitical risk premium ($4\u2013$10/bbl) stemming from\
+      \ U.S.\u2013Iran tensions and potential shipping disruptions in the Strait of\
+      \ Hormuz. OPEC+ has paused voluntary production increases through March 2026,\
+      \ maintaining near-term supply tightness despite soft underlying global demand\
+      \ and rising non-OPEC+ production. Over the 5, 10, and 21 business day horizons,\
+      \ we expect the price to exhibit high volatility, with a slight downward drift\
+      \ in the median forecast as some risk premium is anticipated to deflate. However,\
+      \ the probability distribution is heavily skewed to the upside, reflecting the\
+      \ asymmetric risk of a major supply disruption in key Persian Gulf shipping\
+      \ lanes."
+    horizon_rationale: Over a 21-day horizon (approximately one month), underlying
+      supply/demand fundamentals (ample non-OPEC+ supply and seasonal demand weakness)
+      will begin to assert more influence, pulling the median forecast down to $63.00.
+      However, the potential for severe escalation or transit disruptions in the Strait
+      of Hormuz keeps the right tail highly elongated, with the 0.95 quantile reaching
+      $77.00, while a peaceful resolution combined with oversupply concerns could
+      drop prices to $54.45 (0.05 quantile).
+    langfuse_trace_id: f93e2686ff62d2bd299a6eaa159a9606
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/f93e2686ff62d2bd299a6eaa159a9606
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:02:21.243515'
+  as_of: '2026-02-16T00:00:00'
+  forecast_date: '2026-02-23T00:00:00'
+  payload:
+    point_forecast: 63.2
+    quantiles:
+      '0.05': 59.0
+      '0.1': 60.0
+      '0.2': 61.2
+      '0.3': 62.0
+      '0.4': 62.6
+      '0.5': 63.2
+      '0.6': 63.8
+      '0.7': 64.5
+      '0.8': 65.3
+      '0.9': 66.5
+      '0.95': 67.5
+  metadata:
+    rationale: This oil price forecast models WTI crude futures over 5, 10, and 21
+      business days. The short-term price path is dominated by Middle Eastern geopolitical
+      risk (specifically Strait of Hormuz transit concerns) and OPEC+'s extension
+      of supply cuts through March 2026. However, bearish structural demand fundamentals
+      and strong non-OPEC+ supply growth throughout 2026 act as a powerful anchor,
+      preventing sustained breakout rallies and keeping the point forecasts centered
+      between $63.20 and $63.80.
+    horizon_rationale: In the near term (5 business days), WTI is expected to remain
+      supported by heightened geopolitical risk in the Middle East, particularly around
+      U.S.-Iran tensions and warning advisories in the Strait of Hormuz. OPEC+ has
+      reaffirmed its decision to keep its voluntary production cuts in place through
+      March 2026, maintaining tight physical supplies. However, broader macroeconomic
+      headwinds and soft demand forecasts from the IEA limit significant upside, keeping
+      the point forecast near $63.20. Volatility remains elevated due to potential
+      quick changes in tension levels.
+    langfuse_trace_id: 2438bf9fc260e46829e9dbe17b49d5e8
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2438bf9fc260e46829e9dbe17b49d5e8
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:02:21.243515'
+  as_of: '2026-02-16T00:00:00'
+  forecast_date: '2026-03-02T00:00:00'
+  payload:
+    point_forecast: 63.5
+    quantiles:
+      '0.05': 57.5
+      '0.1': 59.0
+      '0.2': 60.8
+      '0.3': 61.8
+      '0.4': 62.7
+      '0.5': 63.5
+      '0.6': 64.3
+      '0.7': 65.2
+      '0.8': 66.4
+      '0.9': 68.0
+      '0.95': 69.3
+  metadata:
+    rationale: This oil price forecast models WTI crude futures over 5, 10, and 21
+      business days. The short-term price path is dominated by Middle Eastern geopolitical
+      risk (specifically Strait of Hormuz transit concerns) and OPEC+'s extension
+      of supply cuts through March 2026. However, bearish structural demand fundamentals
+      and strong non-OPEC+ supply growth throughout 2026 act as a powerful anchor,
+      preventing sustained breakout rallies and keeping the point forecasts centered
+      between $63.20 and $63.80.
+    horizon_rationale: Over a 10-business-day horizon (into early March), the physical
+      oil market continues to be buffered by OPEC+ production pauses and seasonal
+      winter constraints. Geopolitical risk premiums are highly priced in, with potential
+      spikes if any shipping lane incidents occur. U.S. Strategic Petroleum Reserve
+      (SPR) policy has maintained steady inventory levels, which avoids any immediate
+      domestic supply shock. The point forecast is set at $63.50, with widened tails
+      representing both the downside risk of de-escalation and the upside risk of
+      shipping disruptions.
+    langfuse_trace_id: 2438bf9fc260e46829e9dbe17b49d5e8
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2438bf9fc260e46829e9dbe17b49d5e8
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:02:21.243515'
+  as_of: '2026-02-16T00:00:00'
+  forecast_date: '2026-03-17T00:00:00'
+  payload:
+    point_forecast: 63.8
+    quantiles:
+      '0.05': 55.5
+      '0.1': 57.5
+      '0.2': 59.8
+      '0.3': 61.2
+      '0.4': 62.5
+      '0.5': 63.8
+      '0.6': 65.1
+      '0.7': 66.5
+      '0.8': 68.2
+      '0.9': 70.5
+      '0.95': 72.0
+  metadata:
+    rationale: This oil price forecast models WTI crude futures over 5, 10, and 21
+      business days. The short-term price path is dominated by Middle Eastern geopolitical
+      risk (specifically Strait of Hormuz transit concerns) and OPEC+'s extension
+      of supply cuts through March 2026. However, bearish structural demand fundamentals
+      and strong non-OPEC+ supply growth throughout 2026 act as a powerful anchor,
+      preventing sustained breakout rallies and keeping the point forecasts centered
+      between $63.20 and $63.80.
+    horizon_rationale: At the 21-business-day horizon (mid-March), the focus will
+      shift toward OPEC+'s potential unwinding or extension of voluntary production
+      cuts post-March. Non-OPEC+ supply (e.g., Brazil, Canada, US) continues to expand,
+      keeping the medium-term outlook in potential surplus, which is heavily monitored
+      by analysts forecasting a surplus for 2026. The point forecast is estimated
+      at $63.80, keeping prices close to the upper end of the recent range but capping
+      the extreme upside (with the 0.95 quantile at $72.00) due to projected market
+      balances, while a major ease in geopolitical risk could drag prices back toward
+      the 52-week low near $55.27.
+    langfuse_trace_id: 2438bf9fc260e46829e9dbe17b49d5e8
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2438bf9fc260e46829e9dbe17b49d5e8
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:03:24.157826'
+  as_of: '2026-02-23T00:00:00'
+  forecast_date: '2026-03-02T00:00:00'
+  payload:
+    point_forecast: 66.5
+    quantiles:
+      '0.05': 61.5
+      '0.1': 62.8
+      '0.2': 64.2
+      '0.3': 65.1
+      '0.4': 65.8
+      '0.5': 66.5
+      '0.6': 67.2
+      '0.7': 68.0
+      '0.8': 69.0
+      '0.9': 70.5
+      '0.95': 71.8
+  metadata:
+    rationale: 'Overall, the forecasts represent a market currently driven by a delicate
+      balance: near-term geopolitical risk premium in the Persian Gulf is supporting
+      WTI prices near $66.39, while longer-term demand uncertainties and projected
+      oversupply by the EIA and IEA limit sustained gains. OPEC+ policy maintaining
+      a production pause through March 2026 acts as a strong buffer, but the market''s
+      high sensitivity to potential shipping disruptions in the Strait of Hormuz creates
+      upside tail risk.'
+    horizon_rationale: Over the next 5 business days, WTI crude is expected to trade
+      within a relatively tight range centered near $66.50. The market continues to
+      balance the immediate geopolitical risk premium stemming from US-Iran tensions
+      in the Persian Gulf against a broader outlook of comfortable supply. OPEC+ maintains
+      its pause on production increases through March, which provides short-term price
+      support.
+    langfuse_trace_id: 0c497154e723750de7a4cff60080b383
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/0c497154e723750de7a4cff60080b383
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:03:24.157826'
+  as_of: '2026-02-23T00:00:00'
+  forecast_date: '2026-03-09T00:00:00'
+  payload:
+    point_forecast: 66.8
+    quantiles:
+      '0.05': 59.8
+      '0.1': 61.5
+      '0.2': 63.5
+      '0.3': 64.8
+      '0.4': 65.8
+      '0.5': 66.8
+      '0.6': 67.8
+      '0.7': 68.9
+      '0.8': 70.2
+      '0.9': 72.2
+      '0.95': 74.0
+  metadata:
+    rationale: 'Overall, the forecasts represent a market currently driven by a delicate
+      balance: near-term geopolitical risk premium in the Persian Gulf is supporting
+      WTI prices near $66.39, while longer-term demand uncertainties and projected
+      oversupply by the EIA and IEA limit sustained gains. OPEC+ policy maintaining
+      a production pause through March 2026 acts as a strong buffer, but the market''s
+      high sensitivity to potential shipping disruptions in the Strait of Hormuz creates
+      upside tail risk.'
+    horizon_rationale: At the 10-business-day horizon, uncertainty widens. The market
+      will continue to digest geopolitical updates regarding naval activity and the
+      security of the Strait of Hormuz. While any actual disruption could cause prices
+      to spike towards the $74 level, the lack of immediate physical blockages and
+      the IEA/EIA projections of weak demand growth could see WTI drift back down
+      to the low $60s if tensions ease.
+    langfuse_trace_id: 0c497154e723750de7a4cff60080b383
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/0c497154e723750de7a4cff60080b383
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:03:24.157826'
+  as_of: '2026-02-23T00:00:00'
+  forecast_date: '2026-03-24T00:00:00'
+  payload:
+    point_forecast: 67.0
+    quantiles:
+      '0.05': 57.5
+      '0.1': 59.5
+      '0.2': 62.0
+      '0.3': 64.0
+      '0.4': 65.5
+      '0.5': 67.0
+      '0.6': 68.5
+      '0.7': 70.2
+      '0.8': 72.5
+      '0.9': 75.5
+      '0.95': 78.0
+  metadata:
+    rationale: 'Overall, the forecasts represent a market currently driven by a delicate
+      balance: near-term geopolitical risk premium in the Persian Gulf is supporting
+      WTI prices near $66.39, while longer-term demand uncertainties and projected
+      oversupply by the EIA and IEA limit sustained gains. OPEC+ policy maintaining
+      a production pause through March 2026 acts as a strong buffer, but the market''s
+      high sensitivity to potential shipping disruptions in the Strait of Hormuz creates
+      upside tail risk.'
+    horizon_rationale: Looking 21 business days ahead into late March 2026, the key
+      drivers will be the potential for Q2 supply adjustments by OPEC+ and the evolution
+      of the Middle East geopolitical premium. The distribution is widened significantly
+      to capture both a return to fundamental-driven prices in the high $50s/low $60s
+      (if tensions dissipate and supply builds occur) and the tail-risk of a spike
+      to $75-$78 if naval frictions lead to shipping disruptions.
+    langfuse_trace_id: 0c497154e723750de7a4cff60080b383
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/0c497154e723750de7a4cff60080b383
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:05:18.395117'
+  as_of: '2026-03-02T00:00:00'
+  forecast_date: '2026-03-09T00:00:00'
+  payload:
+    point_forecast: 75.5
+    quantiles:
+      '0.05': 66.5
+      '0.1': 68.5
+      '0.2': 71.0
+      '0.3': 73.0
+      '0.4': 74.5
+      '0.5': 75.5
+      '0.6': 77.0
+      '0.7': 79.5
+      '0.8': 82.5
+      '0.9': 86.5
+      '0.95': 90.0
+  metadata:
+    rationale: Our forecasts combine the immediate geopolitical shock in the Strait
+      of Hormuz with fundamental constraints. While a massive war premium has driven
+      WTI prices into the mid-to-high $70s in the spot market, the medium-term price
+      path is capped by massive U.S. and IEA SPR intervention alongside deteriorating
+      macroeconomic demand, creating a highly volatile and wide distribution of possible
+      outcomes.
+    horizon_rationale: As of March 2, 2026, WTI oil prices have surged sharply from
+      the Friday close of $67.02 to the $73-$78 range following a dramatic military
+      conflict between the US, Israel, and Iran on Feb 28, 2026, which threatens the
+      Strait of Hormuz (representing ~20% of global seaborne trade). The short-term
+      horizon reflects this elevated risk premium, but with significant volatility
+      as the market digests potential escalation against planned emergency SPR releases
+      and OPEC+'s extension of supply cuts.
+    langfuse_trace_id: e91937d682c4a7dc2ae5089359cf1e63
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e91937d682c4a7dc2ae5089359cf1e63
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:05:18.395117'
+  as_of: '2026-03-02T00:00:00'
+  forecast_date: '2026-03-16T00:00:00'
+  payload:
+    point_forecast: 74.5
+    quantiles:
+      '0.05': 62.5
+      '0.1': 65.5
+      '0.2': 69.0
+      '0.3': 71.0
+      '0.4': 73.0
+      '0.5': 74.5
+      '0.6': 76.5
+      '0.7': 79.5
+      '0.8': 83.5
+      '0.9': 89.5
+      '0.95': 94.0
+  metadata:
+    rationale: Our forecasts combine the immediate geopolitical shock in the Strait
+      of Hormuz with fundamental constraints. While a massive war premium has driven
+      WTI prices into the mid-to-high $70s in the spot market, the medium-term price
+      path is capped by massive U.S. and IEA SPR intervention alongside deteriorating
+      macroeconomic demand, creating a highly volatile and wide distribution of possible
+      outcomes.
+    horizon_rationale: At the 10-day horizon, the market will begin to see the initial
+      impact of coordinated emergency oil releases from the US Strategic Petroleum
+      Reserve (which has prepared a substantial release of up to 172 million barrels)
+      and IEA allies. The point forecast moderates slightly as emergency supplies
+      begin to enter logistics networks, but the range of outcomes widens considerably
+      to account for the possibility of either a quick resolution or broader regional
+      disruptions.
+    langfuse_trace_id: e91937d682c4a7dc2ae5089359cf1e63
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e91937d682c4a7dc2ae5089359cf1e63
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:05:18.395117'
+  as_of: '2026-03-02T00:00:00'
+  forecast_date: '2026-03-31T00:00:00'
+  payload:
+    point_forecast: 73.5
+    quantiles:
+      '0.05': 58.5
+      '0.1': 62.0
+      '0.2': 66.5
+      '0.3': 69.5
+      '0.4': 71.5
+      '0.5': 73.5
+      '0.6': 75.8
+      '0.7': 79.0
+      '0.8': 84.0
+      '0.9': 92.0
+      '0.95': 99.0
+  metadata:
+    rationale: Our forecasts combine the immediate geopolitical shock in the Strait
+      of Hormuz with fundamental constraints. While a massive war premium has driven
+      WTI prices into the mid-to-high $70s in the spot market, the medium-term price
+      path is capped by massive U.S. and IEA SPR intervention alongside deteriorating
+      macroeconomic demand, creating a highly volatile and wide distribution of possible
+      outcomes.
+    horizon_rationale: 'By late March 2026, the global demand outlook is expected
+      to deteriorate further due to the high fuel prices, which the IEA projects will
+      contract demand. The distribution is highly skewed: the lower tail represents
+      a return to fundamental oversupply if shipping corridors reopen and SPR barrels
+      flood the market, while the upper tail reflects a prolonged maritime blockade
+      and failure of diplomatic channels, keeping WTI crude near historic highs.'
+    langfuse_trace_id: e91937d682c4a7dc2ae5089359cf1e63
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e91937d682c4a7dc2ae5089359cf1e63
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:07:03.686975'
+  as_of: '2026-03-09T00:00:00'
+  forecast_date: '2026-03-16T00:00:00'
+  payload:
+    point_forecast: 106.5
+    quantiles:
+      '0.05': 86.0
+      '0.1': 92.0
+      '0.2': 98.0
+      '0.3': 101.5
+      '0.4': 104.0
+      '0.5': 106.5
+      '0.6': 110.0
+      '0.7': 114.5
+      '0.8': 119.5
+      '0.9': 126.0
+      '0.95': 133.0
+  metadata:
+    rationale: This forecast is formulated as of March 9, 2026, incorporating the
+      major geopolitical shock involving the United States, Israel, and Iran, which
+      culminated in the closure of the Strait of Hormuz in early March 2026. This
+      disruption representing roughly 20% of global oil flows has injected an unprecedented
+      risk premium, driving WTI from $90.90 on March 6 to a daily close of $104.50
+      on March 9. The probabilistic distribution reflects extreme short-term volatility,
+      with the upper quantiles representing severe supply shortfall scenarios and
+      the lower quantiles representing potential de-escalation and emergency SPR release
+      interventions.
+    horizon_rationale: "WTI prices surged sharply to around $104.50 on Monday, March\
+      \ 9, 2026, up from $90.90 on Friday, March 6. This massive escalation follows\
+      \ the outbreak of military conflict between the US, Israel, and Iran on February\
+      \ 28, 2026, and Iran's subsequent closure of the Strait of Hormuz\u2014a chokepoint\
+      \ handling about 20% of global oil trade. For the 5-day horizon (approx. March\
+      \ 16), the market is expected to remain in extreme panic. While aggressive SPR\
+      \ releases planned by G7 and IEA nations could mitigate some of the supply shock,\
+      \ the sheer size of the deficit (potentially up to 8-10 mb/d) keeps near-term\
+      \ price risks heavily skewed to the upside. The median is projected at $106.50,\
+      \ with a wide upside tail reaching $133 in escalation scenarios, and a downside\
+      \ tail to $86 if quick diplomatic or military progress occurs."
+    langfuse_trace_id: d1e35a0d4345b4f0801c8c2ffdaf4af7
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/d1e35a0d4345b4f0801c8c2ffdaf4af7
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:07:03.686975'
+  as_of: '2026-03-09T00:00:00'
+  forecast_date: '2026-03-23T00:00:00'
+  payload:
+    point_forecast: 108.0
+    quantiles:
+      '0.05': 81.0
+      '0.1': 88.0
+      '0.2': 96.0
+      '0.3': 101.0
+      '0.4': 104.5
+      '0.5': 108.0
+      '0.6': 112.5
+      '0.7': 118.0
+      '0.8': 125.0
+      '0.9': 134.5
+      '0.95': 143.0
+  metadata:
+    rationale: This forecast is formulated as of March 9, 2026, incorporating the
+      major geopolitical shock involving the United States, Israel, and Iran, which
+      culminated in the closure of the Strait of Hormuz in early March 2026. This
+      disruption representing roughly 20% of global oil flows has injected an unprecedented
+      risk premium, driving WTI from $90.90 on March 6 to a daily close of $104.50
+      on March 9. The probabilistic distribution reflects extreme short-term volatility,
+      with the upper quantiles representing severe supply shortfall scenarios and
+      the lower quantiles representing potential de-escalation and emergency SPR release
+      interventions.
+    horizon_rationale: By the 10-day horizon (approx. March 23), physical supply shortages
+      are expected to set in as refinery intakes are affected by the lack of Middle
+      Eastern crude. OPEC+ had planned to gradually unwind voluntary cuts starting
+      in April, but this is grossly insufficient to cover the current loss. The median
+      forecast rises slightly to $108.00 as physical tightness peaks, while the uncertainty
+      band widens. A severe escalation of conflict targeting other regional oil infrastructures
+      could see prices rise to $143.00, whereas coordinated emergency convoy operations
+      or partial reopening of the strait would lead to a sharp correction down toward
+      the $80s.
+    langfuse_trace_id: d1e35a0d4345b4f0801c8c2ffdaf4af7
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/d1e35a0d4345b4f0801c8c2ffdaf4af7
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:07:03.686975'
+  as_of: '2026-03-09T00:00:00'
+  forecast_date: '2026-04-07T00:00:00'
+  payload:
+    point_forecast: 105.5
+    quantiles:
+      '0.05': 75.0
+      '0.1': 83.0
+      '0.2': 92.5
+      '0.3': 98.0
+      '0.4': 102.0
+      '0.5': 105.5
+      '0.6': 109.5
+      '0.7': 115.5
+      '0.8': 123.5
+      '0.9': 135.0
+      '0.95': 145.0
+  metadata:
+    rationale: This forecast is formulated as of March 9, 2026, incorporating the
+      major geopolitical shock involving the United States, Israel, and Iran, which
+      culminated in the closure of the Strait of Hormuz in early March 2026. This
+      disruption representing roughly 20% of global oil flows has injected an unprecedented
+      risk premium, driving WTI from $90.90 on March 6 to a daily close of $104.50
+      on March 9. The probabilistic distribution reflects extreme short-term volatility,
+      with the upper quantiles representing severe supply shortfall scenarios and
+      the lower quantiles representing potential de-escalation and emergency SPR release
+      interventions.
+    horizon_rationale: At the 21-day horizon (approx. April 7), market pressures may
+      begin to moderate slightly as massive, coordinated IEA/US Strategic Petroleum
+      Reserve (SPR) releases and alternative pipeline/shipping routes are established.
+      Although the baseline price remains highly elevated with a median of $105.50,
+      the probability of a resolution, de-escalation, or successful naval escorts
+      increases over this longer timeframe, leading to a fat downside tail ($75.00)
+      in the event of a market normalization, while the threat of a prolonged wider
+      war maintains a strong upper boundary near $145.00.
+    langfuse_trace_id: d1e35a0d4345b4f0801c8c2ffdaf4af7
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/d1e35a0d4345b4f0801c8c2ffdaf4af7
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:08:49.272584'
+  as_of: '2026-03-16T00:00:00'
+  forecast_date: '2026-03-23T00:00:00'
+  payload:
+    point_forecast: 98.0
+    quantiles:
+      '0.05': 82.0
+      '0.1': 86.0
+      '0.2': 91.0
+      '0.3': 94.0
+      '0.4': 96.0
+      '0.5': 98.0
+      '0.6': 99.5
+      '0.7': 101.5
+      '0.8': 104.0
+      '0.9': 108.0
+      '0.95': 112.0
+  metadata:
+    rationale: Overall WTI price dynamics as of March 16, 2026, are completely dominated
+      by the conflict in the Middle East and the closure of the Strait of Hormuz since
+      late February. While the IEA/SPR releases of 400M barrels provide a critical
+      supply bridge, physical logistics limit immediate delivery. Consequently, WTI
+      remains elevated in the short term, with a gradual moderation expected over
+      the medium term. High volatility and wider tail-risks are reflected in the broad,
+      skewed quantile distributions.
+    horizon_rationale: Over the 5-day horizon, the physical closure of the Strait
+      of Hormuz continues to severely restrict 20% of global seaborne crude flows.
+      Although the IEA coordinated release of 400M barrels (including 172M from the
+      US SPR) is announced, the physical logistics of delivery take time, keeping
+      WTI highly elevated. The point forecast is set near recent closes at $98.00,
+      with high volatility and potential upside if military actions escalate.
+    langfuse_trace_id: 3c95edb045bc555f19a9b7204958be9c
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/3c95edb045bc555f19a9b7204958be9c
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:08:49.272584'
+  as_of: '2026-03-16T00:00:00'
+  forecast_date: '2026-03-30T00:00:00'
+  payload:
+    point_forecast: 95.5
+    quantiles:
+      '0.05': 78.0
+      '0.1': 82.5
+      '0.2': 88.0
+      '0.3': 91.5
+      '0.4': 93.5
+      '0.5': 95.5
+      '0.6': 97.5
+      '0.7': 100.0
+      '0.8': 103.5
+      '0.9': 108.0
+      '0.95': 113.0
+  metadata:
+    rationale: Overall WTI price dynamics as of March 16, 2026, are completely dominated
+      by the conflict in the Middle East and the closure of the Strait of Hormuz since
+      late February. While the IEA/SPR releases of 400M barrels provide a critical
+      supply bridge, physical logistics limit immediate delivery. Consequently, WTI
+      remains elevated in the short term, with a gradual moderation expected over
+      the medium term. High volatility and wider tail-risks are reflected in the broad,
+      skewed quantile distributions.
+    horizon_rationale: At the 10-day horizon, some initial physical volumes from the
+      SPR/IEA coordinated release are expected to enter the market, capping extreme
+      upside. However, the spot market remains tight, and WTI is expected to average
+      $95.50. The risk distribution is extremely wide and binary, with the downside
+      accounting for potential ceasefires/reopening and the upside representing active
+      escalation of hostilities.
+    langfuse_trace_id: 3c95edb045bc555f19a9b7204958be9c
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/3c95edb045bc555f19a9b7204958be9c
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:08:49.272584'
+  as_of: '2026-03-16T00:00:00'
+  forecast_date: '2026-04-14T00:00:00'
+  payload:
+    point_forecast: 93.0
+    quantiles:
+      '0.05': 72.0
+      '0.1': 77.0
+      '0.2': 83.0
+      '0.3': 87.5
+      '0.4': 90.5
+      '0.5': 93.0
+      '0.6': 96.0
+      '0.7': 99.5
+      '0.8': 104.0
+      '0.9': 110.0
+      '0.95': 116.0
+  metadata:
+    rationale: Overall WTI price dynamics as of March 16, 2026, are completely dominated
+      by the conflict in the Middle East and the closure of the Strait of Hormuz since
+      late February. While the IEA/SPR releases of 400M barrels provide a critical
+      supply bridge, physical logistics limit immediate delivery. Consequently, WTI
+      remains elevated in the short term, with a gradual moderation expected over
+      the medium term. High volatility and wider tail-risks are reflected in the broad,
+      skewed quantile distributions.
+    horizon_rationale: By day 21 (mid-April), WTI is projected to face a gradual moderate
+      decline toward a median of $93.00, in line with EIA's March STEO expecting Brent
+      to remain above $95 over the next two months but gradually moderate thereafter.
+      Downside risk extends to $72.00 if diplomatic efforts succeed in reopening the
+      Strait of Hormuz, while upside risk extends to $116.00 in the event of severe
+      military escalation.
+    langfuse_trace_id: 3c95edb045bc555f19a9b7204958be9c
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/3c95edb045bc555f19a9b7204958be9c
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:10:00.998816'
+  as_of: '2026-03-23T00:00:00'
+  forecast_date: '2026-03-30T00:00:00'
+  payload:
+    point_forecast: 99.0
+    quantiles:
+      '0.05': 87.0
+      '0.1': 90.5
+      '0.2': 94.0
+      '0.3': 96.0
+      '0.4': 97.5
+      '0.5': 99.0
+      '0.6': 100.5
+      '0.7': 102.5
+      '0.8': 105.0
+      '0.9': 109.0
+      '0.95': 113.0
+  metadata:
+    rationale: WTI crude oil markets are undergoing a historic geopolitical supply
+      shock due to conflict in the Middle East starting in late February 2026, causing
+      the closure of the Strait of Hormuz and shut-ins of over 10 million b/d of Persian
+      Gulf oil production. The global response via a massive 400-million-barrel IEA
+      emergency reserve release and OPEC+ starting its voluntary cut unwinding in
+      April provides a powerful eventual buffer, but physical constraints keep near-term
+      supply critical. The resulting forecasts combine high near-term price stickiness
+      with a rapidly widening and highly asymmetric probability distribution over
+      the multi-week horizon.
+    horizon_rationale: Over a 5-day horizon (as of late March 2026), WTI crude oil
+      is highly supported by the physical closure of the Strait of Hormuz, which has
+      shut in approximately 10-12 million b/d of Middle Eastern crude. Although a
+      massive coordinated SPR release of 400 million barrels has been announced by
+      the IEA (including 172 million barrels from the U.S.), physical logistics prevent
+      these barrels from immediately alleviating the deficit. Volatility remains extremely
+      high. The point forecast is set slightly higher at $99.00/bbl, with a tight
+      downside unless sudden diplomatic breakthroughs occur.
+    langfuse_trace_id: d025cc2d375a06b435a20a8bd41251b5
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/d025cc2d375a06b435a20a8bd41251b5
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:10:00.998816'
+  as_of: '2026-03-23T00:00:00'
+  forecast_date: '2026-04-06T00:00:00'
+  payload:
+    point_forecast: 101.0
+    quantiles:
+      '0.05': 81.0
+      '0.1': 86.0
+      '0.2': 92.0
+      '0.3': 96.0
+      '0.4': 98.5
+      '0.5': 101.0
+      '0.6': 103.5
+      '0.7': 106.5
+      '0.8': 110.5
+      '0.9': 116.0
+      '0.95': 121.0
+  metadata:
+    rationale: WTI crude oil markets are undergoing a historic geopolitical supply
+      shock due to conflict in the Middle East starting in late February 2026, causing
+      the closure of the Strait of Hormuz and shut-ins of over 10 million b/d of Persian
+      Gulf oil production. The global response via a massive 400-million-barrel IEA
+      emergency reserve release and OPEC+ starting its voluntary cut unwinding in
+      April provides a powerful eventual buffer, but physical constraints keep near-term
+      supply critical. The resulting forecasts combine high near-term price stickiness
+      with a rapidly widening and highly asymmetric probability distribution over
+      the multi-week horizon.
+    horizon_rationale: At a 10-day horizon, the physical tightness will continue to
+      manifest as global inventories draw down. While the first tranches of the U.S.
+      SPR release should begin contracting, they will only partially mitigate the
+      massive Persian Gulf shut-ins. OPEC+ plans to unwind 206,000 b/d of voluntary
+      cuts starting in April, which provides a small buffer. This supports a median
+      price projection of $101.00/bbl, with a widening risk distribution reflecting
+      binary outcomes of continued escalation (upside up to $121.00) or early de-escalation
+      signals (downside to $81.00).
+    langfuse_trace_id: d025cc2d375a06b435a20a8bd41251b5
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/d025cc2d375a06b435a20a8bd41251b5
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:10:00.998816'
+  as_of: '2026-03-23T00:00:00'
+  forecast_date: '2026-04-21T00:00:00'
+  payload:
+    point_forecast: 103.0
+    quantiles:
+      '0.05': 72.0
+      '0.1': 79.0
+      '0.2': 88.0
+      '0.3': 94.0
+      '0.4': 99.0
+      '0.5': 103.0
+      '0.6': 107.0
+      '0.7': 112.0
+      '0.8': 118.0
+      '0.9': 126.0
+      '0.95': 132.0
+  metadata:
+    rationale: WTI crude oil markets are undergoing a historic geopolitical supply
+      shock due to conflict in the Middle East starting in late February 2026, causing
+      the closure of the Strait of Hormuz and shut-ins of over 10 million b/d of Persian
+      Gulf oil production. The global response via a massive 400-million-barrel IEA
+      emergency reserve release and OPEC+ starting its voluntary cut unwinding in
+      April provides a powerful eventual buffer, but physical constraints keep near-term
+      supply critical. The resulting forecasts combine high near-term price stickiness
+      with a rapidly widening and highly asymmetric probability distribution over
+      the multi-week horizon.
+    horizon_rationale: Over a 21-day horizon (extending into late April 2026), the
+      price distribution is heavily bimodal and highly uncertain. If the Strait of
+      Hormuz remains fully closed and military hostilities persist, physical shortfalls
+      will drive WTI toward the upper quantiles ($126-$132/bbl). Conversely, any credible
+      diplomatic resolution, combined with the massive 400-million-barrel emergency
+      supply overhang, would trigger a dramatic price collapse back toward the pre-crisis
+      baseline (down to $72-$79/bbl). This extreme asymmetry is reflected in the wide
+      tail quantiles, while the median sits at $103.00/bbl.
+    langfuse_trace_id: d025cc2d375a06b435a20a8bd41251b5
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/d025cc2d375a06b435a20a8bd41251b5
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:11:37.955852'
+  as_of: '2026-03-30T00:00:00'
+  forecast_date: '2026-04-06T00:00:00'
+  payload:
+    point_forecast: 101.5
+    quantiles:
+      '0.05': 75.0
+      '0.1': 82.0
+      '0.2': 90.0
+      '0.3': 95.0
+      '0.4': 98.5
+      '0.5': 101.5
+      '0.6': 104.5
+      '0.7': 108.0
+      '0.8': 112.0
+      '0.9': 118.0
+      '0.95': 125.0
+  metadata:
+    rationale: The WTI crude oil market is currently experiencing unprecedented geopolitical
+      volatility following the outbreak of conflict between the US, Israel, and Iran
+      on February 28, 2026, which effectively closed the Strait of Hormuz. The loss
+      of up to 10 mb/d of oil transit has pushed WTI to a 52-week high close of $99.64.
+      Coordinated emergency releases of 400 million barrels by the IEA and 172 million
+      barrels by the US SPR provide a short-term buffer, but the market remains highly
+      anxious. Our forecasts reflect high near-term prices due to momentum and physical
+      tightening, but show a significantly wider and bifurcated distribution over
+      the 10-day and 21-day horizons, capturing both the potential for sudden diplomatic
+      resolution (sending prices back to the $65-$70 range) and extreme supply-side
+      escalations (sending prices above $130).
+    horizon_rationale: Over a 5-day horizon (by April 6, 2026), the immediate momentum
+      remains heavily bullish as WTI recently closed at a 52-week high of $99.64 on
+      March 27. The de facto closure of the Strait of Hormuz since late February has
+      removed up to 10 mb/d of Gulf oil supply, creating the largest supply disruption
+      in history. While the coordinated IEA release of 400 million barrels (including
+      172 million from the US SPR) acts as a temporary buffer, the physical shipping
+      blockade remains unresolved. We expect prices to consolidate or rise slightly
+      further, with a median of $101.50. The downside risk (0.05 quantile at $75.00)
+      represents a sudden ceasefire rumor, while the upside risk (0.95 quantile at
+      $125.00) reflects further direct military escalation in the Gulf.
+    langfuse_trace_id: 1f9305bcef6cbad03709a894348c3d29
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/1f9305bcef6cbad03709a894348c3d29
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:11:37.955852'
+  as_of: '2026-03-30T00:00:00'
+  forecast_date: '2026-04-13T00:00:00'
+  payload:
+    point_forecast: 103.0
+    quantiles:
+      '0.05': 70.0
+      '0.1': 78.0
+      '0.2': 88.0
+      '0.3': 94.0
+      '0.4': 99.0
+      '0.5': 103.0
+      '0.6': 107.0
+      '0.7': 112.0
+      '0.8': 118.0
+      '0.9': 125.0
+      '0.95': 132.0
+  metadata:
+    rationale: The WTI crude oil market is currently experiencing unprecedented geopolitical
+      volatility following the outbreak of conflict between the US, Israel, and Iran
+      on February 28, 2026, which effectively closed the Strait of Hormuz. The loss
+      of up to 10 mb/d of oil transit has pushed WTI to a 52-week high close of $99.64.
+      Coordinated emergency releases of 400 million barrels by the IEA and 172 million
+      barrels by the US SPR provide a short-term buffer, but the market remains highly
+      anxious. Our forecasts reflect high near-term prices due to momentum and physical
+      tightening, but show a significantly wider and bifurcated distribution over
+      the 10-day and 21-day horizons, capturing both the potential for sudden diplomatic
+      resolution (sending prices back to the $65-$70 range) and extreme supply-side
+      escalations (sending prices above $130).
+    horizon_rationale: 'Over a 10-day horizon (by April 13, 2026), the physical supply
+      squeeze is likely to intensify as existing commercial stocks in Europe and Asia
+      deplete. OPEC+ has agreed to a minor increase of 206k bpd for April, which is
+      far too small to cover the massive shortfall. The SPR releases will start hitting
+      the market but may face grade compatibility and logistics constraints. We expect
+      the median price to rise to $103.00. The distribution widens significantly:
+      a diplomatic breakthrough could bring prices down toward $70.00, whereas an
+      extended conflict with infrastructure damage in the Persian Gulf could push
+      WTI above $130.00 (0.95 quantile at $132.00).'
+    langfuse_trace_id: 1f9305bcef6cbad03709a894348c3d29
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/1f9305bcef6cbad03709a894348c3d29
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:11:37.955852'
+  as_of: '2026-03-30T00:00:00'
+  forecast_date: '2026-04-28T00:00:00'
+  payload:
+    point_forecast: 98.0
+    quantiles:
+      '0.05': 65.0
+      '0.1': 72.0
+      '0.2': 82.0
+      '0.3': 90.0
+      '0.4': 94.5
+      '0.5': 98.0
+      '0.6': 102.5
+      '0.7': 108.0
+      '0.8': 115.0
+      '0.9': 124.0
+      '0.95': 135.0
+  metadata:
+    rationale: The WTI crude oil market is currently experiencing unprecedented geopolitical
+      volatility following the outbreak of conflict between the US, Israel, and Iran
+      on February 28, 2026, which effectively closed the Strait of Hormuz. The loss
+      of up to 10 mb/d of oil transit has pushed WTI to a 52-week high close of $99.64.
+      Coordinated emergency releases of 400 million barrels by the IEA and 172 million
+      barrels by the US SPR provide a short-term buffer, but the market remains highly
+      anxious. Our forecasts reflect high near-term prices due to momentum and physical
+      tightening, but show a significantly wider and bifurcated distribution over
+      the 10-day and 21-day horizons, capturing both the potential for sudden diplomatic
+      resolution (sending prices back to the $65-$70 range) and extreme supply-side
+      escalations (sending prices above $130).
+    horizon_rationale: Over a 21-day horizon (by late April 2026), we anticipate a
+      highly bifurcated market. On one hand, there is a strong probability of some
+      adaptation or de-escalation (such as naval escort systems or diplomatic progress),
+      which would begin to deflate the geopolitical risk premium. This pulls our median
+      forecast slightly down to $98.00, and creates a fat tail on the downside (0.05
+      quantile at $65.00, representing a return to pre-crisis levels). On the other
+      hand, if the blockade persists without a resolution, demand destruction will
+      start to kick in, but a prolonged supply deficit could trigger extreme tail-risk
+      price spikes towards $135.00.
+    langfuse_trace_id: 1f9305bcef6cbad03709a894348c3d29
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/1f9305bcef6cbad03709a894348c3d29
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:13:43.396394'
+  as_of: '2026-04-06T00:00:00'
+  forecast_date: '2026-04-13T00:00:00'
+  payload:
+    point_forecast: 112.0
+    quantiles:
+      '0.05': 95.0
+      '0.1': 100.0
+      '0.2': 104.0
+      '0.3': 107.0
+      '0.4': 109.5
+      '0.5': 112.0
+      '0.6': 114.5
+      '0.7': 117.0
+      '0.8': 120.0
+      '0.9': 124.0
+      '0.95': 128.0
+  metadata:
+    rationale: Global oil markets as of early April 2026 are experiencing one of the
+      most severe supply shocks in history due to the closure of the Strait of Hormuz
+      on February 28, 2026, which blocked roughly 20% of seaborne oil trade. These
+      forecasts are calibrated to reflect extreme volatility, combining short-term
+      bullish momentum (war-risk premium) with medium-term risks of demand destruction,
+      physical SPR release lag times, and potential diplomatic breakthroughs.
+    horizon_rationale: In the immediate 5-day horizon, WTI crude oil prices are expected
+      to remain extremely elevated, consolidating around the $111-$114 range. The
+      closure of the Strait of Hormuz since late February 2026 has introduced a massive
+      geopolitical war-risk premium of $25-$30/bbl due to the disruption of ~10 million
+      bpd of Middle Eastern crude exports. Despite a massive coordinated 400-million-barrel
+      SPR release led by the US and allies, physical logistics take time to clear,
+      keeping physical markets extremely tight. Short-term upside risks include direct
+      military escalations in the Gulf, potentially driving WTI toward $120-$128.
+      Conversely, any reports of successful diplomatic ceasefire talks in Qatar/Pakistan
+      represent a significant downside risk, with potential to trigger a sharp pullback
+      toward $95-$100.
+    langfuse_trace_id: 9b5f34a987671ec989c237ff1d9f8ffb
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/9b5f34a987671ec989c237ff1d9f8ffb
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:13:43.396394'
+  as_of: '2026-04-06T00:00:00'
+  forecast_date: '2026-04-20T00:00:00'
+  payload:
+    point_forecast: 110.0
+    quantiles:
+      '0.05': 88.0
+      '0.1': 94.0
+      '0.2': 100.0
+      '0.3': 104.0
+      '0.4': 107.0
+      '0.5': 110.0
+      '0.6': 113.5
+      '0.7': 117.0
+      '0.8': 121.0
+      '0.9': 126.0
+      '0.95': 132.0
+  metadata:
+    rationale: Global oil markets as of early April 2026 are experiencing one of the
+      most severe supply shocks in history due to the closure of the Strait of Hormuz
+      on February 28, 2026, which blocked roughly 20% of seaborne oil trade. These
+      forecasts are calibrated to reflect extreme volatility, combining short-term
+      bullish momentum (war-risk premium) with medium-term risks of demand destruction,
+      physical SPR release lag times, and potential diplomatic breakthroughs.
+    horizon_rationale: Over a 10-day horizon, the market's distribution becomes wider,
+      reflecting the binary nature of the Middle East crisis. A prolonged blockade
+      would trigger further inventory depletion, potentially overshooting resistance
+      levels and pushing WTI toward $125-$132. Meanwhile, OPEC+'s decision to increase
+      output by 206,000 bpd in May remains largely symbolic because crude is physically
+      trapped. However, there is a growing probability that diplomatic intervention
+      or US convoy escorts could partially resolve the blockage, which would rapidly
+      deflate the war premium. The median is set slightly lower at $110.00 as high
+      prices begin to trigger early demand destruction and as SPR exchanges physically
+      begin to reach domestic refiners, but the standard deviation is significantly
+      expanded to capture these high-stakes geopolitical outcomes.
+    langfuse_trace_id: 9b5f34a987671ec989c237ff1d9f8ffb
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/9b5f34a987671ec989c237ff1d9f8ffb
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:13:43.396394'
+  as_of: '2026-04-06T00:00:00'
+  forecast_date: '2026-05-05T00:00:00'
+  payload:
+    point_forecast: 105.0
+    quantiles:
+      '0.05': 80.0
+      '0.1': 87.0
+      '0.2': 93.0
+      '0.3': 98.0
+      '0.4': 101.5
+      '0.5': 105.0
+      '0.6': 109.5
+      '0.7': 115.0
+      '0.8': 122.0
+      '0.9': 132.0
+      '0.95': 140.0
+  metadata:
+    rationale: Global oil markets as of early April 2026 are experiencing one of the
+      most severe supply shocks in history due to the closure of the Strait of Hormuz
+      on February 28, 2026, which blocked roughly 20% of seaborne oil trade. These
+      forecasts are calibrated to reflect extreme volatility, combining short-term
+      bullish momentum (war-risk premium) with medium-term risks of demand destruction,
+      physical SPR release lag times, and potential diplomatic breakthroughs.
+    horizon_rationale: At the 21-day horizon (approaching early May 2026), structural
+      demand-side forces and physical supply adjustments start to play a larger role.
+      Sustained oil prices near or above $110/bbl are highly likely to induce global
+      macroeconomic slowdowns and fuel demand destruction, placing a natural cap on
+      further upward spikes (represented by the 0.95 quantile of $140.00). Over this
+      monthly period, the probability of a diplomatic resolution, a partial reopening
+      of shipping lanes, or an increase in non-OPEC exports rises significantly. Thus,
+      the point forecast (median) drifts down to $105.00, and the lower tail (0.05
+      quantile) expands down to $80.00, representing a scenario where a comprehensive
+      ceasefire is reached and shipping through the Strait of Hormuz fully normalizes.
+    langfuse_trace_id: 9b5f34a987671ec989c237ff1d9f8ffb
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/9b5f34a987671ec989c237ff1d9f8ffb
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:16:15.581965'
+  as_of: '2026-04-13T00:00:00'
+  forecast_date: '2026-04-20T00:00:00'
+  payload:
+    point_forecast: 103.0
+    quantiles:
+      '0.05': 80.0
+      '0.1': 86.0
+      '0.2': 91.0
+      '0.3': 95.0
+      '0.4': 99.0
+      '0.5': 103.0
+      '0.6': 107.0
+      '0.7': 111.0
+      '0.8': 115.0
+      '0.9': 121.0
+      '0.95': 126.0
+  metadata:
+    rationale: The WTI crude oil market as of April 13, 2026, is dominated by the
+      unprecedented supply crisis following the closure of the Strait of Hormuz and
+      the subsequent U.S. naval blockade. Global supply is down by 10.1 mb/d, countered
+      by a 400-million-barrel international coordinated emergency stock release (including
+      172 million barrels from the U.S. SPR). This creates a highly volatile, bimodal
+      risk profile, where any signs of diplomatic breakthrough can cause sharp, double-digit
+      daily price plunges, while further military escalation could easily push prices
+      above $120/bbl.
+    horizon_rationale: As of April 13, 2026, WTI is trading at approximately $104.44,
+      up sharply from the April 10 close of $96.57. This jump is driven by a new wave
+      of escalation, including a scheduled U.S. naval blockade of Iranian ports starting
+      April 13. While a two-week ceasefire was announced on April 7 (which dropped
+      prices from $112.95 to $94.41), the blockade orders have injected a massive
+      geopolitical risk premium back into the market. With the Strait of Hormuz effectively
+      closed, a historic global supply deficit of 10.1 mb/d exists, only partially
+      offset by the coordinated 400-million-barrel strategic reserve release (including
+      172 million barrels from the US SPR). Over a 5-day horizon (by April 20), we
+      expect extreme volatility. If hostilities break out, WTI could quickly spike
+      back to $120+ (upper quantiles 0.90, 0.95). If the situation stabilizes or ceasefire
+      talks resume, prices could fall back to the mid-$80s (lower quantiles).
+    langfuse_trace_id: 6b2cd661cdd5b384a653a758d6a5d01c
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/6b2cd661cdd5b384a653a758d6a5d01c
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:16:15.581965'
+  as_of: '2026-04-13T00:00:00'
+  forecast_date: '2026-04-27T00:00:00'
+  payload:
+    point_forecast: 101.0
+    quantiles:
+      '0.05': 72.0
+      '0.1': 78.0
+      '0.2': 85.0
+      '0.3': 91.0
+      '0.4': 96.0
+      '0.5': 101.0
+      '0.6': 106.0
+      '0.7': 112.0
+      '0.8': 118.0
+      '0.9': 126.0
+      '0.95': 132.0
+  metadata:
+    rationale: The WTI crude oil market as of April 13, 2026, is dominated by the
+      unprecedented supply crisis following the closure of the Strait of Hormuz and
+      the subsequent U.S. naval blockade. Global supply is down by 10.1 mb/d, countered
+      by a 400-million-barrel international coordinated emergency stock release (including
+      172 million barrels from the U.S. SPR). This creates a highly volatile, bimodal
+      risk profile, where any signs of diplomatic breakthrough can cause sharp, double-digit
+      daily price plunges, while further military escalation could easily push prices
+      above $120/bbl.
+    horizon_rationale: By April 27 (Horizon 10), the market will have endured two
+      weeks of the U.S. naval blockade. The physical shortage of seaborne crude from
+      the Persian Gulf will become increasingly acute, even as emergency exchanges
+      from the SPR continue to inject crude into the market. Over this 10-day horizon,
+      the probability distribution widens significantly. If the blockade leads to
+      broader regional conflict or infrastructure damage, WTI could test $130 (0.95
+      quantile). Conversely, if the ceasefire is reinforced or diplomatic channels
+      successfully resolve the shipping impasse, WTI is expected to drop sharply back
+      to a more sustainable baseline in the $70s-$80s (0.05 and 0.10 quantiles).
+    langfuse_trace_id: 6b2cd661cdd5b384a653a758d6a5d01c
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/6b2cd661cdd5b384a653a758d6a5d01c
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:16:15.581965'
+  as_of: '2026-04-13T00:00:00'
+  forecast_date: '2026-05-12T00:00:00'
+  payload:
+    point_forecast: 97.0
+    quantiles:
+      '0.05': 62.0
+      '0.1': 68.0
+      '0.2': 76.0
+      '0.3': 84.0
+      '0.4': 91.0
+      '0.5': 97.0
+      '0.6': 103.0
+      '0.7': 110.0
+      '0.8': 118.0
+      '0.9': 128.0
+      '0.95': 136.0
+  metadata:
+    rationale: The WTI crude oil market as of April 13, 2026, is dominated by the
+      unprecedented supply crisis following the closure of the Strait of Hormuz and
+      the subsequent U.S. naval blockade. Global supply is down by 10.1 mb/d, countered
+      by a 400-million-barrel international coordinated emergency stock release (including
+      172 million barrels from the U.S. SPR). This creates a highly volatile, bimodal
+      risk profile, where any signs of diplomatic breakthrough can cause sharp, double-digit
+      daily price plunges, while further military escalation could easily push prices
+      above $120/bbl.
+    horizon_rationale: By mid-May (Horizon 21), the OPEC+ production adjustments of
+      206,000 b/d for May 2026 will have taken effect. This period will mark nearly
+      a month since the blockade started. By this time, either a more permanent ceasefire/diplomatic
+      resolution has been achieved (which would send WTI plunging to the $60s-$70s
+      range as the massive supply surplus of 2025/2026 returns) or a prolonged conflict
+      has forced a structural shift in global trade lanes (keeping WTI elevated above
+      $110-$130). This bimodal risk profile leads to a very wide, highly uncertain
+      distribution. The point forecast (median) is set at $97.00, reflecting a slight
+      moderation from current highs as SPR oil reaches physical refiners, but with
+      substantial tails extending from $62.00 up to $136.00.
+    langfuse_trace_id: 6b2cd661cdd5b384a653a758d6a5d01c
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/6b2cd661cdd5b384a653a758d6a5d01c
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:17:46.620506'
+  as_of: '2026-04-20T00:00:00'
+  forecast_date: '2026-04-27T00:00:00'
+  payload:
+    point_forecast: 91.5
+    quantiles:
+      '0.05': 79.0
+      '0.1': 82.0
+      '0.2': 85.0
+      '0.3': 88.0
+      '0.4': 90.0
+      '0.5': 91.5
+      '0.6': 93.0
+      '0.7': 95.0
+      '0.8': 98.0
+      '0.9': 102.0
+      '0.95': 106.0
+  metadata:
+    rationale: The forecasts as of April 20, 2026, model WTI prices under extreme
+      geopolitical strain from the US-Iran conflict and the blockaded Strait of Hormuz.
+      The short-term dip on April 17 ($83.85) has reversed due to the weekend escalation
+      (US seizure of an Iranian vessel). Prices are projected to rebound across all
+      horizons as geopolitical premiums are priced back in, though massive, coordinated
+      SPR releases (172M barrels from the US, 400M internationally) will continue
+      to suppress runaway tail spikes.
+    horizon_rationale: Following the sharp pullback on Friday, April 17 to $83.85
+      due to diplomatic hopes, Monday, April 20 saw Brent rebound to ~$95/bbl on news
+      of a US seizure of an Iranian vessel, which has dampened hopes for an immediate
+      ceasefire. In the 5-day horizon (April 27), WTI is projected to rebound into
+      the low-to-mid 90s, driven by the renewed pricing-in of the Strait of Hormuz
+      blockade and regional escalation risks. However, active SPR releases (including
+      the US DOE exchange contract for 26M barrels announced April 16) and demand
+      destruction in high-price regions will cap the immediate upside, keeping the
+      median at $91.50.
+    langfuse_trace_id: 2feca4d279d03d907fbf81c944e2b41d
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2feca4d279d03d907fbf81c944e2b41d
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:17:46.620506'
+  as_of: '2026-04-20T00:00:00'
+  forecast_date: '2026-05-04T00:00:00'
+  payload:
+    point_forecast: 93.0
+    quantiles:
+      '0.05': 74.0
+      '0.1': 78.0
+      '0.2': 83.0
+      '0.3': 87.0
+      '0.4': 90.0
+      '0.5': 93.0
+      '0.6': 96.0
+      '0.7': 99.0
+      '0.8': 103.0
+      '0.9': 108.0
+      '0.95': 114.0
+  metadata:
+    rationale: The forecasts as of April 20, 2026, model WTI prices under extreme
+      geopolitical strain from the US-Iran conflict and the blockaded Strait of Hormuz.
+      The short-term dip on April 17 ($83.85) has reversed due to the weekend escalation
+      (US seizure of an Iranian vessel). Prices are projected to rebound across all
+      horizons as geopolitical premiums are priced back in, though massive, coordinated
+      SPR releases (172M barrels from the US, 400M internationally) will continue
+      to suppress runaway tail spikes.
+    horizon_rationale: By May 4, uncertainty expands. OPEC+ planned voluntary cuts
+      adjustments (symbolic +206k b/d for May) do little to resolve the physical blockade
+      of the Strait. If diplomatic backchannels unexpectedly succeed, prices can rapidly
+      lose their geopolitical premium (downside risk to $74.00). If naval skirmishes
+      or retaliatory actions escalate, prices can spike back toward the 52-week high
+      of ~$113. The point forecast is set at $93.00, reflecting persistent physical
+      supply tightness cushioned temporarily by the emergency international SPR releases.
+    langfuse_trace_id: 2feca4d279d03d907fbf81c944e2b41d
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2feca4d279d03d907fbf81c944e2b41d
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:17:46.620506'
+  as_of: '2026-04-20T00:00:00'
+  forecast_date: '2026-05-19T00:00:00'
+  payload:
+    point_forecast: 94.5
+    quantiles:
+      '0.05': 66.0
+      '0.1': 72.0
+      '0.2': 80.0
+      '0.3': 86.0
+      '0.4': 91.0
+      '0.5': 94.5
+      '0.6': 98.0
+      '0.7': 102.0
+      '0.8': 108.0
+      '0.9': 115.0
+      '0.95': 122.0
+  metadata:
+    rationale: The forecasts as of April 20, 2026, model WTI prices under extreme
+      geopolitical strain from the US-Iran conflict and the blockaded Strait of Hormuz.
+      The short-term dip on April 17 ($83.85) has reversed due to the weekend escalation
+      (US seizure of an Iranian vessel). Prices are projected to rebound across all
+      horizons as geopolitical premiums are priced back in, though massive, coordinated
+      SPR releases (172M barrels from the US, 400M internationally) will continue
+      to suppress runaway tail spikes.
+    horizon_rationale: In the 21-day horizon (May 19), a highly binary outcome space
+      emerges. A breakthrough and durable ceasefire would reopen the Strait of Hormuz,
+      causing a swift return of Persian Gulf supply and dropping WTI back near the
+      pre-crisis baseline of $60-$70/bbl (reflected in the 0.05-0.10 tails). Conversely,
+      a prolonged impasse with continuing naval blockades will deplete SPR cushions
+      and force further demand destruction, driving WTI back up to $115-$120+. The
+      median of $94.50 reflects the expectation that a partial simmer will continue,
+      with elevated but capped prices.
+    langfuse_trace_id: 2feca4d279d03d907fbf81c944e2b41d
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/2feca4d279d03d907fbf81c944e2b41d
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:18:46.296897'
+  as_of: '2026-04-27T00:00:00'
+  forecast_date: '2026-05-04T00:00:00'
+  payload:
+    point_forecast: 93.0
+    quantiles:
+      '0.05': 75.0
+      '0.1': 80.0
+      '0.2': 85.0
+      '0.3': 89.0
+      '0.4': 91.0
+      '0.5': 93.0
+      '0.6': 95.0
+      '0.7': 98.0
+      '0.8': 102.0
+      '0.9': 107.0
+      '0.95': 112.0
+  metadata:
+    rationale: The WTI crude oil market as of April 27, 2026, is operating in a historic
+      crisis regime following the blockade of the Strait of Hormuz in late February,
+      which disrupted ~10 million b/d of global supply. While the market peaked near
+      $113 on April 7, significant corrections to the low $80s and bounces back to
+      $94.40 indicate a highly volatile, news-driven market. The forecast models this
+      with a slightly declining median trajectory over the next 21 business days,
+      reflecting massive coordinated SPR releases and brewing demand destruction,
+      while maintaining extraordinarily wide and flat tails to reflect the ongoing
+      geopolitical risks and potential for sharp binary shifts.
+    horizon_rationale: Over a 5-day horizon (targeting early May 2026), the crude
+      oil market will continue to trade under extreme volatility. Although the peak
+      of the panic has subsided from the $113 high on April 7, the Strait of Hormuz
+      remains effectively blocked. The U.S. and IEA's massive coordinated 400-million-barrel
+      SPR release program (including the DOE's recent 30-million-barrel exchange requests)
+      provides a temporary physical ceiling. However, high-headline sensitivity suggests
+      any escalation or a sudden de-escalation could move the market by $10-$15 in
+      either direction.
+    langfuse_trace_id: ae38a365e95e8740d217e683ce46f968
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/ae38a365e95e8740d217e683ce46f968
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:18:46.296897'
+  as_of: '2026-04-27T00:00:00'
+  forecast_date: '2026-05-11T00:00:00'
+  payload:
+    point_forecast: 91.5
+    quantiles:
+      '0.05': 70.0
+      '0.1': 76.0
+      '0.2': 82.0
+      '0.3': 86.0
+      '0.4': 89.0
+      '0.5': 91.5
+      '0.6': 94.0
+      '0.7': 98.0
+      '0.8': 103.0
+      '0.9': 110.0
+      '0.95': 115.0
+  metadata:
+    rationale: The WTI crude oil market as of April 27, 2026, is operating in a historic
+      crisis regime following the blockade of the Strait of Hormuz in late February,
+      which disrupted ~10 million b/d of global supply. While the market peaked near
+      $113 on April 7, significant corrections to the low $80s and bounces back to
+      $94.40 indicate a highly volatile, news-driven market. The forecast models this
+      with a slightly declining median trajectory over the next 21 business days,
+      reflecting massive coordinated SPR releases and brewing demand destruction,
+      while maintaining extraordinarily wide and flat tails to reflect the ongoing
+      geopolitical risks and potential for sharp binary shifts.
+    horizon_rationale: Over a 10-day horizon, the physical supply deficit caused by
+      the seaborne shutdown will clash directly with emerging demand destruction and
+      SPR flows. Eight OPEC+ countries adjusted May production upwards by 206,000
+      b/d, yet regional delivery is severely hampered. Our median price drifts slightly
+      lower to $91.50 as localized stockpiles and SPR swaps ease immediate constraints,
+      but the wider tail limits ($70 on the downside with diplomatic resolution, $115
+      on the upside with renewed hostilities) reflect the binary nature of the conflict.
+    langfuse_trace_id: ae38a365e95e8740d217e683ce46f968
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/ae38a365e95e8740d217e683ce46f968
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:18:46.296897'
+  as_of: '2026-04-27T00:00:00'
+  forecast_date: '2026-05-26T00:00:00'
+  payload:
+    point_forecast: 88.5
+    quantiles:
+      '0.05': 64.0
+      '0.1': 70.0
+      '0.2': 77.0
+      '0.3': 82.0
+      '0.4': 85.5
+      '0.5': 88.5
+      '0.6': 92.0
+      '0.7': 96.0
+      '0.8': 102.0
+      '0.9': 111.0
+      '0.95': 118.0
+  metadata:
+    rationale: The WTI crude oil market as of April 27, 2026, is operating in a historic
+      crisis regime following the blockade of the Strait of Hormuz in late February,
+      which disrupted ~10 million b/d of global supply. While the market peaked near
+      $113 on April 7, significant corrections to the low $80s and bounces back to
+      $94.40 indicate a highly volatile, news-driven market. The forecast models this
+      with a slightly declining median trajectory over the next 21 business days,
+      reflecting massive coordinated SPR releases and brewing demand destruction,
+      while maintaining extraordinarily wide and flat tails to reflect the ongoing
+      geopolitical risks and potential for sharp binary shifts.
+    horizon_rationale: "At the 21-day horizon (late May 2026), the cumulative effect\
+      \ of demand destruction\u2014especially in Asia due to sustained $90+ WTI prices\u2014\
+      is expected to exert stronger downward pressure on the median price ($88.50).\
+      \ If diplomatic mediation succeeds in establishing safe maritime corridors,\
+      \ prices will swiftly mean-revert toward the pre-crisis baseline ($60-$65 range).\
+      \ Conversely, if the blockade persists and SPR flows are deemed insufficient\
+      \ to prevent a global physical inventory depletion, prices can easily jump back\
+      \ to $118+."
+    langfuse_trace_id: ae38a365e95e8740d217e683ce46f968
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/ae38a365e95e8740d217e683ce46f968
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:20:50.335609'
+  as_of: '2026-05-04T00:00:00'
+  forecast_date: '2026-05-11T00:00:00'
+  payload:
+    point_forecast: 101.5
+    quantiles:
+      '0.05': 82.0
+      '0.1': 88.0
+      '0.2': 93.0
+      '0.3': 96.5
+      '0.4': 99.0
+      '0.5': 101.5
+      '0.6': 103.5
+      '0.7': 106.0
+      '0.8': 109.0
+      '0.9': 112.5
+      '0.95': 115.5
+  metadata:
+    rationale: The WTI crude oil market as of May 4, 2026 is dominated by extreme
+      geopolitical tensions following the February 2026 US-Iran conflict and the closure
+      of the Strait of Hormuz. WTI prices surged above $100, peaking near $113, but
+      remain highly volatile. The US emergency SPR release of 172 million barrels
+      serves as a key bearish buffer, while the UAE's exit from OPEC effective May
+      1 introduces long-term supply uncertainty. The forecasts incorporate high short-term
+      volatility, with a gradual downward drift in the median as demand destruction
+      and emergency supplies offset the geopolitical premium, and a wide distribution
+      representing the dual possibilities of either conflict escalation or a diplomatic
+      breakthrough.
+    horizon_rationale: Over a 5-business-day horizon (May 11, 2026), WTI crude oil
+      prices are expected to remain highly elevated, driven by the ongoing deadlock
+      in the US-Iran conflict and the continued effective closure of the Strait of
+      Hormuz. The median forecast is set at $101.50, slightly easing from the last
+      close of $101.94 but supported by extremely tight physical markets. Downside
+      risks (0.05 quantile at $82.00) reflect the potential for sudden diplomatic
+      progress or a temporary ceasefire, which previously caused a drop to $83.85
+      on April 17. Upside risks (0.95 quantile at $115.50) reflect a potential retest
+      of the April high if conflict intensifies or further naval incidents occur.
+    langfuse_trace_id: e26328576a2b2628aa2dd7364e35ab1c
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e26328576a2b2628aa2dd7364e35ab1c
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:20:50.335609'
+  as_of: '2026-05-04T00:00:00'
+  forecast_date: '2026-05-18T00:00:00'
+  payload:
+    point_forecast: 100.5
+    quantiles:
+      '0.05': 78.0
+      '0.1': 84.0
+      '0.2': 91.0
+      '0.3': 95.0
+      '0.4': 98.0
+      '0.5': 100.5
+      '0.6': 103.0
+      '0.7': 106.5
+      '0.8': 110.0
+      '0.9': 114.5
+      '0.95': 118.0
+  metadata:
+    rationale: The WTI crude oil market as of May 4, 2026 is dominated by extreme
+      geopolitical tensions following the February 2026 US-Iran conflict and the closure
+      of the Strait of Hormuz. WTI prices surged above $100, peaking near $113, but
+      remain highly volatile. The US emergency SPR release of 172 million barrels
+      serves as a key bearish buffer, while the UAE's exit from OPEC effective May
+      1 introduces long-term supply uncertainty. The forecasts incorporate high short-term
+      volatility, with a gradual downward drift in the median as demand destruction
+      and emergency supplies offset the geopolitical premium, and a wide distribution
+      representing the dual possibilities of either conflict escalation or a diplomatic
+      breakthrough.
+    horizon_rationale: At a 10-business-day horizon (May 18, 2026), the market is
+      projected to stay highly volatile. The median forecast is slightly lower at
+      $100.50 as the massive 172-million-barrel Strategic Petroleum Reserve (SPR)
+      emergency drawdown continues to supply refiners. The distribution widens, with
+      the downside (0.05 quantile at $78.00) accounting for a potential breakthrough
+      in negotiations, while the upside (0.95 quantile at $118.00) covers potential
+      military escalation or additional shipping blockades in the Persian Gulf.
+    langfuse_trace_id: e26328576a2b2628aa2dd7364e35ab1c
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e26328576a2b2628aa2dd7364e35ab1c
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:20:50.335609'
+  as_of: '2026-05-04T00:00:00'
+  forecast_date: '2026-06-02T00:00:00'
+  payload:
+    point_forecast: 98.0
+    quantiles:
+      '0.05': 72.0
+      '0.1': 79.0
+      '0.2': 87.0
+      '0.3': 92.0
+      '0.4': 95.5
+      '0.5': 98.0
+      '0.6': 101.5
+      '0.7': 105.0
+      '0.8': 109.5
+      '0.9': 115.0
+      '0.95': 119.5
+  metadata:
+    rationale: The WTI crude oil market as of May 4, 2026 is dominated by extreme
+      geopolitical tensions following the February 2026 US-Iran conflict and the closure
+      of the Strait of Hormuz. WTI prices surged above $100, peaking near $113, but
+      remain highly volatile. The US emergency SPR release of 172 million barrels
+      serves as a key bearish buffer, while the UAE's exit from OPEC effective May
+      1 introduces long-term supply uncertainty. The forecasts incorporate high short-term
+      volatility, with a gradual downward drift in the median as demand destruction
+      and emergency supplies offset the geopolitical premium, and a wide distribution
+      representing the dual possibilities of either conflict escalation or a diplomatic
+      breakthrough.
+    horizon_rationale: For the 21-business-day horizon (June 2, 2026), the median
+      is forecast at $98.00. Over a month, high energy prices are expected to induce
+      notable global demand destruction, and supply relief from OPEC+ (including the
+      June target increase of 188,000 bpd announced on May 3) and independent production
+      from the UAE (which left OPEC on May 1) should start playing a role. The probability
+      of a diplomatic resolution also increases over time, dragging the lower tail
+      down significantly (0.05 quantile at $72.00). The upside tail (0.95 quantile
+      at $119.50) remains high, as a protracted conflict with no resolution would
+      keep severe physical shortages active.
+    langfuse_trace_id: e26328576a2b2628aa2dd7364e35ab1c
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/e26328576a2b2628aa2dd7364e35ab1c
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:22:26.218331'
+  as_of: '2026-05-11T00:00:00'
+  forecast_date: '2026-05-18T00:00:00'
+  payload:
+    point_forecast: 94.5
+    quantiles:
+      '0.05': 81.0
+      '0.1': 84.0
+      '0.2': 87.5
+      '0.3': 90.0
+      '0.4': 92.3
+      '0.5': 94.5
+      '0.6': 96.7
+      '0.7': 99.2
+      '0.8': 102.0
+      '0.9': 106.0
+      '0.95': 109.5
+  metadata:
+    rationale: This probabilistic forecast reflects the supply-demand balance under
+      severe geopolitical duress. WTI oil prices remain highly elevated due to the
+      blockaded Strait of Hormuz, but are capped and drifted lower by a massive, coordinated
+      SPR release from the US/IEA and a weakening global demand outlook. Additionally,
+      structural changes in OPEC+ (UAE's exit) and ongoing macroeconomic headwinds
+      introduce a bearish medium-term trend. This dynamic is modeled with a slightly
+      declining median price accompanied by very wide tails that represent the high
+      likelihood of extreme binary outcomes (peace/reopening vs. escalation/blockade).
+    horizon_rationale: Over a short-term 5-day horizon, WTI crude is expected to consolidate
+      near its current level, with a minor downward bias to $94.50. The physical supply
+      shortage due to the Strait of Hormuz blockade is countered by ongoing U.S. emergency
+      SPR releases. Volatility remains exceptionally high given daily headline-driven
+      shifts. The downside tail reflects potential diplomatic breakthrough announcements,
+      while the upside tail accounts for sudden escalation.
+    langfuse_trace_id: 95c5572883d13d9fd3d842b9422f46c8
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/95c5572883d13d9fd3d842b9422f46c8
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:22:26.218331'
+  as_of: '2026-05-11T00:00:00'
+  forecast_date: '2026-06-09T00:00:00'
+  payload:
+    point_forecast: 91.5
+    quantiles:
+      '0.05': 68.0
+      '0.1': 72.5
+      '0.2': 78.5
+      '0.3': 83.0
+      '0.4': 87.5
+      '0.5': 91.5
+      '0.6': 95.5
+      '0.7': 100.5
+      '0.8': 106.5
+      '0.9': 114.5
+      '0.95': 122.0
+  metadata:
+    rationale: This probabilistic forecast reflects the supply-demand balance under
+      severe geopolitical duress. WTI oil prices remain highly elevated due to the
+      blockaded Strait of Hormuz, but are capped and drifted lower by a massive, coordinated
+      SPR release from the US/IEA and a weakening global demand outlook. Additionally,
+      structural changes in OPEC+ (UAE's exit) and ongoing macroeconomic headwinds
+      introduce a bearish medium-term trend. This dynamic is modeled with a slightly
+      declining median price accompanied by very wide tails that represent the high
+      likelihood of extreme binary outcomes (peace/reopening vs. escalation/blockade).
+    horizon_rationale: 'By late May/early June (21 business days), structural market
+      adjustments will be more pronounced. UAE''s departure from OPEC may begin to
+      trigger increased independent supply, adding to the bearish demand fundamentals
+      and pulling the median forecast to $91.50. The tails are extremely wide: a potential
+      diplomatic resolution or reopening of the Strait of Hormuz could rapidly deflate
+      the war premium toward $68.00, whereas prolonged blockade or further escalation
+      could drive prices to $122.00.'
+    langfuse_trace_id: 95c5572883d13d9fd3d842b9422f46c8
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/95c5572883d13d9fd3d842b9422f46c8
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:23:04.427276'
+  as_of: '2026-05-18T00:00:00'
+  forecast_date: '2026-06-01T00:00:00'
+  payload:
+    point_forecast: 103.5
+    quantiles:
+      '0.05': 81.0
+      '0.1': 87.0
+      '0.2': 93.0
+      '0.3': 98.0
+      '0.4': 101.0
+      '0.5': 103.5
+      '0.6': 106.0
+      '0.7': 109.5
+      '0.8': 114.0
+      '0.9': 120.0
+      '0.95': 126.0
+  metadata:
+    rationale: WTI prices as of May 18, 2026, are highly volatile and driven by the
+      Strait of Hormuz closure that began on Feb 28, 2026, which severely restricted
+      global tanker traffic. Offsetting these shortages are coordinated emergency
+      releases from the US SPR and other IEA members, along with demand contraction
+      resulting from sustained high prices. The recent exit of the UAE from OPEC+
+      on May 1 also points to potential supply competition. The probabilistic forecasts
+      reflect a wide range of outcomes over the next month, with a slight downward
+      drift in the point forecast as demand destruction and strategic reserves releases
+      offset the war premium.
+    horizon_rationale: At a 10 business day horizon, the point forecast decays slightly
+      to $103.50/bbl. While physical tightness keeps prices high, demand-saving measures
+      and high costs are beginning to suppress fuel consumption, as highlighted by
+      the IEA's downgraded demand expectations. The UAE's exit from OPEC+ on May 1
+      also adds potential medium-term competitive supply pressure, widening the downside
+      tail risk.
+    langfuse_trace_id: f0eb8ce0a149c4ecf5cc6938be48a8b7
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/f0eb8ce0a149c4ecf5cc6938be48a8b7
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:23:04.427276'
+  as_of: '2026-05-18T00:00:00'
+  forecast_date: '2026-06-16T00:00:00'
+  payload:
+    point_forecast: 101.5
+    quantiles:
+      '0.05': 76.0
+      '0.1': 83.0
+      '0.2': 91.0
+      '0.3': 96.0
+      '0.4': 99.0
+      '0.5': 101.5
+      '0.6': 104.5
+      '0.7': 108.5
+      '0.8': 114.0
+      '0.9': 122.0
+      '0.95': 129.0
+  metadata:
+    rationale: WTI prices as of May 18, 2026, are highly volatile and driven by the
+      Strait of Hormuz closure that began on Feb 28, 2026, which severely restricted
+      global tanker traffic. Offsetting these shortages are coordinated emergency
+      releases from the US SPR and other IEA members, along with demand contraction
+      resulting from sustained high prices. The recent exit of the UAE from OPEC+
+      on May 1 also points to potential supply competition. The probabilistic forecasts
+      reflect a wide range of outcomes over the next month, with a slight downward
+      drift in the point forecast as demand destruction and strategic reserves releases
+      offset the war premium.
+    horizon_rationale: 'Over 21 business days (about a month), WTI''s central expectation
+      moves down toward $101.50/bbl, as contraction in global oil demand (forecast
+      by IEA to drop 420k b/d in 2026) and sustained emergency reserves releases take
+      a more permanent hold. The distribution is highly dispersed: the upper tail
+      ($129/bbl) captures potential escalatory strikes on regional infrastructure,
+      whereas the lower tail ($76/bbl) represents a potential partial reopening of
+      shipping lanes or a price war following OPEC+ fragmentation.'
+    langfuse_trace_id: f0eb8ce0a149c4ecf5cc6938be48a8b7
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/f0eb8ce0a149c4ecf5cc6938be48a8b7
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:24:45.633481'
+  as_of: '2026-05-25T00:00:00'
+  forecast_date: '2026-06-01T00:00:00'
+  payload:
+    point_forecast: 95.0
+    quantiles:
+      '0.05': 83.0
+      '0.1': 86.0
+      '0.2': 90.0
+      '0.3': 92.0
+      '0.4': 93.5
+      '0.5': 95.0
+      '0.6': 96.5
+      '0.7': 98.5
+      '0.8': 101.0
+      '0.9': 105.0
+      '0.95': 109.0
+  metadata:
+    rationale: Our probabilistic forecast reflects the highly binary state of the
+      WTI crude market as of late May 2026. The primary driver is the geopolitical
+      standoff in the Strait of Hormuz, where a potential US-Iran peace MOU has triggered
+      a sharp price drop from the $108 level. If the MOU is finalized and the Strait
+      reopens, the supply shock will resolve, though downside is buffered by historically
+      low OECD stocks and the need for US SPR replenishment. If negotiations collapse,
+      WTI is prone to retesting its 52-week high of $112.95. Meanwhile, macroeconomic
+      demand is weak, with the IEA downgrading 2026 demand, and OPEC+ policy remains
+      reactive after the UAE's exit on May 1.
+    horizon_rationale: Over a 5-business-day horizon (approx. June 1, 2026), WTI oil
+      prices are projected to consolidate slightly lower around a median of $95.00.
+      High-level negotiations for a 60-day US-Iran MOU to reopen the Strait of Hormuz
+      have injected substantial downward pressure, prompting a sharp drop from above
+      $107. However, public Iranian contradictions regarding control of the Strait
+      introduce a strong upside risk, capped around $109.00 if talks break down. Downside
+      risks down to $83.00 would emerge upon a sudden official signing of the ceasefire.
+    langfuse_trace_id: 139924069807c85cd9fd5edbe36073ab
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/139924069807c85cd9fd5edbe36073ab
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:24:45.633481'
+  as_of: '2026-05-25T00:00:00'
+  forecast_date: '2026-06-08T00:00:00'
+  payload:
+    point_forecast: 92.0
+    quantiles:
+      '0.05': 78.0
+      '0.1': 82.0
+      '0.2': 86.5
+      '0.3': 89.0
+      '0.4': 90.5
+      '0.5': 92.0
+      '0.6': 94.0
+      '0.7': 96.5
+      '0.8': 100.0
+      '0.9': 106.0
+      '0.95': 111.0
+  metadata:
+    rationale: Our probabilistic forecast reflects the highly binary state of the
+      WTI crude market as of late May 2026. The primary driver is the geopolitical
+      standoff in the Strait of Hormuz, where a potential US-Iran peace MOU has triggered
+      a sharp price drop from the $108 level. If the MOU is finalized and the Strait
+      reopens, the supply shock will resolve, though downside is buffered by historically
+      low OECD stocks and the need for US SPR replenishment. If negotiations collapse,
+      WTI is prone to retesting its 52-week high of $112.95. Meanwhile, macroeconomic
+      demand is weak, with the IEA downgrading 2026 demand, and OPEC+ policy remains
+      reactive after the UAE's exit on May 1.
+    horizon_rationale: At 10 business days (approx. June 8, 2026), the median forecast
+      shifts down to $92.00 as the market anticipates either some diplomatic pause
+      or a gradual de-escalation of the blockade. The OPEC+ June production adjustment
+      of 188,000 bpd offers minor support, but is secondary to the geopolitical binary.
+      If the ceasefire MOU is officially formalized, WTI could test $78.00. Conversely,
+      if negotiations collapse and hostilities resume in the Gulf, prices could quickly
+      surge back toward $111.00, close to the 52-week high.
+    langfuse_trace_id: 139924069807c85cd9fd5edbe36073ab
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/139924069807c85cd9fd5edbe36073ab
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:24:45.633481'
+  as_of: '2026-05-25T00:00:00'
+  forecast_date: '2026-06-23T00:00:00'
+  payload:
+    point_forecast: 88.0
+    quantiles:
+      '0.05': 70.0
+      '0.1': 75.0
+      '0.2': 80.0
+      '0.3': 83.5
+      '0.4': 86.0
+      '0.5': 88.0
+      '0.6': 91.0
+      '0.7': 95.0
+      '0.8': 100.0
+      '0.9': 108.0
+      '0.95': 115.0
+  metadata:
+    rationale: Our probabilistic forecast reflects the highly binary state of the
+      WTI crude market as of late May 2026. The primary driver is the geopolitical
+      standoff in the Strait of Hormuz, where a potential US-Iran peace MOU has triggered
+      a sharp price drop from the $108 level. If the MOU is finalized and the Strait
+      reopens, the supply shock will resolve, though downside is buffered by historically
+      low OECD stocks and the need for US SPR replenishment. If negotiations collapse,
+      WTI is prone to retesting its 52-week high of $112.95. Meanwhile, macroeconomic
+      demand is weak, with the IEA downgrading 2026 demand, and OPEC+ policy remains
+      reactive after the UAE's exit on May 1.
+    horizon_rationale: By 21 business days (approx. June 23, 2026), the median is
+      modeled at $88.00. Over this month-long horizon, the likelihood of a negotiated
+      framework or tactical pause increases, which would start to reopen shipping
+      lanes and return offline Middle East crude. This downside potential is bounded
+      around $70.00 due to severely depleted OECD inventories (at 2003 lows) and the
+      critical need for US SPR replenishment (currently at a 40-year low of ~357-374M
+      barrels). If hostilities escalate further, WTI could spike to $115.00, driven
+      by structural supply deficits.
+    langfuse_trace_id: 139924069807c85cd9fd5edbe36073ab
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/139924069807c85cd9fd5edbe36073ab
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:26:02.044318'
+  as_of: '2026-06-01T00:00:00'
+  forecast_date: '2026-06-08T00:00:00'
+  payload:
+    point_forecast: 86.5
+    quantiles:
+      '0.05': 72.0
+      '0.1': 76.0
+      '0.2': 80.0
+      '0.3': 83.0
+      '0.4': 85.0
+      '0.5': 86.5
+      '0.6': 88.5
+      '0.7': 91.0
+      '0.8': 94.0
+      '0.9': 98.5
+      '0.95': 103.0
+  metadata:
+    rationale: This WTI crude oil forecast as of June 1, 2026, incorporates the sharp
+      late-May price correction from $108.66 down to $87.36. This decline was driven
+      by diplomatic optimism regarding a potential 60-day US-Iran ceasefire and the
+      reopening of the Strait of Hormuz. Given the extreme geopolitical volatility,
+      low global and US SPR inventory levels (historically supportive of prices),
+      and OPEC+ compliance adjustments, the forecasting distributions are exceptionally
+      wide. Point forecasts reflect a slight downward bias on hopes of successful
+      diplomatic resolution, balanced by substantial upside risk if ceasefire talks
+      fail.
+    horizon_rationale: Over a 5-day horizon (approx. June 8, 2026), WTI crude oil
+      prices are expected to exhibit high volatility as the market digests ongoing
+      negotiations regarding a 60-day US-Iran memorandum of understanding (MoU). A
+      successful announcement could compress the geopolitical risk premium further,
+      pushing prices toward $75-$80. Conversely, a failure in negotiations or an uptick
+      in maritime tension near the Strait of Hormuz could quickly rebound WTI back
+      toward $95-$100+. The point forecast is set slightly below the last close at
+      $86.50 to reflect a marginal downward drift on ceasefire optimism.
+    langfuse_trace_id: 4459e9d86d52ae3c854714697f8a2188
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/4459e9d86d52ae3c854714697f8a2188
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:26:02.044318'
+  as_of: '2026-06-01T00:00:00'
+  forecast_date: '2026-06-15T00:00:00'
+  payload:
+    point_forecast: 85.8
+    quantiles:
+      '0.05': 67.0
+      '0.1': 71.0
+      '0.2': 76.0
+      '0.3': 80.5
+      '0.4': 83.5
+      '0.5': 85.8
+      '0.6': 88.5
+      '0.7': 92.5
+      '0.8': 97.0
+      '0.9': 103.5
+      '0.95': 108.5
+  metadata:
+    rationale: This WTI crude oil forecast as of June 1, 2026, incorporates the sharp
+      late-May price correction from $108.66 down to $87.36. This decline was driven
+      by diplomatic optimism regarding a potential 60-day US-Iran ceasefire and the
+      reopening of the Strait of Hormuz. Given the extreme geopolitical volatility,
+      low global and US SPR inventory levels (historically supportive of prices),
+      and OPEC+ compliance adjustments, the forecasting distributions are exceptionally
+      wide. Point forecasts reflect a slight downward bias on hopes of successful
+      diplomatic resolution, balanced by substantial upside risk if ceasefire talks
+      fail.
+    horizon_rationale: Over a 10-day horizon (approx. June 15, 2026), the probability
+      distribution widens significantly. If the ceasefire MoU is signed and implementation
+      details emerge, physical shipping lanes could begin a multi-month normalization
+      process, leading to a breakdown toward pre-conflict baseline levels near $67-$71.
+      However, because US Strategic Petroleum Reserves (SPR) are at their lowest levels
+      since the 1980s (around 357M barrels), there is minimal buffer to absorb any
+      renewed supply shock, leaving the upside highly sensitive to negotiation failure,
+      potentially spiking prices to $108+.
+    langfuse_trace_id: 4459e9d86d52ae3c854714697f8a2188
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/4459e9d86d52ae3c854714697f8a2188
+- predictor_id: agent_predictor_wti_analyst_news_gemini-3.5-flash_continuous
+  task_id: wti_oil_price_forecast
+  issued_at: '2026-07-02T11:26:02.044318'
+  as_of: '2026-06-01T00:00:00'
+  forecast_date: '2026-06-30T00:00:00'
+  payload:
+    point_forecast: 84.5
+    quantiles:
+      '0.05': 61.0
+      '0.1': 66.0
+      '0.2': 72.0
+      '0.3': 77.5
+      '0.4': 81.5
+      '0.5': 84.5
+      '0.6': 88.5
+      '0.7': 93.5
+      '0.8': 99.5
+      '0.9': 107.0
+      '0.95': 113.0
+  metadata:
+    rationale: This WTI crude oil forecast as of June 1, 2026, incorporates the sharp
+      late-May price correction from $108.66 down to $87.36. This decline was driven
+      by diplomatic optimism regarding a potential 60-day US-Iran ceasefire and the
+      reopening of the Strait of Hormuz. Given the extreme geopolitical volatility,
+      low global and US SPR inventory levels (historically supportive of prices),
+      and OPEC+ compliance adjustments, the forecasting distributions are exceptionally
+      wide. Point forecasts reflect a slight downward bias on hopes of successful
+      diplomatic resolution, balanced by substantial upside risk if ceasefire talks
+      fail.
+    horizon_rationale: Over a 21-day horizon (approx. June 30, 2026), WTI crude oil
+      prices have a highly bi-modal potential outcome. If a comprehensive US-Iran
+      agreement is finalized and the Strait of Hormuz is physically cleared of sea
+      mines, WTI could swiftly mean-revert toward the $61-$66 range as the war premium
+      completely unwinds. OPEC+ cuts unwinding (188k bpd adjustment for June) and
+      the UAE's earlier exit from the cartel will also weigh on prices under a peaceful
+      resolution. If negotiations collapse completely and conflict escalates, WTI
+      could test or exceed its 52-week high of $112.95.
+    langfuse_trace_id: 4459e9d86d52ae3c854714697f8a2188
+    langfuse_trace_url: https://us.cloud.langfuse.com/project/cmobssx3g00buad07gb4o1gh6/traces/4459e9d86d52ae3c854714697f8a2188
+scores:
+- 1.5158681570005823
+- 10.33933640156896
+- 1.8892550886169952
+- 15.752476287085168
+- 1.8865273719976765
+- 5.743226497429463
+- 29.479420572075966
+- 3.0344655564993874
+- 25.54272391579368
+- 21.531816655939277
+- 14.038591684388724
+- 12.115702479338848
+- 19.223798906310538
+- 8.68181818181818
+- 12.99578687179187
+- 6.023552886710678
+- 5.942067863527407
+- 4.523965693702383
+- 3.309256309320117
+- 2.5818169333718037
+- 6.897275057705968
+- 7.114464058363731
+- 6.7195891072927445
+- 4.91008247816858
+- 5.043223168239119
+- 8.050246435748642
+- 13.579420988224756
+- 4.636611875423713
+- 7.9176029173795825
+- 5.42917330402973
+- 6.70231407733003
+- 3.1888442236529895
+- 8.126775694287517
+- 8.164048060897956
+- 8.126775694287515
+- 4.498760191862248
+- 4.622892395523953
+- 2.9106612402545506
+- 5.072728937322444
+- 4.115040739705738
+- 9.116036054122548
+- 4.552066393135005
+- 6.947766264608081
+- 17.583055354346914
+- 2.241486604548682
+- 2.1834707969476357
+- 10.154628848241376
+- 3.1157038665014847
+- 4.041735537190081
+- 9.483471074380162
+metric: crps
+mean_score: 8.027948515080224
+ran_at: '2026-07-02T11:26:02.335944'
+skipped_origins: 0


### PR DESCRIPTION
## Summary

Follow-up to #161. That PR added an independent leakage verifier to `search_web`, but it only activated when the calling LLM supplied a `cutoff_date` tool argument. A production trace showed this bypassed outright: **11 of 14 `search_web` calls in a real backtest simply omitted `cutoff_date`**, so both the soft prompt instruction and the verifier were silently skipped, and live googleSearch results (dated the actual current date) flowed straight into a historical forecast whose origin was six weeks earlier.

This PR closes that bypass by moving the cutoff from something the **model supplies** to something the **harness enforces**: `AgentPredictor.predict()` now seeds the forecast's `as_of` into ADK session state before each run, and `search_web` reads it via an ADK-injected `ToolContext` — a parameter excluded from the LLM-visible tool schema, so the model can neither see it, omit it, nor spoof it. This value is authoritative whenever present; the model's own `cutoff_date` argument becomes a redundant, logged-on-disagreement fallback for callers outside `AgentPredictor` (e.g. interactive `adk web` use).

Because `AgentPredictor`/`ForecastContext.as_of` are shared across every forecasting domain, this closes the bypass everywhere in one change — no per-domain edits needed this time.

Clickup Ticket(s): N/A

## Why this needed a second agent, not a better prompt

Both leaks in this saga (this one and #161's) trace back to the same root cause: a single LLM cannot reliably introspect on *where its own words came from* — whether a claim was retrieved just now or recalled from training. No amount of prompt engineering fixes that, because the model isn't lying about its confidence, it genuinely can't always tell the difference. The fix that actually works is architectural: a **second, independent LLM call** whose only job is to audit the first one's output against an external fact (the cutoff date) it wasn't in the loop to negotiate. That's a real agentic decomposition — specialized sub-agents cross-checking each other — not just a bigger prompt on a single model. This mirrors the published TimeSPEC pattern (claim-level extraction + independent verification beats prompt-only cutoff instructions by 75-99% in their evaluations).

**The caveat that matters just as much:** this is harm *reduction*, not a substitute for live evaluation. A verifier can only catch what it's told to look for and reason correctly about; it cannot conjure certainty from a fundamentally leaky retrieval channel (the live web index doesn't stop existing at the backtest origin). The only setup where future-leakage is *structurally impossible*, not just guarded against, is genuine live evaluation — predicting into a future that hasn't been indexed anywhere yet. Backtesting an agent with live web search, however well-guarded, is always a step down from that in terms of what it can prove.

## Changes Made

- `aieng-forecasting/aieng/forecasting/methods/agentic/agent_factory.py`: `search_web` now accepts an ADK-injected `tool_context: ToolContext`; reads the harness-seeded `as_of` (new `AS_OF_STATE_KEY`) as the authoritative cutoff, falling back to the LLM's `cutoff_date` only when no harness value exists. Logs a warning if the two disagree.
- `aieng-forecasting/aieng/forecasting/methods/agentic/adk_runner.py`: `run_text_async`/`_resolve_session_id` gained an optional `initial_state` parameter, threaded into ADK's `create_session(..., state=...)` — purely additive, every existing call site unaffected.
- `aieng-forecasting/aieng/forecasting/methods/agentic/predictor.py`: `AgentPredictor.predict()` seeds `{AS_OF_STATE_KEY: context.as_of}` into the session before each run.
- New tests across all three files, including the specific case that was silently broken before (harness `as_of` present, LLM omits `cutoff_date` entirely) and the disagreement-logging path.
- Verified 2026 eval prediction files for both WTI news-agent variants, regenerated with the fix in place (only these two predictors' cache was cleared; everything else stayed cached).

## Testing

- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Type checking passes (`uv run mypy <src_dir>`)
- [x] Linting passes (actual pre-commit hook suite, not just ad-hoc `ruff` — learned that lesson on #161)
- [x] Manual testing performed (describe below)

**Manual testing details:**
- `uv run pytest aieng-forecasting/tests/aieng/forecasting/methods/agentic -q` — 95 passed, no regressions.
- `uv run pytest tests/` (full `aieng-forecasting` suite) — 387 passed, 7 skipped.
- `python -m pytest implementations/tests -q` — 82 passed.
- Re-ran the 2026 eval spec for both news-agent models after clearing only their stale eval cache, then audited the resulting Langfuse traces:
  - Across 169 sampled `search_web` calls (36 traces, both models): 0 occurrences of `[SEARCH_VERIFICATION_FAILED]`, 0 calls with retry-range latency — everything passed on the first attempt.
  - Traced one case end to end: origin `as_of=2026-05-18`, raw search result dated **"As of July 2, 2026"** (~6 weeks post-cutoff, the same leak class as before) — the verifier flagged 6 claims, stripped them, and the analyst's final `set_model_response` rationale contains no trace of the July content. This is the exact scenario that slipped through silently before this fix.
- Known cosmetic side effect (not a safety issue): the Langfuse trace's top-level `search_web` span now displays its `input`/`output` mirroring the raw first child call rather than the tool's actual arguments/return value — likely because ADK's OTEL instrumentation can't cleanly serialize the new `tool_context` parameter. Confirmed via source code and the final rationale that actual runtime behavior is correct; only the trace *display* is affected.

## Related Issues

Follow-up to #161.

## Deployment Notes

The 2025 backtest prediction files for these two predictors were not re-run in this PR (only the smaller 2026 eval spec, per the new "verify before opening" process) — a full backtest rerun can follow separately if wanted, but isn't required for correctness since the fix is unconditional at the code level.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code completed
- [x] Documentation updated (if applicable)
- [x] No sensitive information (API keys, credentials) exposed