### PR TITLE
fix(wti): require self-contained code imports

### DIFF
--- a/implementations/energy_oil_forecasting/README.md
+++ b/implementations/energy_oil_forecasting/README.md
@@ -8,7 +8,7 @@ WTI Crude Oil is highly liquid and sensitive to geopolitical risk, macroeconomic
 
 1. **Statistical models** (Prophet) extrapolate trend and seasonality but are blind to regime-breaking news.
 2. **Context-aware agentic models** (bounded Google Search) adapt to shocks by reasoning over shipping lane closures, OPEC+ policy, and political escalation.
-3. **Code-executing agentic models** verify trends, compute rolling indicators, and self-calibrate intervals via sandboxed Python.
+3. **Code-executing agentic models** verify trends, compute rolling indicators, and self-calibrate intervals via self-contained sandboxed Python scripts with explicit imports.
 
 ---
 

--- a/implementations/energy_oil_forecasting/analyst_agent/agent.py
+++ b/implementations/energy_oil_forecasting/analyst_agent/agent.py
@@ -218,6 +218,11 @@ there are no disk files to read.
 3. Call `load_skill_resource(<skill_name>, <file_path>)` to load a
    reference file (e.g. `references/wti_benchmarks.json`).
 
+Every `run_code` call must be a complete, self-contained Python script:
+include every import used in that same script. In particular, include
+`import json` whenever serializing results with `json.dumps`; do not rely on
+imports from an earlier call.
+
 These skills have NO scripts. Do not call `run_skill_script`.\
 """
 
@@ -534,9 +539,7 @@ def build_wti_code_exec_config(
     return AgentConfig(
         name="wti_analyst_code",
         model=model,
-        instruction=(
-            _WTI_ANALYST_INSTRUCTION + _CONTEXT_RETRIEVAL_SUPPLEMENT + _CODE_EXEC_SKILLS_SUPPLEMENT
-        ),
+        instruction=(_WTI_ANALYST_INSTRUCTION + _CONTEXT_RETRIEVAL_SUPPLEMENT + _CODE_EXEC_SKILLS_SUPPLEMENT),
         max_output_tokens=max_output_tokens,
         context_retrieval=ContextRetrievalConfig(
             enabled=True,
@@ -611,9 +614,7 @@ def build_wti_tool_config(
     return AgentConfig(
         name="wti_analyst_tool",
         model=model,
-        instruction=(
-            _WTI_ANALYST_INSTRUCTION + _CONTEXT_RETRIEVAL_SUPPLEMENT + _FORECAST_TOOL_SUPPLEMENT
-        ),
+        instruction=(_WTI_ANALYST_INSTRUCTION + _CONTEXT_RETRIEVAL_SUPPLEMENT + _FORECAST_TOOL_SUPPLEMENT),
         context_retrieval=ContextRetrievalConfig(
             enabled=True,
             instruction=_WTI_CONTEXT_RETRIEVAL_INSTRUCTION,

--- a/implementations/tests/energy_oil_forecasting/test_analyst_agent.py
+++ b/implementations/tests/energy_oil_forecasting/test_analyst_agent.py
@@ -1,0 +1,12 @@
+"""Tests for the WTI analyst agent configurations."""
+
+from energy_oil_forecasting.analyst_agent import build_wti_code_exec_config
+
+
+def test_code_exec_instruction_requires_self_contained_imports() -> None:
+    """Generated sandbox scripts must import modules used for serialization."""
+    instruction = build_wti_code_exec_config().instruction
+
+    assert "include every import" in instruction
+    assert "import json" in instruction
+    assert "json.dumps" in instruction


### PR DESCRIPTION
Fixes #181

## Summary

Require every WTI `run_code` call to include its own imports, including `import json` whenever it uses `json.dumps`.

Sandbox executions are isolated, so an import from an earlier call is not available to a later script. This prompt-level guard prevents the analyst agent from failing during JSON serialization without changing runtime architecture.

## Tests

- Added a focused configuration test for the generated WTI code-execution instruction
- `pytest implementations/tests/energy_oil_forecasting/test_analyst_agent.py -q` (1 passed)
- Ruff check and format check pass on the changed Python files
- `git diff --check` passes

This PR was prepared with AI assistance and manually reviewed.